### PR TITLE
MGMT-14996:  Day 2 -Can't add hosts to SNO 4.14 cluster

### DIFF
--- a/libs/ui-lib/lib/ocm/components/AddHosts/types.ts
+++ b/libs/ui-lib/lib/ocm/components/AddHosts/types.ts
@@ -1,10 +1,6 @@
-import {
-  Cluster,
-  FeatureSupportLevels,
-  OcmCpuArchitecture,
-  SupportedCpuArchitecture,
-} from '../../../common';
+import { Cluster, OcmCpuArchitecture, SupportedCpuArchitecture } from '../../../common';
 import { HostsNetworkConfigurationType } from '../../services';
+import { FeaturesSupportsLevel } from '../newFeatureSupportLevels/types';
 
 /* The type is reverse engineered.
    The OCM object contains additional data.
@@ -53,7 +49,7 @@ export type OcmClusterType = {
   };
 
   aiCluster?: Cluster;
-  aiSupportLevels?: FeatureSupportLevels;
+  aiSupportLevels?: FeaturesSupportsLevel;
 };
 
 export type Day2ClusterDetailValues = {

--- a/libs/ui-lib/lib/ocm/components/HostsClusterDetailTab/utils.ts
+++ b/libs/ui-lib/lib/ocm/components/HostsClusterDetailTab/utils.ts
@@ -1,13 +1,13 @@
-import { getFeatureSupported } from '../featureSupportLevels/FeatureSupportLevelProvider';
 import { OcmClusterType } from '../AddHosts/types';
+import { getFeatureSupported } from '../newFeatureSupportLevels/NewFeatureSupportLevelProvider';
 import { AddHostsTabState } from './types';
 
 const isSNOExpansionAllowed = (cluster: OcmClusterType) => {
-  return getFeatureSupported(
-    cluster.openshift_version,
-    cluster.aiSupportLevels || [],
-    'SINGLE_NODE_EXPANSION',
-  );
+  if (cluster.aiSupportLevels) {
+    return getFeatureSupported(cluster.aiSupportLevels.features || [], 'SINGLE_NODE_EXPANSION');
+  } else {
+    return false;
+  }
 };
 
 const makeState = (

--- a/libs/ui-lib/lib/ocm/components/index.ts
+++ b/libs/ui-lib/lib/ocm/components/index.ts
@@ -6,3 +6,4 @@ export * from './AddHosts';
 export * from './clusterWizard';
 export * from './HostsClusterDetailTab';
 export * from './featureSupportLevels';
+export * from './newFeatureSupportLevels';

--- a/libs/ui-lib/lib/ocm/components/newFeatureSupportLevels/index.ts
+++ b/libs/ui-lib/lib/ocm/components/newFeatureSupportLevels/index.ts
@@ -1,2 +1,3 @@
 export { default as NewFeatureSupportLevelProvider } from './NewFeatureSupportLevelProvider';
 export { default as ClusterNewFeatureSupportLevelsDetailItem } from './ReviewClusterNewFeatureSupportLevels';
+export * from './types';

--- a/libs/ui-lib/lib/ocm/components/newFeatureSupportLevels/types.ts
+++ b/libs/ui-lib/lib/ocm/components/newFeatureSupportLevels/types.ts
@@ -1,0 +1,12 @@
+import {
+  ArchitectureSupportLevelMap,
+  NewFeatureSupportLevelMap,
+} from '../../../common/components/newFeatureSupportLevels';
+
+export interface ArchitecturesSupportsLevel {
+  architectures: ArchitectureSupportLevelMap;
+}
+
+export interface FeaturesSupportsLevel {
+  features: NewFeatureSupportLevelMap;
+}

--- a/libs/ui-lib/lib/ocm/index.ts
+++ b/libs/ui-lib/lib/ocm/index.ts
@@ -6,6 +6,7 @@ export * as Services from './services';
 
 // without namespace
 export * from './components';
+export * from './services';
 
 // re-export selected from common
 export * as Features from '../common/features';

--- a/libs/ui-lib/lib/ocm/services/CpuArchitectureService.ts
+++ b/libs/ui-lib/lib/ocm/services/CpuArchitectureService.ts
@@ -55,8 +55,17 @@ const mapClusterCpuArchToInfraEnvCpuArch = (
   }
 };
 
+const getCpuArchitecture = (cpuArchitecture?: string, isOcm?: boolean): string => {
+  const cpuArch =
+    isOcm && cpuArchitecture
+      ? mapOcmArchToCpuArchitecture(cpuArchitecture)
+      : cpuArchitecture || CpuArchitecture.x86;
+  return cpuArch || CpuArchitecture.x86;
+};
+
 export {
   mapOcmArchToCpuArchitecture,
   mapClusterCpuArchToInfraEnvCpuArch,
   getDefaultCpuArchitecture,
+  getCpuArchitecture,
 };

--- a/libs/ui-lib/lib/ocm/services/CpuArchitectureService.ts
+++ b/libs/ui-lib/lib/ocm/services/CpuArchitectureService.ts
@@ -55,11 +55,10 @@ const mapClusterCpuArchToInfraEnvCpuArch = (
   }
 };
 
-const getCpuArchitecture = (cpuArchitecture?: string, isOcm?: boolean): string => {
-  const cpuArch =
-    isOcm && cpuArchitecture
-      ? mapOcmArchToCpuArchitecture(cpuArchitecture)
-      : cpuArchitecture || CpuArchitecture.x86;
+const getCpuArchitecture = (cpuArchitecture?: string): string => {
+  const cpuArch = cpuArchitecture
+    ? mapOcmArchToCpuArchitecture(cpuArchitecture)
+    : CpuArchitecture.x86;
   return cpuArch || CpuArchitecture.x86;
 };
 

--- a/libs/ui-lib/lib/ocm/services/NewFeatureSupportLevelsService.ts
+++ b/libs/ui-lib/lib/ocm/services/NewFeatureSupportLevelsService.ts
@@ -1,0 +1,14 @@
+import { getCpuArchitecture } from './CpuArchitectureService';
+import { NewFeatureSupportLevelsAPI } from './apis';
+
+const NewFeatureSupportLevelsService = {
+  async getFeaturesSupportLevel(openshiftVersion: string, cpuArchitecture?: string) {
+    const cpuArch = getCpuArchitecture(cpuArchitecture);
+    const { data: features } = await NewFeatureSupportLevelsAPI.featuresSupportLevel(
+      openshiftVersion,
+      cpuArch,
+    );
+    return features;
+  },
+};
+export default NewFeatureSupportLevelsService;

--- a/libs/ui-lib/lib/ocm/services/apis/NewFeatureSupportLevelsAPI.ts
+++ b/libs/ui-lib/lib/ocm/services/apis/NewFeatureSupportLevelsAPI.ts
@@ -1,26 +1,24 @@
-import {
-  ArchitectureSupportLevelMap,
-  NewFeatureSupportLevelMap,
-} from '../../../common/components/newFeatureSupportLevels';
+import { CpuArchitecture } from '../../../common';
 import { clientWithoutConverter } from '../../api/axiosClient';
-
-export interface ArchitecturesSupportsLevel {
-  architectures: ArchitectureSupportLevelMap;
-}
-
-export interface FeaturesSupportsLevel {
-  features: NewFeatureSupportLevelMap;
-}
+import {
+  ArchitecturesSupportsLevel,
+  FeaturesSupportsLevel,
+} from '../../components/newFeatureSupportLevels/types';
+import { mapOcmArchToCpuArchitecture } from '../CpuArchitectureService';
 
 const NewFeatureSupportLevelsAPI = {
   makeBaseURI() {
     return `/v2/support-levels`;
   },
 
-  featuresSupportLevel(openshiftVersion: string, cpuArchitecture?: string) {
+  featuresSupportLevel(openshiftVersion: string, cpuArchitecture?: string, isOcm?: boolean) {
+    const cpuArch =
+      isOcm && cpuArchitecture
+        ? mapOcmArchToCpuArchitecture(cpuArchitecture)
+        : cpuArchitecture || CpuArchitecture.x86;
     let queryParams = '?';
     queryParams += openshiftVersion ? `openshift_version=${openshiftVersion}&` : '';
-    queryParams += cpuArchitecture ? `cpu_architecture=${cpuArchitecture}` : '';
+    queryParams += cpuArchitecture ? `cpu_architecture=${cpuArch || CpuArchitecture.x86}` : '';
     return clientWithoutConverter.get<FeaturesSupportsLevel>(
       `${NewFeatureSupportLevelsAPI.makeBaseURI()}/features${queryParams}`,
     );

--- a/libs/ui-lib/lib/ocm/services/apis/NewFeatureSupportLevelsAPI.ts
+++ b/libs/ui-lib/lib/ocm/services/apis/NewFeatureSupportLevelsAPI.ts
@@ -3,18 +3,16 @@ import {
   ArchitecturesSupportsLevel,
   FeaturesSupportsLevel,
 } from '../../components/newFeatureSupportLevels/types';
-import { getCpuArchitecture } from '../CpuArchitectureService';
 
 const NewFeatureSupportLevelsAPI = {
   makeBaseURI() {
     return `/v2/support-levels`;
   },
 
-  featuresSupportLevel(openshiftVersion: string, cpuArchitecture?: string, isOcm?: boolean) {
-    const cpuArch = getCpuArchitecture(cpuArchitecture, isOcm);
+  featuresSupportLevel(openshiftVersion: string, cpuArchitecture?: string) {
     let queryParams = '?';
     queryParams += openshiftVersion ? `openshift_version=${openshiftVersion}&` : '';
-    queryParams += cpuArchitecture ? `cpu_architecture=${cpuArch}` : '';
+    queryParams += cpuArchitecture ? `cpu_architecture=${cpuArchitecture}` : '';
     return clientWithoutConverter.get<FeaturesSupportsLevel>(
       `${NewFeatureSupportLevelsAPI.makeBaseURI()}/features${queryParams}`,
     );

--- a/libs/ui-lib/lib/ocm/services/apis/NewFeatureSupportLevelsAPI.ts
+++ b/libs/ui-lib/lib/ocm/services/apis/NewFeatureSupportLevelsAPI.ts
@@ -1,10 +1,9 @@
-import { CpuArchitecture } from '../../../common';
 import { clientWithoutConverter } from '../../api/axiosClient';
 import {
   ArchitecturesSupportsLevel,
   FeaturesSupportsLevel,
 } from '../../components/newFeatureSupportLevels/types';
-import { mapOcmArchToCpuArchitecture } from '../CpuArchitectureService';
+import { getCpuArchitecture } from '../CpuArchitectureService';
 
 const NewFeatureSupportLevelsAPI = {
   makeBaseURI() {
@@ -12,13 +11,10 @@ const NewFeatureSupportLevelsAPI = {
   },
 
   featuresSupportLevel(openshiftVersion: string, cpuArchitecture?: string, isOcm?: boolean) {
-    const cpuArch =
-      isOcm && cpuArchitecture
-        ? mapOcmArchToCpuArchitecture(cpuArchitecture)
-        : cpuArchitecture || CpuArchitecture.x86;
+    const cpuArch = getCpuArchitecture(cpuArchitecture, isOcm);
     let queryParams = '?';
     queryParams += openshiftVersion ? `openshift_version=${openshiftVersion}&` : '';
-    queryParams += cpuArchitecture ? `cpu_architecture=${cpuArch || CpuArchitecture.x86}` : '';
+    queryParams += cpuArchitecture ? `cpu_architecture=${cpuArch}` : '';
     return clientWithoutConverter.get<FeaturesSupportsLevel>(
       `${NewFeatureSupportLevelsAPI.makeBaseURI()}/features${queryParams}`,
     );

--- a/libs/ui-lib/lib/ocm/services/apis/index.ts
+++ b/libs/ui-lib/lib/ocm/services/apis/index.ts
@@ -6,3 +6,4 @@ export { default as HostsAPI } from './HostsAPI';
 export { default as InfraEnvsAPI } from './InfraEnvsAPI';
 export { default as EventsAPI } from './EventsAPI';
 export { default as FeatureSupportLevelsAPI } from './FeatureSupportLevelsAPI';
+export { default as NewFeatureSupportLevelsAPI } from './NewFeatureSupportLevelsAPI';

--- a/libs/ui-lib/lib/ocm/services/index.ts
+++ b/libs/ui-lib/lib/ocm/services/index.ts
@@ -6,5 +6,6 @@ export { default as InfraEnvsService } from './InfraEnvsService';
 export { default as DiscoveryImageFormService } from './DiscoveryImageFormService';
 export { default as DiskEncryptionService } from './DiskEncryptionService';
 export { default as OperatorsService } from './OperatorsService';
+export { default as NewFeatureSupportLevelsService } from './NewFeatureSupportLevelsService';
 export * from './types';
 export * as APIs from './apis';


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-14996

Related to https://gitlab.cee.redhat.com/service/uhc-portal/-/merge_requests/4247

Before these changes we can not add hosts to SNO cluster with 4.14 version.
Now it works:


https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/84b6bdcf-ee48-4146-8fbd-47e7942b48a4

