### PR TITLE
Improve setup documentation

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -16,7 +16,7 @@ The principal folders are: `apps` and `libs`.
 1. A Linux distro, like Fedora.
 2. [NodeJS](https://nodejs.org/en) > v14, or newer LTS version.
 3. [Yarn](https://yarnpkg.com/getting-started/install)
-4. This project uses `rsync` in order to synchronize .css files in one if it's build steps.
+4. This project uses `rsync` in order to synchronize .css files in one of its build steps.
 5. A back-end API to connect to. Please see instructions in
    [assisted-test-infra](https://github.com/openshift/assisted-test-infra).
 

--- a/libs/ui-lib-tests/README.md
+++ b/libs/ui-lib-tests/README.md
@@ -1,14 +1,14 @@
 #### Assisted UI tests
 
 This folder contains the integration test suites run by the Vertical Markets UI team for the
-[Assisted Installer UI Lib](https://github.com/openshift-assisted/assisted-ui-lib).
-
-Due to the nature of the Assisted Installer, each individual test in this suite depends on the
-previous tests having completed correctly.
+[Assisted Installer UI](https://github.com/openshift-assisted/assisted-installer-ui).
 
 In order to run the tests fast and not to depend on HW infrastructure, the API is mocked. It's
 important to mock the API accurately to avoid having passing UI tests that would fail with a real
 API.
+
+Each individual test should mock the required status in which starts, as they should all be
+independent of each other.
 
 # How to use this repo
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "clean:all": "yarn workspaces foreach -vp run clean && yarn rimraf node_modules",
     "format:all": "yarn prettier --cache --cache-strategy=content --check .",
     "lint:all": "yarn eslint --max-warnings 0 --cache --cache-strategy=content --cache-location=node_modules/.cache/eslint/.eslint-cache .",
-    "test:all": "yarn workspace @openshift-assisted/integration-tests-ocm run test:assisted-ui"
+    "test:run": "yarn workspace @openshift-assisted/ui-lib-tests run cy:run",
+    "test:open": "yarn workspace @openshift-assisted/ui-lib-tests run cy:open"
   },
   "workspaces": [
     "apps/*",


### PR DESCRIPTION
- Fixed some typos
- The command `yarn test:all` from main `package.json` was incorrect. I have modified it to be able to run the integration tests, or to open them. Or is there a preferred way to run them? In that case, we should drop the `yarn test:all` command.