### PR TITLE
Improve text assertions

### DIFF
--- a/libs/ui-lib-tests/cypress/integration/create-multinode/0-create-cluster.cy.ts
+++ b/libs/ui-lib-tests/cypress/integration/create-multinode/0-create-cluster.cy.ts
@@ -37,7 +37,7 @@ describe(`Assisted Installer Multinode Cluster Installation`, () => {
       commonActions.waitForNext();
       commonActions.clickNextButton();
 
-      cy.get('h2').should('contain', 'Host discovery');
+      commonActions.verifyIsAtStep('Host discovery');
     });
   });
 });

--- a/libs/ui-lib-tests/cypress/integration/create-multinode/1-host-discovery.cy.ts
+++ b/libs/ui-lib-tests/cypress/integration/create-multinode/1-host-discovery.cy.ts
@@ -34,7 +34,7 @@ describe(`Assisted Installer Multinode Host discovery`, () => {
 
   describe('Downloading the Discovery ISO', () => {
     it('Should generate discovery ISO and wait for generate to complete', () => {
-      bareMetalDiscoveryPage.getAddHostsButton().should('contain', 'Add hosts');
+      bareMetalDiscoveryPage.getAddHostsButton().should('contain.text', 'Add hosts');
       bareMetalDiscoveryPage.openAddHostsModal();
 
       bareMetalDiscoveryIsoModal.getGenerateDiscoveryIso().click();

--- a/libs/ui-lib-tests/cypress/integration/create-multinode/3-review.cy.ts
+++ b/libs/ui-lib-tests/cypress/integration/create-multinode/3-review.cy.ts
@@ -14,7 +14,7 @@ describe(`Assisted Installer Multinode Review`, () => {
   beforeEach(() => {
     cy.loadAiAPIIntercepts(null);
     commonActions.visitClusterDetailsPage();
-    commonActions.getHeader('h2').should('contain', 'Review and create');
+    commonActions.verifyIsAtStep('Review and create');
   });
 
   describe('Cluster summary', () => {

--- a/libs/ui-lib-tests/cypress/integration/create-sno/0-create-cluster.cy.ts
+++ b/libs/ui-lib-tests/cypress/integration/create-sno/0-create-cluster.cy.ts
@@ -46,7 +46,7 @@ describe(`Assisted Installer SNO Cluster Installation`, () => {
       commonActions.waitForNext();
       commonActions.clickNextButton();
 
-      commonActions.getHeader('h2').should('contain', 'Host discovery');
+      commonActions.verifyIsAtStep('Host discovery');
     });
 
     it('Show the dev-preview badge for SNO', () => {

--- a/libs/ui-lib-tests/cypress/integration/create-sno/0-create-cluster.cy.ts
+++ b/libs/ui-lib-tests/cypress/integration/create-sno/0-create-cluster.cy.ts
@@ -55,7 +55,7 @@ describe(`Assisted Installer SNO Cluster Installation`, () => {
       clusterDetailsPage.enableSno();
       commonActions
         .getWarningAlert()
-        .should('contain', 'Limitations for using Single Node OpenShift');
+        .should('contain.text', 'Limitations for using Single Node OpenShift');
     });
 
     it('Lists the new cluster', () => {

--- a/libs/ui-lib-tests/cypress/integration/create-sno/0-create-cluster.cy.ts
+++ b/libs/ui-lib-tests/cypress/integration/create-sno/0-create-cluster.cy.ts
@@ -30,7 +30,7 @@ describe(`Assisted Installer SNO Cluster Installation`, () => {
       commonActions.visitNewClusterPage();
 
       clusterDetailsPage.inputClusterName();
-      clusterDetailsPage.inputbaseDnsDomain();
+      clusterDetailsPage.inputBaseDnsDomain();
       clusterDetailsPage.inputOpenshiftVersion();
 
       clusterDetailsPage.enableSno();

--- a/libs/ui-lib-tests/cypress/integration/create-sno/1-host-discovery.cy.ts
+++ b/libs/ui-lib-tests/cypress/integration/create-sno/1-host-discovery.cy.ts
@@ -20,7 +20,7 @@ describe(`Assisted Installer SNO Host discovery`, () => {
 
   describe('Downloading the Discovery ISO', () => {
     it('Should generate discovery ISO and wait for generate to complete', () => {
-      bareMetalDiscoveryPage.getAddHostsButton().should('contain', 'Add host');
+      bareMetalDiscoveryPage.getAddHostsButton().should('contain.text', 'Add host');
       bareMetalDiscoveryPage.openAddHostsModal();
 
       bareMetalDiscoveryIsoModal.getGenerateDiscoveryIso().click();

--- a/libs/ui-lib-tests/cypress/integration/create-sno/3-review.cy.ts
+++ b/libs/ui-lib-tests/cypress/integration/create-sno/3-review.cy.ts
@@ -14,7 +14,7 @@ describe(`Assisted Installer SNO Review`, () => {
   beforeEach(() => {
     cy.loadAiAPIIntercepts(null);
     commonActions.visitClusterDetailsPage();
-    commonActions.getHeader('h2').should('contain', 'Review and create');
+    commonActions.verifyIsAtStep('Review and create');
   });
 
   describe('Cluster summary', () => {

--- a/libs/ui-lib-tests/cypress/integration/custom-manifests/1-create-cluster-with-custom-manifests.cy.ts
+++ b/libs/ui-lib-tests/cypress/integration/custom-manifests/1-create-cluster-with-custom-manifests.cy.ts
@@ -25,7 +25,9 @@ describe(`Assisted Installer Cluster Installation with Custom Manifests`, () => 
       clusterDetailsPage.inputPullSecret();
       clusterDetailsPage.getCustomManifestCheckbox().should('be.visible').check();
       clusterDetailsPage.getCustomManifestCheckbox().should('be.checked');
-      commonActions.getInfoAlert().should('contain', 'This is an advanced configuration feature.');
+      commonActions
+        .getInfoAlert()
+        .should('contain.text', 'This is an advanced configuration feature.');
       commonActions.getWizardStepNav('Custom manifests').should('exist');
       commonActions.waitForNext();
       commonActions.clickNextButton();

--- a/libs/ui-lib-tests/cypress/integration/custom-manifests/1-create-cluster-with-custom-manifests.cy.ts
+++ b/libs/ui-lib-tests/cypress/integration/custom-manifests/1-create-cluster-with-custom-manifests.cy.ts
@@ -19,7 +19,7 @@ describe(`Assisted Installer Cluster Installation with Custom Manifests`, () => 
       commonActions.visitNewClusterPage();
 
       clusterDetailsPage.inputClusterName();
-      clusterDetailsPage.inputbaseDnsDomain();
+      clusterDetailsPage.inputBaseDnsDomain();
       clusterDetailsPage.inputOpenshiftVersion();
 
       clusterDetailsPage.inputPullSecret();

--- a/libs/ui-lib-tests/cypress/integration/custom-manifests/2-modifying-existing-custom-manifest.cy.ts
+++ b/libs/ui-lib-tests/cypress/integration/custom-manifests/2-modifying-existing-custom-manifest.cy.ts
@@ -15,7 +15,7 @@ describe(`Assisted Installer Custom manifests step`, () => {
     commonActions.visitClusterDetailsPage();
   });
 
-  describe('Modifyng existing Custom Manifests', () => {
+  describe('Modifying existing Custom Manifests', () => {
     it('Can configure custom manifests step and next button is disabled', () => {
       cy.wait('@list-manifests').then(() => {
         commonActions
@@ -36,17 +36,20 @@ describe(`Assisted Installer Custom manifests step`, () => {
       customManifestsPage.fileUpload(0).attachFile(`custom-manifests/files/img.png`);
       customManifestsPage
         .getYamlContentError()
-        .contains('File type is not supported. File type must be yaml, yml or json.');
+        .should('contain.text', 'File type is not supported. File type must be yaml, yml or json.');
       commonActions.getNextButton().should('be.disabled');
     });
     it('Incorrect file name', () => {
       customManifestsPage.getFileName(0).clear().type('test.txt');
       customManifestsPage
         .getFileNameError()
-        .contains('Must have a yaml, yml or json extension and can not contain /.');
+        .should('contain.text', 'Must have a yaml, yml or json extension and can not contain /.');
       customManifestsPage
         .getAlertTitle()
-        .contains('Custom manifests configuration contains missing or invalid fields');
+        .should(
+          'contain.text',
+          'Custom manifests configuration contains missing or invalid fields',
+        );
       commonActions.getNextButton().should('be.disabled');
     });
   });

--- a/libs/ui-lib-tests/cypress/integration/custom-manifests/4-view-custom-manifests-review-and-create-page.cy.ts
+++ b/libs/ui-lib-tests/cypress/integration/custom-manifests/4-view-custom-manifests-review-and-create-page.cy.ts
@@ -21,7 +21,9 @@ describe(`Assisted Installer Review and create step with custom manifests`, () =
         .getWizardStepNav('Review and create')
         .should('have.class', ACTIVE_NAV_ITEM_CLASS);
       reviewAndCreatePage.getCustomManifestsSection().click();
-      reviewAndCreatePage.getCustomManifestsDetail().contains('manifests/manifest1.yaml');
+      reviewAndCreatePage
+        .getCustomManifestsDetail()
+        .should('contain.text', 'manifests/manifest1.yaml');
     });
   });
 });

--- a/libs/ui-lib-tests/cypress/integration/dualstack/3-review.cy.ts
+++ b/libs/ui-lib-tests/cypress/integration/dualstack/3-review.cy.ts
@@ -12,7 +12,7 @@ describe(`Assisted Installer Dualstack Review`, () => {
   beforeEach(() => {
     cy.loadAiAPIIntercepts(null);
     commonActions.visitClusterDetailsPage();
-    commonActions.getHeader('h2').should('contain', 'Review and create');
+    commonActions.verifyIsAtStep('Review and create');
   });
 
   it('Should be ready to install', () => {

--- a/libs/ui-lib-tests/cypress/integration/features/disk-encryption.cy.ts
+++ b/libs/ui-lib-tests/cypress/integration/features/disk-encryption.cy.ts
@@ -69,7 +69,7 @@ describe(`Assisted Installer Disk Encryption`, () => {
     utils.setLastWizardSignal('CLUSTER_CREATED');
 
     commonActions.clickNextButton();
-    cy.get('h2').should('contain', 'Host discovery');
+    commonActions.verifyIsAtStep('Host discovery');
     bareMetalDiscoveryPage.setClusterIdFromUrl();
   });
 });

--- a/libs/ui-lib-tests/cypress/integration/static-ip/0-create-cluster.cy.ts
+++ b/libs/ui-lib-tests/cypress/integration/static-ip/0-create-cluster.cy.ts
@@ -42,7 +42,7 @@ describe(`Assisted Installer Static IP Cluster Creation`, () => {
         utils.setLastWizardSignal('CLUSTER_CREATED');
       });
 
-      cy.get('h2').should('contain', 'Static network configurations');
+      commonActions.verifyIsAtStep('Static network configurations');
     });
   });
 });

--- a/libs/ui-lib-tests/cypress/integration/static-ip/3-configure-static-ip-yaml.cy.ts
+++ b/libs/ui-lib-tests/cypress/integration/static-ip/3-configure-static-ip-yaml.cy.ts
@@ -76,7 +76,7 @@ describe(`Assisted Installer Static IP YAML configuration`, () => {
     });
 
     it('Can show the correct type view', () => {
-      commonActions.getHeader('h2').contains('Static network configurations');
+      commonActions.verifyIsAtStep('Static network configurations');
       staticIpPage.getYamlViewSelect().should('be.enabled');
     });
 

--- a/libs/ui-lib-tests/cypress/integration/ui-behaviour/cluster-creation.cy.ts
+++ b/libs/ui-lib-tests/cypress/integration/ui-behaviour/cluster-creation.cy.ts
@@ -24,7 +24,7 @@ describe('Assisted Installer UI behaviour - cluster creation', () => {
 
       clusterDetailsPage
         .getSelectedOpenShiftVersion()
-        .should('contain', `OpenShift ${versionsFixtures.getDefaultOpenShiftVersion()}`);
+        .should('contain.text', `OpenShift ${versionsFixtures.getDefaultOpenShiftVersion()}`);
 
       // Checking that the submitting value (item ID) for each version is correct
       clusterDetailsPage.openOpenshiftVersionDropdown();

--- a/libs/ui-lib-tests/cypress/integration/ui-behaviour/cluster-updates.cy.ts
+++ b/libs/ui-lib-tests/cypress/integration/ui-behaviour/cluster-updates.cy.ts
@@ -29,7 +29,7 @@ describe('Assisted Installer UI behaviour - cluster updates', () => {
       navbar.clickOnNavItem('Cluster details');
       commonActions.clickNextButton();
       commonActions.clickNextButton();
-      commonActions.getHeader('h2').should('contain', 'Host discovery');
+      commonActions.verifyIsAtStep('Host discovery');
     });
   });
 

--- a/libs/ui-lib-tests/cypress/support/variables/storage-step.ts
+++ b/libs/ui-lib-tests/cypress/support/variables/storage-step.ts
@@ -4,4 +4,4 @@ Cypress.env(
   'skipFormattingWarningDesc',
   'You have opted out of formatting bootable disks on some hosts. To ensure the hosts reboot into the expected installation disk, manual user intervention might be required during OpenShift installation.',
 );
-Cypress.env('warningIconPath', 'M569');
+Cypress.env('warningIconFillColor', '#f0ab00');

--- a/libs/ui-lib-tests/cypress/views/bareMetalDiscovery.ts
+++ b/libs/ui-lib-tests/cypress/views/bareMetalDiscovery.ts
@@ -45,7 +45,7 @@ export const bareMetalDiscoveryPage = {
     });
   },
   waitForHostRowToContain: (text, timeout = Cypress.env('HOST_DISCOVERY_TIMEOUT')) => {
-    cy.get('table.hosts-table > tbody > tr', { timeout: timeout }).should('contain', text);
+    cy.get('table.hosts-table > tbody > tr', { timeout: timeout }).should('contain.text', text);
   },
   selectHostRowKebabAction: (rowIndex, actionItem) => {
     cy.get(`[data-testid=host-row-${rowIndex}] > .pf-c-table__action .pf-c-dropdown__toggle`)
@@ -98,21 +98,21 @@ export const bareMetalDiscoveryPage = {
   validateHostRowColumnValue: (hostRowIndex, columnDataTestId, value) => {
     cy.get(
       `[data-testid=host-row-${hostRowIndex}] > [data-testid=${columnDataTestId}] > .pf-m-align-items-center > .pf-l-flex > .pf-c-button`,
-    ).should('contain', value);
+    ).should('contain.text', value);
   },
   sortCpuAscending: () => {
     // first click will sort in Ascending order (lowest to highest)
     cy.get(`${Cypress.env('colHeaderCpuCoresId')} > .pf-c-table__button`).click();
     cy.get(`${Cypress.env('colHeaderCpuCoresId')} > .pf-c-table__button > div > span > svg > path`)
       .invoke('attr', 'd')
-      .should('contain', 'M88');
+      .should('contain.text', 'M88');
   },
   sortCpuDescending: () => {
     // second click will sort in Descending order (highest to lowest)
     cy.get(`${Cypress.env('colHeaderCpuCoresId')} > .pf-c-table__button`).click();
     cy.get(`${Cypress.env('colHeaderCpuCoresId')} > .pf-c-table__button > div > span > svg > path`)
       .invoke('attr', 'd')
-      .should('contain', 'M168');
+      .should('contain.text', 'M168');
   },
   clickSaveEditHostsForm: () => {
     cy.get(Cypress.env('submitButton')).click();

--- a/libs/ui-lib-tests/cypress/views/bareMetalDiscoveryIsoModal.ts
+++ b/libs/ui-lib-tests/cypress/views/bareMetalDiscoveryIsoModal.ts
@@ -12,13 +12,13 @@ export const bareMetalDiscoveryIsoModal = {
         'contain',
         'Add host', // TODO variation for SNO
       );
-      cy.get('.pf-c-form__label-text').should('contain', 'SSH public key');
+      cy.get('.pf-c-form__label-text').should('contain.text', 'SSH public key');
       cy.get('#sshPublicKey-filename')
         .invoke('attr', 'placeholder')
-        .should('contain', 'Drag a file here or browse to upload');
+        .should('contain.text', 'Drag a file here or browse to upload');
       cy.get('#sshPublicKey-browse-button')
         .invoke('attr', 'aria-disabled')
-        .should('contain', 'false');
+        .should('contain.text', 'false');
     });
   },
   getMinimalIsoOption: () => {
@@ -31,7 +31,7 @@ export const bareMetalDiscoveryIsoModal = {
     bareMetalDiscoveryIsoModal.getSshPublicKey().should('be.visible');
     if (sshKey) {
       bareMetalDiscoveryIsoModal.getSshPublicKey().fill(sshKey);
-      bareMetalDiscoveryIsoModal.getSshPublicKey().invoke('text').should('contain', sshKey);
+      bareMetalDiscoveryIsoModal.getSshPublicKey().invoke('text').should('contain.text', sshKey);
     } else {
       // trigger empty ssh key error field helper
       bareMetalDiscoveryIsoModal.getSshPublicKey().clear().type(' {backspace}');
@@ -65,7 +65,7 @@ export const bareMetalDiscoveryIsoModal = {
     return cy.get('#form-input-hostname-field-helper');
   },
   validateChangeHostnameHelperTextError: (msg) => {
-    cy.get('.pf-m-error').should('contain', msg);
+    cy.get('.pf-m-error').should('contain.text', msg);
   },
   validateNeverShareWarning: () => {
     cy.get('.pf-c-modal-box__body > .pf-c-alert').should(
@@ -105,7 +105,7 @@ export const bareMetalDiscoveryIsoModal = {
     bareMetalDiscoveryIsoModal.getImageTypeDropdown().within(() => {
       cy.get('li').contains(typeLabel).click();
     });
-    bareMetalDiscoveryIsoModal.getSelectedImageType().should('contain', typeLabel);
+    bareMetalDiscoveryIsoModal.getSelectedImageType().should('contain.text', typeLabel);
   },
   getCancelGenerateDiscoveryIsoButton: () => {
     return cy.get('.pf-c-modal-box__footer > .pf-m-link');
@@ -141,7 +141,7 @@ export const bareMetalDiscoveryIsoModal = {
     }
   },
   waitForIsoGeneration: (timeout = Cypress.env('GENERATE_ISO_TIMEOUT')) => {
-    cy.get('h4', { timeout: timeout }).should('contain', Cypress.env('isoReadyToDownloadText'));
+    cy.get('h4', { timeout }).should('contain.text', Cypress.env('isoReadyToDownloadText'));
   },
   verifyDownloadIsoLinks: () => {
     return cy

--- a/libs/ui-lib-tests/cypress/views/clusterDetails.ts
+++ b/libs/ui-lib-tests/cypress/views/clusterDetails.ts
@@ -22,7 +22,7 @@ export const clusterDetailsPage = {
     clusterDetailsPage.getOpenshiftVersionDropdown().within(() => {
       cy.get('li').contains(version).click();
     });
-    clusterDetailsPage.getSelectedOpenShiftVersion().should('contain', `OpenShift ${version}`);
+    clusterDetailsPage.getSelectedOpenShiftVersion().should('contain.text', `OpenShift ${version}`);
   },
   getPullSecret: () => {
     return cy.get(Cypress.env('pullSecretFieldId'));
@@ -36,7 +36,7 @@ export const clusterDetailsPage = {
     }
     clusterDetailsPage.getPullSecret().clear();
     cy.pasteText(Cypress.env('pullSecretFieldId'), pullSecret);
-    clusterDetailsPage.getPullSecret().should('contain', pullSecret);
+    clusterDetailsPage.getPullSecret().should('contain.text', pullSecret);
   },
   checkAiTechSupportLevel: () => {
     cy.get(Cypress.env('assistedInstallerSupportLevel'))
@@ -102,7 +102,7 @@ export const clusterDetailsPage = {
   validateInputNameFieldHelper: (status) => {
     cy.get(`[aria-label='Validation'] > svg`)
       .invoke('attr', 'fill')
-      .should('contain', status === 'fail' ? '#c9190b' : '#3e8635');
+      .should('contain.text', status === 'fail' ? '#c9190b' : '#3e8635');
   },
   getClusterNameFieldValidator: () => {
     return cy.get(Cypress.env('clusterNameFieldValidator'));

--- a/libs/ui-lib-tests/cypress/views/clusterDetails.ts
+++ b/libs/ui-lib-tests/cypress/views/clusterDetails.ts
@@ -41,17 +41,17 @@ export const clusterDetailsPage = {
   checkAiTechSupportLevel: () => {
     cy.get(Cypress.env('assistedInstallerSupportLevel'))
       .should('be.visible')
-      .contains(Cypress.env('techPreviewSupportLevel'));
+      .should('contain.text', Cypress.env('techPreviewSupportLevel'));
   },
   checkSnoDevSupportLevel: () => {
     cy.get(Cypress.env('snoSupportLevel'))
       .should('be.visible')
-      .contains(Cypress.env('devPreviewSupportLevel'));
+      .should('contain.text', Cypress.env('devPreviewSupportLevel'));
   },
   getBaseDnsDomain: () => {
     return cy.get(Cypress.env('baseDnsDomainFieldId'));
   },
-  inputbaseDnsDomain: (dns = Cypress.env('DNS_DOMAIN_NAME')) => {
+  inputBaseDnsDomain: (dns = Cypress.env('DNS_DOMAIN_NAME')) => {
     clusterDetailsPage.getBaseDnsDomain().clear().type(dns).should('have.value', dns);
   },
   getSno: () => {
@@ -69,10 +69,9 @@ export const clusterDetailsPage = {
   },
   selectCpuArchitecture: (cpuArchitecture) => {
     cy.get(`ul.pf-c-dropdown__menu li[id=${cpuArchitecture}] a`).click();
-    cy.get(`${Cypress.env('cpuArchitectureFieldId')} .pf-c-dropdown__toggle-text`).contains(
-      cpuArchitecture,
-      { matchCase: false },
-    );
+    cy.get(`${Cypress.env('cpuArchitectureFieldId')} .pf-c-dropdown__toggle-text`)
+      .invoke('text')
+      .should('match', new RegExp(cpuArchitecture, 'i'));
   },
   CpuArchitectureExists: (cpuArchitecture) => {
     cy.get(`ul.pf-c-dropdown__menu li[id=${cpuArchitecture}] a`).should('exist');

--- a/libs/ui-lib-tests/cypress/views/clusterList.ts
+++ b/libs/ui-lib-tests/cypress/views/clusterList.ts
@@ -13,7 +13,7 @@ export const clusterListPage = {
   },
   openCluster: (clusterName = Cypress.env('CLUSTER_NAME')) => {
     cy.getClusterNameLinkSelector(clusterName).click();
-    cy.get('.pf-c-breadcrumb__list > :nth-child(3)').contains(clusterName);
+    cy.get('.pf-c-breadcrumb__list > :nth-child(3)').should('contain', clusterName);
     cy.get(Cypress.env('clusterNameFieldId')).should('have.value', clusterName);
   },
   deleteCluster: (clusterName = Cypress.env('CLUSTER_NAME')) => {

--- a/libs/ui-lib-tests/cypress/views/clusterList.ts
+++ b/libs/ui-lib-tests/cypress/views/clusterList.ts
@@ -46,7 +46,7 @@ export const clusterListPage = {
       .within(() => {
         cy.get('td[data-label="Provider (Location)"]', {
           timeout: timeout,
-        }).should('contain', provider);
+        }).should('contain.text', provider);
       });
   },
   filterSearchString: (searchString) => {

--- a/libs/ui-lib-tests/cypress/views/common.ts
+++ b/libs/ui-lib-tests/cypress/views/common.ts
@@ -1,44 +1,8 @@
-import { getCwd, getUiVersion } from '../support/utils';
 import * as utils from '../support/utils';
 
 export const commonActions = {
-  clickButtonContainingText: (text: string) => {
-    cy.get(`button:contains('${text}')`).scrollIntoView().should('be.visible').click();
-  },
   getWizardStepNav: (stepName: string) => {
     return cy.get('.pf-c-wizard__nav-item').contains(stepName);
-  },
-  clickDropDownMenuItem: (menuItemName: string) => {
-    cy.get('.pf-c-dropdown__menu-item').contains(menuItemName).click();
-  },
-  newLogAssistedUIVersion: () => {
-    getUiVersion().then((uiVersion) => {
-      cy.log('assisted-ui-lib-version', uiVersion);
-      getCwd().then((homeDir) => {
-        cy.log(`Writing UI version to ${homeDir}/test_artifacts/versions.log`);
-        cy.writeFile(`${homeDir}/test_artifacts/versions.log`, `UI: ${uiVersion}`, { flag: 'a+' });
-      });
-    });
-  },
-  waitForSpinnerToDisappear: () => {
-    cy.get('.pf-c-spinner__tail-ball').should('not.exist');
-  },
-  waitForValidationsToInitialize: () => {
-    cy.get('.pf-m-info').should('not.exist');
-  },
-  closeCookiesBanner: () => {
-    cy.get('body').then(($body) => {
-      if ($body.find(Cypress.env('trusteConsentButtonId')).length > 0) {
-        cy.get(Cypress.env('trusteConsentButtonId')).click();
-      }
-    });
-  },
-  closePendoBanner: () => {
-    cy.get('body').then(($body) => {
-      if ($body.find(Cypress.env('pendoCloseGuide')).length > 0) {
-        cy.get(Cypress.env('pendoCloseGuide')).click();
-      }
-    });
   },
   getNextButton: () => {
     return cy.get(Cypress.env('nextButton'));
@@ -46,17 +10,9 @@ export const commonActions = {
   clickNextButton: () => {
     commonActions.getNextButton().should('be.enabled').click();
   },
-  getBackButton: () => {
-    return cy.get(Cypress.env('backButton'));
-  },
-  waitForSave: () => {
-    cy.get(Cypress.env('spanRoleProgressBar')).should('not.match', /.*Saving.*changes.*/);
-  },
   waitForNext: () => {
     cy.get(Cypress.env('nextButton')).should('be.enabled');
   },
-  getHeader: (level = 'h1', timeout = Cypress.env('WAIT_FOR_HEADER_TIMEOUT')) =>
-    cy.get(level, { timeout: timeout }),
   getInfoAlert: () => {
     return cy.get(Cypress.env('infoAlertAriaLabel'));
   },
@@ -69,31 +25,31 @@ export const commonActions = {
   getDNSErrorMessage: () => {
     return cy.get('#form-input-dns-field-helper-error');
   },
+  verifyIsAtStep: (stepTitle: string) => {
+    cy.get('h2').should('contain.text', stepTitle);
+  },
   startAtNetworkingStep: () => {
     if (utils.hasWizardSignal('READY_TO_INSTALL')) {
       commonActions.getWizardStepNav('Networking').click();
     } else {
-      commonActions.getHeader('h2').should('contain', 'Host discovery');
+      commonActions.verifyIsAtStep('Host discovery');
       commonActions.clickNextButton();
       commonActions.clickNextButton();
     }
   },
+  startAtOperatorsStep: () => {
+    commonActions.getWizardStepNav('Operators').click();
+  },
   startAtStorageStep: () => {
     commonActions.getWizardStepNav('Storage').click();
+  },
+  startAtCustomManifestsStep: () => {
+    commonActions.getWizardStepNav('Custom manifests').click();
   },
   visitNewClusterPage: () => {
     cy.visit('/clusters/~new');
   },
   visitClusterDetailsPage: () => {
     cy.visit(`/clusters/${Cypress.env('clusterId')}`);
-  },
-  startAtCustomManifestsStep: () => {
-    commonActions.getWizardStepNav('Custom manifests').click();
-  },
-  clickBackButton: () => {
-    commonActions.getBackButton().should('be.enabled').click();
-  },
-  startAtOperatorsStep: () => {
-    commonActions.getWizardStepNav('Operators').click();
   },
 };

--- a/libs/ui-lib-tests/cypress/views/hostsTableSection.ts
+++ b/libs/ui-lib-tests/cypress/views/hostsTableSection.ts
@@ -78,7 +78,7 @@ export const hostsTableSection = {
   ) => {
     // Start at index 2 here because of selector
     for (let i = 2; i <= numMasters + numWorkers + 1; i++) {
-      cy.hostDetailSelector(i, 'Status', timeout).should('contain', status);
+      cy.hostDetailSelector(i, 'Status', timeout).should('contain.text', status);
     }
   },
   getHostDisksExpander: (hostIndex: number) => {

--- a/libs/ui-lib-tests/cypress/views/installationPage.ts
+++ b/libs/ui-lib-tests/cypress/views/installationPage.ts
@@ -72,7 +72,7 @@ export const installationPage = {
     cy.get(Cypress.env('clusterProgressStatusValueId')).scrollIntoView().should('be.visible');
     cy.get(Cypress.env('clusterProgressStatusValueId'), {
       timeout: timeout,
-    }).should('contain', status);
+    }).should('contain.text', status);
   },
   operatorsPopover: {
     open: () => {
@@ -80,7 +80,7 @@ export const installationPage = {
     },
     validateListItemContents: (msg) => {
       cy.get('.pf-c-popover__body').within(() => {
-        cy.get('li').should('contain', msg);
+        cy.get('li').should('contain.text', msg);
       });
     },
     close: () => {

--- a/libs/ui-lib-tests/cypress/views/networkingPage.ts
+++ b/libs/ui-lib-tests/cypress/views/networkingPage.ts
@@ -51,7 +51,7 @@ export const networkingPage = {
   validateSupportLimitation: () => {
     cy.newByDataTestId(Cypress.env('networkingVmsAlert'))
       .should('be.visible')
-      .contains(Cypress.env('vmsSupportLimitationText'));
+      .should('contain.text', Cypress.env('vmsSupportLimitationText'));
   },
   validateBMnoSupportLimitation: () => {
     cy.newByDataTestId(Cypress.env('networkingVmsAlert')).should('not.exist');
@@ -59,7 +59,7 @@ export const networkingPage = {
   checkDhcpSupportLevel: () => {
     cy.get(Cypress.env('vipAutoAllocSupportLevel'))
       .should('be.visible')
-      .contains(Cypress.env('devPreviewSupportLevel'));
+      .should('contain.text', Cypress.env('devPreviewSupportLevel'));
   },
   waitForNetworkStatusToNotContain: (
     text,

--- a/libs/ui-lib-tests/cypress/views/networkingPage.ts
+++ b/libs/ui-lib-tests/cypress/views/networkingPage.ts
@@ -78,7 +78,7 @@ export const networkingPage = {
     timeout = Cypress.env('HOST_READY_TIMEOUT'),
   ) => {
     for (let i = 2; i <= numMasters + numWorkers + 1; i++) {
-      cy.hostDetailSelector(i, 'Status', timeout).should('contain', status);
+      cy.hostDetailSelector(i, 'Status', timeout).should('contain.text', status);
     }
   },
   waitForHostNetworkStatusInsufficient: (
@@ -87,7 +87,7 @@ export const networkingPage = {
   ) => {
     // host row index starts at 0 and increments by 2
     cy.newByDataTestId(`host-row-${idx}`).within(() => {
-      cy.newByDataTestId('nic-status', timeout).should('contain', 'Insufficient');
+      cy.newByDataTestId('nic-status', timeout).should('contain.text', 'Insufficient');
     });
   },
   getClusterNetworkCidr: () => {
@@ -248,7 +248,7 @@ export const networkingPage = {
     cy.get('.pf-c-content')
       .should('be.visible')
       .within(() => {
-        cy.get('p').should('contain', 'Please refer to the');
+        cy.get('p').should('contain.text', 'Please refer to the');
         cy.get('li').should((list) => {
           expect(list).to.have.length(4);
           expect(list.eq(0)).to.have.text('DHCP or static IP Addresses');

--- a/libs/ui-lib-tests/cypress/views/reviewCreate.ts
+++ b/libs/ui-lib-tests/cypress/views/reviewCreate.ts
@@ -12,9 +12,9 @@ export const reviewAndCreatePage = {
     version = Cypress.env('OPENSHIFT_VERSION'),
     stackType = 'IPv4',
   } = {}) => {
-    cy.get(Cypress.env('clusterAddressValueId')).should('contain', `${clusterName}.${dns}`);
-    cy.get(Cypress.env('openshiftVersionValueId')).should('contain', version);
-    cy.get(Cypress.env('stackTypeValueId')).should('contain', stackType);
+    cy.get(Cypress.env('clusterAddressValueId')).should('contain.text', `${clusterName}.${dns}`);
+    cy.get(Cypress.env('openshiftVersionValueId')).should('contain.text', version);
+    cy.get(Cypress.env('stackTypeValueId')).should('contain.text', stackType);
   },
   checkAllClusterValidationsPassed: (timeout = 1000) => {
     cy.get(Cypress.env('clusterPreflightChecksResult'), { timeout }).should(

--- a/libs/ui-lib-tests/cypress/views/storagePage.ts
+++ b/libs/ui-lib-tests/cypress/views/storagePage.ts
@@ -26,7 +26,6 @@ export const storagePage = {
   },
   getSkipFormattingCheckbox: (hostId: string, indexSelect: number) => {
     return cy.get(`input[id="select-formatted-${hostId}-${indexSelect}"]`);
-    ``;
   },
   validateSkipFormattingDisks: (hostId: string, numDisks: number) => {
     cy.get(Cypress.env('skipFormattingDataLabel')).should('have.length', numDisks);
@@ -40,13 +39,16 @@ export const storagePage = {
     storagePage.getSkipFormattingCheckbox(hostId, 2).should('be.disabled');
   },
   validateSkipFormattingWarning: () => {
-    cy.get('.pf-c-alert__title').should('contain', Cypress.env('skipFormattingWarningTitle'));
-    cy.get('.pf-c-alert__description').should('contain', Cypress.env('skipFormattingWarningDesc'));
+    cy.get('.pf-c-alert__title').should('contain.text', Cypress.env('skipFormattingWarningTitle'));
+    cy.get('.pf-c-alert__description').should(
+      'contain.text',
+      Cypress.env('skipFormattingWarningDesc'),
+    );
   },
   validateSkipFormattingIcon: (diskId: string) => {
     //If a disk is skip formatting validate that warning icon is shown
-    cy.get(`[data-testid="disk-row-${diskId}"] [data-testid="disk-name"] > svg > path`)
-      .invoke('attr', 'd')
-      .should('contain', Cypress.env('warningIconPath'));
+    cy.get(`[data-testid="disk-row-${diskId}"] [data-testid="disk-name"]`).within((/* $diskRow */) => {
+      cy.get('[role="img"]').should('have.attr', 'fill', Cypress.env('warningIconFillColor'));
+    })
   },
 };

--- a/libs/ui-lib-tests/cypress/views/storagePage.ts
+++ b/libs/ui-lib-tests/cypress/views/storagePage.ts
@@ -47,8 +47,10 @@ export const storagePage = {
   },
   validateSkipFormattingIcon: (diskId: string) => {
     //If a disk is skip formatting validate that warning icon is shown
-    cy.get(`[data-testid="disk-row-${diskId}"] [data-testid="disk-name"]`).within((/* $diskRow */) => {
-      cy.get('[role="img"]').should('have.attr', 'fill', Cypress.env('warningIconFillColor'));
-    })
+    cy.get(`[data-testid="disk-row-${diskId}"] [data-testid="disk-name"]`).within(
+      (/* $diskRow */) => {
+        cy.get('[role="img"]').should('have.attr', 'fill', Cypress.env('warningIconFillColor'));
+      },
+    );
   },
 };


### PR DESCRIPTION
- When integration tests fail by doing text comparisons, sometimes we use the pattern `.should('contain')` which doesn't output the expected result. That makes debugging the issue harder.

We should use `.should('contain.text')` which prints what text it found instead of the expected one.


| before                                       | after                            |
|----------------------------------------------|----------------------------------|
| ![without-diff](https://github.com/openshift-assisted/assisted-installer-ui/assets/829045/9d7eb716-5c39-43b5-b622-96213921e35f) |![with-diff](https://github.com/openshift-assisted/assisted-installer-ui/assets/829045/6e44667a-4746-4697-afac-9dacc1b824d5)|

- In other cases, we were using `.contains(text)` to validate the text content. But this is not an assertion, rather it's a selector. I've changed the incorrect uses of `.contains` to `.should('contain.text')`.