### PR TITLE
MGMT-14640: InfraEnvs cache return type hotfix

### DIFF
--- a/libs/ui-lib/lib/ocm/hooks/useInfraEnvId.ts
+++ b/libs/ui-lib/lib/ocm/hooks/useInfraEnvId.ts
@@ -16,8 +16,9 @@ export default function useInfraEnvId(
   const findInfraEnvId = React.useCallback(async () => {
     try {
       const infraEnvId = await InfraEnvsService.getInfraEnvId(clusterId, cpuArchitecture);
-      if (infraEnvId && !(infraEnvId instanceof Error)) setInfraEnv(infraEnvId);
-      else {
+      if (infraEnvId && !(infraEnvId instanceof Error)) {
+        setInfraEnv(infraEnvId);
+      } else {
         //If infraEnv doesn't exist create a new one
         if (pullSecret) {
           const infraEnv = await InfraEnvsService.create({

--- a/libs/ui-lib/lib/ocm/services/InfraEnvIdsCacheService.ts
+++ b/libs/ui-lib/lib/ocm/services/InfraEnvIdsCacheService.ts
@@ -50,7 +50,7 @@ const InfraEnvIdsCacheService: InfraEnvStorage = {
     const cache = read();
     const clusterInfraEnvs = cache[clusterId];
     if (!clusterInfraEnvs) {
-      return new Error(`Not infraEnvs founded for this cluster ${clusterId}`);
+      return new Error(`Not infraEnvs found for this cluster ${clusterId}`);
     }
     if (cpuArchitecture !== CpuArchitecture.USE_DAY1_ARCHITECTURE) {
       return clusterInfraEnvs[cpuArchitecture] || new Error(`InfraEnv can't be found`);

--- a/libs/ui-lib/lib/ocm/services/InfraEnvsService.ts
+++ b/libs/ui-lib/lib/ocm/services/InfraEnvsService.ts
@@ -16,7 +16,7 @@ const InfraEnvsService = {
     cpuArchitecture: CpuArchitecture,
   ): Promise<string | Error> {
     let infraEnvId = InfraEnvCache.getInfraEnvId(clusterId, cpuArchitecture);
-    if (infraEnvId === null) {
+    if (infraEnvId instanceof Error) {
       const { data: infraEnvs } = await InfraEnvsAPI.list(clusterId);
       if (infraEnvs.length > 0) {
         InfraEnvCache.updateInfraEnvs(clusterId, infraEnvs);


### PR DESCRIPTION
`InfraEnvCache.getInfraEnvId()` is now returning `Error` instead of `null`, the condition in `InfraEnvsService` needs to be changed accordingly.

Otherwise the UI is stuck loading in case the infra env hasn't been cached previously.