### PR TITLE
[MGMT-15152] Fix jump bug and adapt tests

### DIFF
--- a/libs/ui-lib-tests/cypress/@types/Cypress.d.ts
+++ b/libs/ui-lib-tests/cypress/@types/Cypress.d.ts
@@ -30,6 +30,6 @@ declare namespace Cypress {
     hostDetailSelector(i: number, label: string, timeout?: number): Chainable<Element>;
     getClusterNameLinkSelector(clusterName?: string): Chainable<Element>;
     getIndexByName(selector: string, name: string, timeout?: number): Chainable<Element>;
-    loadAiAPIIntercepts(conf: AIInterceptsConfig | null, loadManifestContent?: boolean);
+    loadAiAPIIntercepts(conf: AIInterceptsConfig | null);
   }
 }

--- a/libs/ui-lib-tests/cypress/fixtures/custom-manifests/1-cluster-created.ts
+++ b/libs/ui-lib-tests/cypress/fixtures/custom-manifests/1-cluster-created.ts
@@ -2,7 +2,6 @@
 
 import { baseCluster, fakeClusterId } from '../cluster/base-cluster';
 import { clusterValidationsInfo } from '../cluster/validation-info-initial-cluster';
-import { customManifest, customManifestContent } from './manifests';
 
 const featureUsage = {
   'SDN network type': {
@@ -42,8 +41,6 @@ const customManifestsCluster = {
   network_type: 'OpenShiftSDN',
   user_managed_networking: false,
   vip_dhcp_allocation: true,
-  manifests: customManifest,
-  manifestContent: customManifestContent,
   e2e_mock_source: '5-cluster-ready',
   status: 'ready',
   status_info: 'Cluster ready to be installed',

--- a/libs/ui-lib-tests/cypress/fixtures/custom-manifests/index.ts
+++ b/libs/ui-lib-tests/cypress/fixtures/custom-manifests/index.ts
@@ -3,7 +3,7 @@ import { clusterReadyBuilder } from '../create-sno/5-cluster-ready';
 import { isoDownloadedClusterBuilder } from '../create-sno/2-iso-downloaded';
 import { hostDiscoveredBuilder } from '../create-sno/3-host-discovered';
 import { hostRenamedBuilder } from '../create-sno/4-host-renamed';
-import { customManifest, customManifestContent } from './manifests';
+import { customManifests, customManifestContent } from './manifests';
 
 const isoDownloadedCluster = isoDownloadedClusterBuilder(customManifestsCluster);
 const hostDiscoveredCluster = hostDiscoveredBuilder(isoDownloadedCluster);
@@ -15,7 +15,7 @@ const createCustomManifestsFixtureMapping = {
     READY_TO_INSTALL: readyToInstallCluster,
     default: customManifestsCluster,
   },
-  manifests: customManifest,
+  manifests: customManifests,
   manifestContent: customManifestContent,
 };
 

--- a/libs/ui-lib-tests/cypress/fixtures/custom-manifests/manifests.ts
+++ b/libs/ui-lib-tests/cypress/fixtures/custom-manifests/manifests.ts
@@ -1,9 +1,19 @@
-export const customManifest = [
-  {
-    file_name: 'manifest1.yaml',
-    folder: 'manifests',
-  },
-];
+const dummyManifest = {
+  file_name: 'manifest1.yaml',
+  folder: 'manifests',
+};
 
-export const customManifestContent =
-  "{apiVersion: scaffolder.backstage.io/v1beta3, kind: Template, metadata: {name: docs-template, title: 'Documentation Template', description: 'Create a new standalone documentation project', tags: [recommended, techdocs, mkdocs]}, spec: {owner: my-awesome-team, type: documentation, parameters: [{title: 'Fill in some steps', required: [name, description], properties: {name: {title: Name, type: string, description: 'Unique name of the component', 'ui:field': EntityNamePicker, 'ui:autofocus': true}, description: {title: Description, type: string, description: 'A description for the component'}, owner: {title: Owner, type: string, description: 'Owner of the component', 'ui:field': OwnerPicker, 'ui:options': {allowedKinds: [Group]}}}}, {title: 'Choose a location', required: [repoUrl], properties: {repoUrl: {title: 'Repository Location', type: string, 'ui:field': RepoUrlPicker, 'ui:options': {allowedHosts: [github.com]}}}}], steps: [{id: fetch, name: 'Template Docs Skeleton', action: 'fetch:template', input: {url: ./skeleton, values: {name: '${{ parameters.name }}', description: '${{ parameters.description }}', destination: '${{ parameters.repoUrl | parseRepoUrl }}', owner: '${{ parameters.owner }}'}}}, {id: publish, name: Publish, action: 'publish:github', input: {allowedHosts: [github.com], description: 'This is ${{ parameters.name }}', repoUrl: '${{ parameters.repoUrl }}'}}, {id: register, name: Register, action: 'catalog:register', input: {repoContentsUrl: '${{ steps.publish.output.repoContentsUrl }}', catalogInfoPath: /catalog-info.yaml}}], output: {links: [{title: Repository, url: '${{ steps.publish.output.remoteUrl }}'}, {title: 'Open in catalog', icon: catalog, entityRef: '${{ steps.register.output.entityRef }}'}]}}}";
+export const customManifests = [dummyManifest];
+
+export const customManifestContent = `
+apiVersion: scaffolder.backstage.io/v1beta3
+kind: Template
+metadata:
+  name: docs-template
+  title: Documentation Template
+  description: Create a new standalone documentation project
+  tags:
+    - recommended
+    - techdocs
+    - mkdocs
+     `;

--- a/libs/ui-lib-tests/cypress/integration/custom-manifests/1-create-cluster-with-custom-manifests.cy.ts
+++ b/libs/ui-lib-tests/cypress/integration/custom-manifests/1-create-cluster-with-custom-manifests.cy.ts
@@ -11,7 +11,7 @@ describe(`Assisted Installer Cluster Installation with Custom Manifests`, () => 
   });
 
   beforeEach(() => {
-    cy.loadAiAPIIntercepts(null, false);
+    cy.loadAiAPIIntercepts(null);
   });
 
   describe('Creating a new cluster', () => {
@@ -21,8 +21,8 @@ describe(`Assisted Installer Cluster Installation with Custom Manifests`, () => 
       clusterDetailsPage.inputClusterName();
       clusterDetailsPage.inputBaseDnsDomain();
       clusterDetailsPage.inputOpenshiftVersion();
-
       clusterDetailsPage.inputPullSecret();
+
       clusterDetailsPage.getCustomManifestCheckbox().should('be.visible').check();
       clusterDetailsPage.getCustomManifestCheckbox().should('be.checked');
       commonActions
@@ -31,6 +31,14 @@ describe(`Assisted Installer Cluster Installation with Custom Manifests`, () => 
       commonActions.getWizardStepNav('Custom manifests').should('exist');
       commonActions.waitForNext();
       commonActions.clickNextButton();
+
+      cy.wait('@create-manifest').then(({ request }) => {
+        expect(request.body).to.deep.equal({
+          folder: 'manifests',
+          file_name: 'manifest1.yaml',
+          content: '',
+        });
+      });
     });
   });
 });

--- a/libs/ui-lib-tests/cypress/integration/custom-manifests/3-removing-adding-custom-manifests.cy.ts
+++ b/libs/ui-lib-tests/cypress/integration/custom-manifests/3-removing-adding-custom-manifests.cy.ts
@@ -1,10 +1,11 @@
 import { commonActions } from '../../views/common';
 import { customManifestsPage } from '../../views/customManifestsPage';
+import * as utils from '../../support/utils';
 
 describe(`Assisted Installer Custom manifests step`, () => {
   before(() => {
     cy.loadAiAPIIntercepts({
-      activeSignal: 'READY_TO_INSTALL',
+      activeSignal: 'ONLY_DUMMY_CUSTOM_MANIFEST',
       activeScenario: 'AI_CREATE_CUSTOM_MANIFESTS',
     });
   });
@@ -14,26 +15,43 @@ describe(`Assisted Installer Custom manifests step`, () => {
     commonActions.visitClusterDetailsPage();
   });
 
-  describe('List of Custom Manifests', () => {
-    it('Can add more custom manifests', () => {
+  describe('Custom Manifests actions', () => {
+    it('Can add new custom manifests', () => {
+      // First make the incomplete dummy manifest valid
       customManifestsPage.getStartFromScratch().click();
       customManifestsPage.fileUpload(0).attachFile(`custom-manifests/files/manifest1.yaml`);
-      cy.loadAiAPIIntercepts(null, true);
       customManifestsPage.getLinkToAdd().should('be.enabled');
       customManifestsPage.getLinkToAdd().click();
+
+      // Now we can add a new manifest
       customManifestsPage.getFileName(1).type('manifest2.yaml');
       customManifestsPage.fileUpload(1).attachFile(`custom-manifests/files/manifest1.yaml`);
       customManifestsPage.getLinkToAdd().should('be.enabled');
+
+      cy.wait('@create-manifest').then(({ request }) => {
+        // Verify that the new manifest content is submitted correctly
+        expect(request.body).to.include({
+          folder: 'manifests',
+          file_name: 'manifest2.yaml',
+          content:
+            'YXBpVmVyc2lvbjogbWFjaGluZWNvbmZpZ3VyYXRpb24ub3BlbnNoaWZ0LmlvL3YxCmtpbmQ6IE1hY2hpbmVDb25maWcKbWV0YWRhdGE6CiAgbGFiZWxzOgogICAgbWFjaGluZWNvbmZpZ3VyYXRpb24ub3BlbnNoaWZ0LmlvL3JvbGU6IG1hc3RlcgogIG5hbWU6IDk5LW9wZW5zaGlmdC1tYWNoaW5lY29uZmlnLW1hc3Rlci1rYXJncwpzcGVjOgogIGtlcm5lbEFyZ3VtZW50czoKICAgIC0gbG9nbGV2ZWw9Nwo=',
+        });
+      });
     });
+
     it('Can delete custom manifest', () => {
-      cy.loadAiAPIIntercepts(null, true);
+      utils.setLastWizardSignal('CUSTOM_MANIFEST_ADDED');
       commonActions.startAtCustomManifestsStep();
+
       customManifestsPage.getLinkToAdd().should('be.enabled');
       customManifestsPage.getLinkToAdd().click();
       customManifestsPage.getFileName(1).type('manifest2.yaml');
       customManifestsPage.fileUpload(1).attachFile(`custom-manifests/files/manifest1.yaml`);
       customManifestsPage.getRemoveManifestButton(1).click();
       customManifestsPage.getRemoveConfirmationButton().click();
+      cy.wait('@delete-manifests').then(({ request }) => {
+        expect(request.url).to.contain('folder=manifests&file_name=manifest2.yaml');
+      });
     });
   });
 });

--- a/libs/ui-lib-tests/cypress/integration/custom-manifests/4-view-custom-manifests-review-and-create-page.cy.ts
+++ b/libs/ui-lib-tests/cypress/integration/custom-manifests/4-view-custom-manifests-review-and-create-page.cy.ts
@@ -11,7 +11,7 @@ describe(`Assisted Installer Review and create step with custom manifests`, () =
   });
 
   beforeEach(() => {
-    cy.loadAiAPIIntercepts(null, true);
+    cy.loadAiAPIIntercepts(null);
     commonActions.visitClusterDetailsPage();
   });
 

--- a/libs/ui-lib-tests/cypress/support/utils.ts
+++ b/libs/ui-lib-tests/cypress/support/utils.ts
@@ -26,7 +26,11 @@ const signalOrder = [
   'NETWORKING_DUAL_STACK_SELECT_SINGLE_STACK',
   'NETWORKING_DUAL_STACK_SELECT_DUAL_STACK',
 
-  // Last signal must always be Ready to install
+  // Custom manifests transitions
+  'ONLY_DUMMY_CUSTOM_MANIFEST_ADDED',
+  'CUSTOM_MANIFEST_ADDED',
+
+  // End of Day1 flow
   'READY_TO_INSTALL',
 ];
 

--- a/libs/ui-lib-tests/cypress/views/common.ts
+++ b/libs/ui-lib-tests/cypress/views/common.ts
@@ -25,8 +25,8 @@ export const commonActions = {
   getDNSErrorMessage: () => {
     return cy.get('#form-input-dns-field-helper-error');
   },
-  verifyIsAtStep: (stepTitle: string) => {
-    cy.get('h2').should('contain.text', stepTitle);
+  verifyIsAtStep: (stepTitle: string, timeout?: number) => {
+    cy.get('h2', { timeout }).should('contain.text', stepTitle);
   },
   startAtNetworkingStep: () => {
     if (utils.hasWizardSignal('READY_TO_INSTALL')) {
@@ -34,6 +34,7 @@ export const commonActions = {
     } else {
       commonActions.verifyIsAtStep('Host discovery');
       commonActions.clickNextButton();
+      commonActions.verifyIsAtStep('Storage', 1500);
       commonActions.clickNextButton();
     }
   },

--- a/libs/ui-lib/lib/ocm/components/clusterWizard/ClusterWizardContextProvider.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/ClusterWizardContextProvider.tsx
@@ -126,7 +126,9 @@ const ClusterWizardContextProvider = ({
       isSingleClusterFeatureEnabled,
     );
     // Only move step if there is still none, or the user is at a forbidden step
-    const shouldMoveStep = !currentStepId || isStepAfter(currentStepId, requiredStepId);
+    const shouldMoveStep =
+      !currentStepId ||
+      (customManifestsStepNeedsToBeFilled && isStepAfter(currentStepId, requiredStepId));
     if (shouldMoveStep) {
       setCurrentStepId(requiredStepId);
     }

--- a/libs/ui-lib/lib/ocm/components/clusterWizard/constants.ts
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/constants.ts
@@ -22,6 +22,19 @@ export const defaultWizardSteps: ClusterWizardStepsType[] = [
   'review',
 ];
 
+export const wizardStepsOrder: ClusterWizardStepsType[] = [
+  'cluster-details',
+  'static-ip-yaml-view',
+  'static-ip-network-wide-configurations',
+  'static-ip-host-configurations',
+  'operators',
+  'host-discovery',
+  'storage',
+  'networking',
+  'custom-manifests',
+  'review',
+];
+
 export const staticIpFormViewSubSteps: ClusterWizardStepsType[] = [
   'static-ip-network-wide-configurations',
   'static-ip-host-configurations',

--- a/libs/ui-lib/lib/ocm/components/clusterWizard/constants.ts
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/constants.ts
@@ -22,19 +22,6 @@ export const defaultWizardSteps: ClusterWizardStepsType[] = [
   'review',
 ];
 
-export const wizardStepsOrder: ClusterWizardStepsType[] = [
-  'cluster-details',
-  'static-ip-yaml-view',
-  'static-ip-network-wide-configurations',
-  'static-ip-host-configurations',
-  'operators',
-  'host-discovery',
-  'storage',
-  'networking',
-  'custom-manifests',
-  'review',
-];
-
 export const staticIpFormViewSubSteps: ClusterWizardStepsType[] = [
   'static-ip-network-wide-configurations',
   'static-ip-host-configurations',

--- a/libs/ui-lib/lib/ocm/components/clusterWizard/wizardTransition.ts
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/wizardTransition.ts
@@ -16,6 +16,7 @@ import {
   Validation as HostValidation,
 } from '../../../common/types/hosts';
 import { getKeys } from '../../../common/utils';
+import { wizardStepsOrder } from './constants';
 
 export type ClusterWizardStepsType =
   | 'cluster-details'
@@ -40,6 +41,16 @@ export const getLastStepForWizard = (
   } else {
     return 'review';
   }
+};
+
+export const isStepAfter = (stepA: ClusterWizardStepsType, stepB: ClusterWizardStepsType) => {
+  const indexA = wizardStepsOrder.findIndex((step) => step === stepA);
+  const indexB = wizardStepsOrder.findIndex((step) => step === stepB);
+  if (indexA === -1 || indexB === -1) {
+    return false; // Missing step in "wizardStepsOrder"
+  }
+
+  return indexA > indexB;
 };
 
 export const getClusterWizardFirstStep = (

--- a/libs/ui-lib/lib/ocm/components/clusterWizard/wizardTransition.ts
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/wizardTransition.ts
@@ -16,7 +16,6 @@ import {
   Validation as HostValidation,
 } from '../../../common/types/hosts';
 import { getKeys } from '../../../common/utils';
-import { wizardStepsOrder } from './constants';
 
 export type ClusterWizardStepsType =
   | 'cluster-details'
@@ -29,6 +28,19 @@ export type ClusterWizardStepsType =
   | 'networking'
   | 'review'
   | 'custom-manifests';
+
+const wizardStepsOrder: ClusterWizardStepsType[] = [
+  'cluster-details',
+  'static-ip-yaml-view',
+  'static-ip-network-wide-configurations',
+  'static-ip-host-configurations',
+  'operators',
+  'host-discovery',
+  'storage',
+  'networking',
+  'custom-manifests',
+  'review',
+];
 
 export const ClusterWizardFlowStateNew = 'new';
 export type ClusterWizardFlowStateType = Cluster['status'] | typeof ClusterWizardFlowStateNew;


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-15152

- While writing Integration tests for Day2, I noticed some intermitent test failures.
Sometimes, the test would click on the nav wizard and it would not move to the expected step. This is due to the effect that loads the custom manifests, and sometimes it would jump to the customManifests / review step even if the user had selected a previous step.

- I also noted that some requests were not correctly intercepted (eg. delete of a custom manifest includes the folder and filename, and the POST was not mocked.

- Finally, did some changes in the custom manifests tests to align them to use the "lastWizardSignal" as the other tests do.