### PR TITLE
MGMT-14261: Show disabled 'Add hosts' tab when cluster product id is not 'OCP-AssistedInstall'

### DIFF
--- a/libs/ui-lib/lib/ocm/components/HostsClusterDetailTab/utils.ts
+++ b/libs/ui-lib/lib/ocm/components/HostsClusterDetailTab/utils.ts
@@ -29,11 +29,16 @@ const disabledTabResult = (tooltipMessage: string) => ({
 });
 
 export const getAddHostTabDetails = ({ cluster }: { cluster: OcmClusterType }) => {
-  const isHiddenTab =
-    (cluster.state !== 'ready' && cluster.state !== 'installed') ||
-    cluster.product?.id !== 'OCP-AssistedInstall';
+  const isHiddenTab = cluster.state !== 'ready' && cluster.state !== 'installed';
   if (isHiddenTab) {
     return hiddenTabResult;
+  }
+
+  // Cluster’s product id is not 'OCP-AssistedInstall'. We show disabled tab with a message
+  if (cluster.product?.id !== 'OCP-AssistedInstall') {
+    return disabledTabResult(
+      'Only clusters installed with Assisted Installer can be scaled up using the web interface. You can still scale up clusters using the CLI.',
+    );
   }
 
   // Checking if the Day1 cluster has reported metrics, so it can be determined if it's an SNO / multi node and has required information


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-14261

When the cluster product id is not OCP-AssistedInstall ( clusters that aren't installed with Assisted Installer), then we show the 'Add hosts' tab disabled and with a tooltip:
![Captura desde 2023-05-16 11-41-02](https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/bf046f06-1ceb-4bf6-bf34-36399a9790e0)
