### PR TITLE
New cluster events - adding "%" sign to search text field return all events instead of specific ones

### DIFF
--- a/libs/ui-lib/lib/ocm/services/apis/EventsAPI.ts
+++ b/libs/ui-lib/lib/ocm/services/apis/EventsAPI.ts
@@ -27,7 +27,7 @@ const EventsAPI = {
     params += severities?.length ? `severities=${severities?.join(',')}&` : '';
     params += deletedHosts ? `deleted_hosts=${deletedHosts.toString()}&` : '';
     params += clusterLevel ? `cluster_level=${clusterLevel.toString()}&` : '';
-    params += message ? `message=${message}&` : '';
+    params += message ? `message=${encodeURIComponent(message)}&` : '';
 
     params += `limit=${limit}&`;
     params += `offset=${offset}`;


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-14519

**Before:**
![image](https://user-images.githubusercontent.com/87187179/236252488-4c4f32d1-d989-4409-afe8-7b4e31168304.png)

**After:**
![image](https://user-images.githubusercontent.com/87187179/236252337-b5c5ea9c-a6c9-412f-ac4e-b88230e35359.png)
