### PR TITLE
MGMT-14805: Custom manifests are added when editing an existing cluster in Cluster Details Page

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/CustomManifestCheckbox.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/CustomManifestCheckbox.tsx
@@ -39,10 +39,8 @@ const CustomManifestCheckbox = ({ clusterId }: CustomManifestCheckboxProps) => {
     setDeleteCustomManifestsOpen(false);
     setManifestsRemoved(true);
     //if cluster exists remove existing cluster manifests
-    if (clusterId) {
-      if (customManifests) {
-        void ClustersService.removeClusterManifests(customManifests, clusterId);
-      }
+    if (clusterId && customManifests) {
+      void ClustersService.removeClusterManifests(customManifests, clusterId);
     }
   }, [clusterWizardContext, setValue, clusterId, customManifests]);
 

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/CustomManifestCheckbox.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/CustomManifestCheckbox.tsx
@@ -7,7 +7,6 @@ import { useClusterWizardContext } from '../clusterWizard/ClusterWizardContext';
 import DeleteCustomManifestModal from './manifestsConfiguration/DeleteCustomManifestModal';
 import useClusterCustomManifests from '../../hooks/useClusterCustomManifests';
 import { ClustersService } from '../../services';
-import { ListManifestsExtended } from './manifestsConfiguration/data/dataTypes';
 
 const Label = () => {
   return (
@@ -34,7 +33,6 @@ const CustomManifestCheckbox = ({ clusterId }: CustomManifestCheckboxProps) => {
   const { customManifests } = useClusterCustomManifests(clusterId, false);
   const [isDeleteCustomManifestsOpen, setDeleteCustomManifestsOpen] = React.useState(false);
   const [manifestsRemoved, setManifestsRemoved] = React.useState(false);
-  const [manifestsDummy, setManifestsDummy] = React.useState<ListManifestsExtended | undefined>();
   const cleanCustomManifests = React.useCallback(() => {
     setValue(false);
     clusterWizardContext.setAddCustomManifests(false);
@@ -43,17 +41,10 @@ const CustomManifestCheckbox = ({ clusterId }: CustomManifestCheckboxProps) => {
     //if cluster exists remove existing cluster manifests
     if (clusterId) {
       if (customManifests) {
-        void ClustersService.removeClusterManifests(customManifests, clusterId).then(() => {
-          setManifestsDummy(undefined);
-        });
-      }
-      if (manifestsDummy !== undefined) {
-        void ClustersService.removeClusterManifests(manifestsDummy, clusterId).then(() => {
-          setManifestsDummy(undefined);
-        });
+        void ClustersService.removeClusterManifests(customManifests, clusterId);
       }
     }
-  }, [clusterWizardContext, setValue, clusterId, customManifests, manifestsDummy]);
+  }, [clusterWizardContext, setValue, clusterId, customManifests]);
 
   const onChanged = React.useCallback(
     (checked: boolean) => {
@@ -80,9 +71,7 @@ const CustomManifestCheckbox = ({ clusterId }: CustomManifestCheckboxProps) => {
   }, [clusterWizardContext, setValue]);
 
   const customManifestsActivated =
-    clusterWizardContext.addCustomManifests ||
-    (customManifests && customManifests.length > 0) ||
-    manifestsDummy !== undefined;
+    clusterWizardContext.addCustomManifests || (customManifests && customManifests.length > 0);
   return (
     <>
       <FormGroup id={`form-control__${fieldId}`} isInline fieldId={fieldId}>

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/CustomManifestCheckbox.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/CustomManifestCheckbox.tsx
@@ -67,15 +67,6 @@ const CustomManifestCheckbox = ({ clusterId }: CustomManifestCheckboxProps) => {
         setValue(checked);
         setManifestsRemoved(false);
         clusterWizardContext.setAddCustomManifests(checked);
-        //if cluster exists create new custom manifests
-        if (clusterId) {
-          void ClustersService.createDummyManifest(clusterId).then((manifestCreated) => {
-            const manifestDummy = manifestCreated.data;
-            const manifestLists: ListManifestsExtended = [];
-            manifestLists.push(manifestDummy);
-            setManifestsDummy(manifestLists);
-          });
-        }
       }
     },
     [setValue, clusterWizardContext, setDeleteCustomManifestsOpen, cleanCustomManifests, clusterId],

--- a/libs/ui-lib/lib/ocm/components/clusterWizard/ClusterDetails.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/ClusterDetails.tsx
@@ -65,10 +65,8 @@ const ClusterDetails = ({ cluster, infraEnv }: ClusterDetailsProps) => {
   const handleCustomManifestsChange = React.useCallback(
     async (clusterId: string, addCustomManifests: boolean) => {
       const addCustomManifestsNew = customManifests ? customManifests.length === 0 : true;
-      if (addCustomManifests) {
-        if (addCustomManifestsNew && clusterId) {
-          await ClustersService.createDummyManifest(clusterId);
-        }
+      if (addCustomManifests && addCustomManifestsNew && clusterId) {
+        await ClustersService.createDummyManifest(clusterId);
       }
     },
     [customManifests],

--- a/libs/ui-lib/lib/ocm/components/clusterWizard/ClusterDetails.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/ClusterDetails.tsx
@@ -64,16 +64,11 @@ const ClusterDetails = ({ cluster, infraEnv }: ClusterDetailsProps) => {
 
   const handleCustomManifestsChange = React.useCallback(
     async (clusterId: string, addCustomManifests: boolean) => {
-      //If checkbox is selected, then we need to know if cluster is created or updated
-      const addCustomManifestsNew = customManifests
-        ? customManifests.length === 0
-        : addCustomManifests;
-      if (clusterId && addCustomManifestsNew) {
-        await ClustersService.createDummyManifest(clusterId);
-      }
-      //If checkbox is unselected, we need to remove custom manifests if exists
-      else if (!addCustomManifests && customManifests && customManifests.length > 0) {
-        await ClustersService.removeClusterManifests(customManifests, clusterId);
+      const addCustomManifestsNew = customManifests ? customManifests.length === 0 : true;
+      if (addCustomManifests) {
+        if (addCustomManifestsNew && clusterId) {
+          await ClustersService.createDummyManifest(clusterId);
+        }
       }
     },
     [customManifests],


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-14805

BEFORE:
If you have a cluster created and you go back to the cluster details page and click next, custom manifests are created even if the checkbox is not selected.

AFTER:

https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/9c0217b1-1372-48b4-8b52-5cef022b7c7f

