### PR TITLE
[2.7-cim] Remove unused 'count' from NetworkStepProps

### DIFF
--- a/src/cim/components/Hypershift/HostedClusterWizard/NetworkStep/types.ts
+++ b/src/cim/components/Hypershift/HostedClusterWizard/NetworkStep/types.ts
@@ -21,5 +21,4 @@ export type NetworkStepProps = {
   formRef: React.Ref<FormikProps<NetworkFormValues>>;
   onValuesChanged: (values: NetworkFormValues, initRender: boolean) => void;
   initialValues: NetworkFormValues;
-  count: number;
 };


### PR DESCRIPTION
Backport of https://github.com/openshift-assisted/assisted-installer-ui/pull/2120