### PR TITLE
MGMT:15167: Change IBM zSystems string to IBM Z

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/CpuArchitectureDropdown.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/CpuArchitectureDropdown.tsx
@@ -35,7 +35,7 @@ export const architectureData: Record<SupportedCpuArchitecture, CpuArchitectureI
   [CpuArchitecture.s390x]: {
     description: 'Some features may not be available',
     featureSupportLevelId: 'S390X_ARCHITECTURE',
-    label: 'IBM zSystems (s390x)',
+    label: 'IBM Z (s390x)',
   },
 };
 


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-15167

Change string for IBM Z (s390) CPU architecture:

![image](https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/6cfc1b5c-889e-404f-9659-a8bd4a57787c)
