### PR TITLE
MGMT-11675: Adjust link to console for multicluster operator install

### DIFF
--- a/libs/ui-lib/lib/common/components/clusterDetail/ClusterCredentials.tsx
+++ b/libs/ui-lib/lib/common/components/clusterDetail/ClusterCredentials.tsx
@@ -17,6 +17,16 @@ type ClusterCredentialsProps = {
   notAvailable?: boolean;
 };
 
+
+export const getConsoleUrl = (consoleUrl:string,isMceOperatorEnabled:boolean) =>{
+  if (isMceOperatorEnabled){
+    return consoleUrl.concat('/multicloud/infrastructure/clusters');
+  }
+  else {
+    return consoleUrl;
+  }
+}
+
 const ClusterCredentials: React.FC<ClusterCredentialsProps> = ({
   cluster,
   credentials,
@@ -54,6 +64,7 @@ const ClusterCredentials: React.FC<ClusterCredentialsProps> = ({
   } else if (!credentials.username && !credentials.consoleUrl) {
     return <>N/A</>;
   } else {
+    const consoleUrl = credentials.consoleUrl? getConsoleUrl(credentials.consoleUrl,false):'';
     credentialsBody = (
       <DetailList>
         {credentials.consoleUrl && (
@@ -66,15 +77,15 @@ const ClusterCredentials: React.FC<ClusterCredentialsProps> = ({
                   icon={<ExternalLinkAltIcon />}
                   iconPosition="right"
                   isInline
-                  onClick={() => window.open(credentials.consoleUrl, '_blank', 'noopener')}
+                  onClick={() => window.open(consoleUrl, '_blank', 'noopener')}
                   data-testid={`${idPrefix}-link-console-url`}
                 >
-                  {credentials.consoleUrl}
+                  {consoleUrl}
                 </Button>
                 <br />
                 {cluster.apiVip && cluster.ingressVip && (
                   <TroubleshootingOpenshiftConsoleButton
-                    consoleUrl={credentials.consoleUrl}
+                    consoleUrl={consoleUrl}
                     cluster={cluster}
                     idPrefix={idPrefix}
                   />


### PR DESCRIPTION
When a user installs the Mutlicluster engine operator via Assisted installer in OCM we should change the link to the console to direct them to the all clusters perspective and land them on the cluster list page.

 
![link_console](https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/06686300-96f9-4aa9-8746-184602ee7aed)
