### PR TITLE
Use custom resolve conditions ('source' instead of 'development')

### DIFF
--- a/apps/assisted-ui/vite.config.ts
+++ b/apps/assisted-ui/vite.config.ts
@@ -26,6 +26,9 @@ export default defineConfig(async ({ mode }) => {
       outDir: 'build',
       sourcemap: true,
     },
+    resolve: {
+      conditions: ['source'],
+    },
     plugins: [
       EnvironmentPlugin(defaultValues, {
         prefix: envVarsPrefix,

--- a/libs/ui-lib/package.json
+++ b/libs/ui-lib/package.json
@@ -47,17 +47,17 @@
   },
   "exports": {
     ".": {
-      "development": "./lib/index.ts",
+      "source": "./lib/index.ts",
       "types": "./@types/index.d.ts",
       "default": "./build/index.js"
     },
     "./cim": {
-      "development": "./lib/cim/index.ts",
+      "source": "./lib/cim/index.ts",
       "types": "./@types/cim/index.d.ts",
       "default": "./build/cim/index.js"
     },
     "./ocm": {
-      "development": "./lib/ocm/index.ts",
+      "source": "./lib/ocm/index.ts",
       "types": "./@types/ocm/index.d.ts",
       "default": "./build/ocm/index.js"
     }


### PR DESCRIPTION
Using 'development' as the package exports condition clashes with the settings in the uhc-portal where Webpack is used and the default condition is 'development'. Since that project's Webpack config is poorly configured, we are not able to tell them to import from the default condition without triggering a major refactor on their side. This change settles the issue with minimal impact on their side.