### PR TITLE
NO-ISSUE: Changes the package name in order to allow publishing it under @openshift-assisted

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "openshift-assisted-ui-lib",
+  "name": "@openshift-assisted/ui-lib",
   "version": "2.7.11-cim",
   "description": "React component library for the Bare Metal Installer",
   "license": "Apache-2.0",
-  "repository": "openshift-assisted/assisted-ui-lib",
+  "repository": "openshift-assisted/assisted-installer-ui",
   "main": "dist/index.js",
   "exports": {
     ".": "./dist/index.js",


### PR DESCRIPTION
Changes the lib name to `@openshift-assisted/ui-lib`
This PR is meant to allow publishing the lib, after the account owning `openshift-assisted-ui-lib` in npm got locked.
It is meant for `2.7.11-cim`.
We'll need to update the pkg name and import specifiers in solostron/console after bumping the lib version in the 2.7 branch.