### PR TITLE
MGMT-14679: Solve problems with Add hosts in onprem clusters

### DIFF
--- a/libs/ui-lib/lib/ocm/components/AddHosts/day2Wizard/Day2ClusterDetails.tsx
+++ b/libs/ui-lib/lib/ocm/components/AddHosts/day2Wizard/Day2ClusterDetails.tsx
@@ -149,7 +149,7 @@ const Day2ClusterDetails = () => {
 
   const changeCpuArchitectureDropdownAsync = React.useCallback(
     async (value: string, initialValues: Day2ClusterDetailValues) => {
-      if (!pullSecret) {
+      if (pullSecret === undefined) {
         setErrorState(new Error('Pull secret is missing'));
       } else {
         if (value !== initialValues.cpuArchitecture) {
@@ -160,7 +160,7 @@ const Day2ClusterDetails = () => {
               day2Cluster.id,
               value as SupportedCpuArchitecture,
             );
-            if (!infraEnv) {
+            if (!infraEnv || infraEnv instanceof Error) {
               try {
                 infraEnv = await InfraEnvsService.create({
                   name: InfraEnvsService.makeInfraEnvName(


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-14679

 On-prem AI day2 add host, after cluster is installed, trying to add day2 host, but getting "Error loading data".
 Now this don't happen:
 

https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/1516f304-eb05-47ca-bf54-26dcd0438c16

