### PR TITLE
MGMT-14972: Full iso should be blocked in case of OCI (external partners)

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/DiscoveryImageForm.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/DiscoveryImageForm.tsx
@@ -109,6 +109,7 @@ const DiscoveryImageForm = ({
           ? mapClusterCpuArchToInfraEnvCpuArch(infraEnv.cpuArchitecture)
           : mapClusterCpuArchToInfraEnvCpuArch(cpuArchitecture)
       }
+      isOracleCloudInfrastructure={cluster.platform?.type === 'oci'}
     />
   );
 };

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/DiscoveryImageTypeDropdown.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/DiscoveryImageTypeDropdown.tsx
@@ -26,6 +26,7 @@ type DiscoveryImageTypeDropdownProps = {
   defaultValue: string | undefined;
   onChange: (isIpxeSelected: boolean) => void;
   selectedCpuArchitecture?: SupportedCpuArchitecture;
+  isDisabled?: boolean;
 };
 
 export const DiscoveryImageTypeDropdown = ({
@@ -33,6 +34,7 @@ export const DiscoveryImageTypeDropdown = ({
   defaultValue,
   onChange,
   selectedCpuArchitecture,
+  isDisabled,
 }: DiscoveryImageTypeDropdownProps) => {
   const [field, { value }, { setValue }] = useField<DiscoveryImageType>(name);
   const [isOpen, setOpen] = React.useState(false);
@@ -95,11 +97,12 @@ export const DiscoveryImageTypeDropdown = ({
         toggleIndicator={CaretDownIcon}
         isText
         className="pf-u-w-100"
+        isDisabled={isDisabled}
       >
         {current || value}
       </DropdownToggle>
     ),
-    [setOpen, current, value],
+    [setOpen, current, value, isDisabled],
   );
 
   return (

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/DiscoveryImageTypeDropdown.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/DiscoveryImageTypeDropdown.tsx
@@ -34,7 +34,7 @@ export const DiscoveryImageTypeDropdown = ({
   defaultValue,
   onChange,
   selectedCpuArchitecture,
-  isDisabled,
+  isDisabled = false,
 }: DiscoveryImageTypeDropdownProps) => {
   const [field, { value }, { setValue }] = useField<DiscoveryImageType>(name);
   const [isOpen, setOpen] = React.useState(false);

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/OcmDiscoveryImageConfigForm.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/OcmDiscoveryImageConfigForm.tsx
@@ -68,6 +68,7 @@ type OcmDiscoveryImageConfigFormProps = Proxy & {
   enableCertificate?: boolean;
   trustBundle?: InfraEnv['additionalTrustBundle'];
   selectedCpuArchitecture?: SupportedCpuArchitecture;
+  isOracleCloudInfrastructure?: boolean;
 };
 
 export const OcmDiscoveryImageConfigForm = ({
@@ -82,6 +83,7 @@ export const OcmDiscoveryImageConfigForm = ({
   enableCertificate,
   trustBundle,
   selectedCpuArchitecture,
+  isOracleCloudInfrastructure,
 }: OcmDiscoveryImageConfigFormProps) => {
   const imageTypeValue = isIpxeSelected
     ? 'discovery-image-ipxe'
@@ -147,6 +149,7 @@ export const OcmDiscoveryImageConfigForm = ({
                       defaultValue={discoveryImageTypes[imageTypeValue]}
                       onChange={updateDiscoveryButtonAndAlertText}
                       selectedCpuArchitecture={selectedCpuArchitecture}
+                      isDisabled={isOracleCloudInfrastructure}
                     />
                     <UploadSSH
                       labelText={t(

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/OcmDiscoveryImageConfigForm.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/OcmDiscoveryImageConfigForm.tsx
@@ -83,7 +83,7 @@ export const OcmDiscoveryImageConfigForm = ({
   enableCertificate,
   trustBundle,
   selectedCpuArchitecture,
-  isOracleCloudInfrastructure,
+  isOracleCloudInfrastructure = false,
 }: OcmDiscoveryImageConfigFormProps) => {
   const imageTypeValue = isIpxeSelected
     ? 'discovery-image-ipxe'


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-14972

We need to disable image dropdown when we use OCI (external partners):
![image](https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/d55c9582-fc82-4675-9692-71b4522273d8)
