### PR TITLE
MGMT-14993: Set full iso as default image when using s390x cpu architecture

### DIFF
--- a/libs/ui-lib/lib/ocm/services/ClustersService.ts
+++ b/libs/ui-lib/lib/ocm/services/ClustersService.ts
@@ -4,6 +4,7 @@ import InfraEnvsService from './InfraEnvsService';
 import {
   AI_UI_TAG,
   Cluster,
+  CpuArchitecture,
   CreateManifestParams,
   Host,
   InfraEnvCreateParams,
@@ -36,6 +37,10 @@ const ClustersService = {
 
     if (params.platform?.type === 'oci') {
       infraEnvCreateParams.imageType = 'minimal-iso';
+    }
+
+    if (params.cpuArchitecture === CpuArchitecture.s390x) {
+      infraEnvCreateParams.imageType = 'full-iso';
     }
 
     await InfraEnvsService.create(infraEnvCreateParams);


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-14993

When we create a cluster with s390x architecture, we post full iso as image type.

![image](https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/6ac82e49-7269-4621-aab9-9ce0a93413f9)
