### PR TITLE
MGMT-14593: Update link to know if cluster supports multiarch

### DIFF
--- a/libs/ui-lib/lib/common/config/constants.ts
+++ b/libs/ui-lib/lib/common/config/constants.ts
@@ -370,9 +370,8 @@ export const CHANGE_ISO_PASSWORD_FILE_LINK =
 export const CUSTOM_MANIFESTS_HELP_LINK =
   'https://docs.openshift.com/container-platform/4.12/installing/install_config/installing-customizing.html';
 
-//TODO (mortegag): Change the link. Related to https://issues.redhat.com/browse/MGMT-13976
 export const HOW_TO_KNOW_IF_CLUSTER_SUPPORTS_MULTIPLE_CPU_ARCHS =
-  'https://57587--docspreview.netlify.app/openshift-enterprise/latest/post_installation_configuration/multi-architecture-configuration.html#multi-architecture-verifying-cluster-compatibility_multi-architecture-configuration';
+  'https://access.redhat.com/documentation/en-us/assisted_installer_for_openshift_container_platform/2022/html-single/assisted_installer_for_openshift_container_platform/index#checking-for-multiple-architectures_expanding-the-cluster';
 
 export const MCE_LINK =
   'https://docs.openshift.com/container-platform/4.13/architecture/mce-overview-ocp.html';


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-14593

Update the link of "follow these steps" in  'Add hosts' modal for day2 clusters:
![image](https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/7e3b741b-25dc-488e-8ff9-737194d10849)
