### PR TITLE
MGMT-14645: Change Power and z names in the UI

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/CpuArchitectureDropdown.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/CpuArchitectureDropdown.tsx
@@ -30,12 +30,12 @@ export const architectureData: Record<SupportedCpuArchitecture, CpuArchitectureI
   [CpuArchitecture.ppc64le]: {
     description: 'Some features may not be available',
     featureSupportLevelId: 'PPC64LE_ARCHITECTURE',
-    label: 'PowerPC 64-bit LE',
+    label: 'IBM Power (ppc64le)',
   },
   [CpuArchitecture.s390x]: {
     description: 'Some features may not be available',
     featureSupportLevelId: 'S390X_ARCHITECTURE',
-    label: 'System/390 64-bit',
+    label: 'IBM zSystems (s390x)',
   },
 };
 


### PR DESCRIPTION
New official names:

IBM zSystems (s390x)
IBM Power (ppc64le)

![Captura desde 2023-05-17 13-05-48](https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/7dd273f9-53b4-42b2-8b57-0bfa99baec36)
