### PR TITLE
MGMT-14807: Change base domain validation regexp to avoid catastrophic backtracking problems

### DIFF
--- a/libs/ui-lib/lib/common/components/ui/formik/validationSchemas.ts
+++ b/libs/ui-lib/lib/common/components/ui/formik/validationSchemas.ts
@@ -30,7 +30,7 @@ const CLUSTER_NAME_VALID_CHARS_REGEX = /^[a-z0-9-]*$/;
 const SSH_PUBLIC_KEY_REGEX =
   /^(ssh-rsa|ssh-ed25519|ecdsa-[-a-z0-9]*) AAAA[0-9A-Za-z+/]+[=]{0,3}( .+)?$/;
 const DNS_NAME_REGEX = /^([a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,}$/;
-const BASE_DOMAIN_REGEX = /^([a-z0-9]+(-[a-z0-9]+)*)+$/;
+const BASE_DOMAIN_REGEX = /^([a-z0-9]+(-[a-z0-9]+)*)$/;
 const DNS_NAME_REGEX_OCM = /^([a-z0-9]+(-[a-z0-9]+)*[.])+[a-z]{2,}$/;
 
 const PROXY_DNS_REGEX =


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-14807

It reverts some changes done in #2133 

We need to change the base domain regexp because causes catastrophic backtracking in some cases:
![image](https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/3ea26a19-0c1a-42dd-bdc0-b1b174994fcd)
