### PR TITLE
MGMT-14842: In "Technology Preview" popover link doesn't open up URL

### DIFF
--- a/libs/ui-lib/lib/common/components/ui/ExternalLink.tsx
+++ b/libs/ui-lib/lib/common/components/ui/ExternalLink.tsx
@@ -1,15 +1,24 @@
-import React, { ReactNode } from 'react';
+import React, { ReactNode, MouseEvent } from 'react';
 import { Text } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 
 interface ExternalLinkProps {
   href?: string;
-  onClick?: VoidFunction;
+  onClick?: (event: MouseEvent<HTMLAnchorElement>) => void;
   children?: ReactNode;
 }
-const ExternalLink: React.FC<ExternalLinkProps> = ({ href, children, onClick }) => (
-  <Text component="a" href={href} onClick={onClick} target="_blank" rel="noopener noreferrer">
-    {children ? children : href} <ExternalLinkAltIcon color="rgb(0, 123, 186)" />
-  </Text>
-);
+const ExternalLink: React.FC<ExternalLinkProps> = ({ href, onClick, children }) => {
+  const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
+    event.stopPropagation(); // Stop event propagation here
+    if (onClick) {
+      onClick(event);
+    }
+  };
+
+  return (
+    <Text component="a" href={href} onClick={handleClick} target="_blank" rel="noopener noreferrer">
+      {children ? children : href} <ExternalLinkAltIcon color="rgb(0, 123, 186)" />
+    </Text>
+  );
+};
 export default ExternalLink;


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-14842

In "Technology Preview" popover link doesn't open up URL. With these changes the link works well:

https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/c19d00fe-52d3-4e19-acca-856e0885b188

