### PR TITLE
MGMT-14718: Problems renaming manifests file name

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusterWizard/wizardTransition.ts
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/wizardTransition.ts
@@ -32,6 +32,16 @@ export type ClusterWizardStepsType =
 export const ClusterWizardFlowStateNew = 'new';
 export type ClusterWizardFlowStateType = Cluster['status'] | typeof ClusterWizardFlowStateNew;
 
+export const getLastStepForWizard = (
+  customManifestsStepNeedsToBeFilled: boolean,
+): ClusterWizardStepsType => {
+  if (customManifestsStepNeedsToBeFilled) {
+    return 'custom-manifests';
+  } else {
+    return 'review';
+  }
+};
+
 export const getClusterWizardFirstStep = (
   locationState: ClusterWizardFlowStateType | undefined,
   staticIpInfo: StaticIpInfo | undefined,
@@ -55,12 +65,9 @@ export const getClusterWizardFirstStep = (
     return 'static-ip-network-wide-configurations';
   }
 
-  if (customManifestsStepNeedsToBeFilled) {
-    return 'custom-manifests';
-  }
   switch (state) {
     case 'ready':
-      return 'review';
+      return getLastStepForWizard(customManifestsStepNeedsToBeFilled || false);
     case 'pending-for-input':
     case 'adding-hosts':
     case 'insufficient':

--- a/libs/ui-lib/lib/ocm/hooks/useClusterCustomManifests.ts
+++ b/libs/ui-lib/lib/ocm/hooks/useClusterCustomManifests.ts
@@ -45,7 +45,11 @@ const getManifestsInfo = async (customManifests: ListManifests, clusterId: strin
   return manifestsExtended;
 };
 
-const useClusterCustomManifests = (clusterId: Cluster['id'], extendedVersion: boolean) => {
+const useClusterCustomManifests = (
+  clusterId: Cluster['id'],
+  extendedVersion: boolean,
+  refresh = true,
+) => {
   const [customManifests, setCustomManifests] = React.useState<ListManifestsExtended>();
   const [error, setError] = React.useState('');
   const [extendedManifestsLoaded, setExtendedManifestsLoaded] = React.useState<boolean>(false);
@@ -81,8 +85,10 @@ const useClusterCustomManifests = (clusterId: Cluster['id'], extendedVersion: bo
   }, [clusterId, extendedVersion]);
 
   React.useEffect(() => {
-    void fetchCustomManifests();
-  }, [fetchCustomManifests]);
+    if (refresh) {
+      void fetchCustomManifests();
+    }
+  }, [fetchCustomManifests, refresh]);
 
   return {
     customManifests,


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-14718

Previously, when uploading a manifest and choosing a file name , every time user add a char or remove it , a patch request was sent to BE, and a new manifest is added.

Now, this does not happen, see the video:

https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/885490b2-8d11-4651-a4cc-b795a0e89824

