### PR TITLE
MGMT-14284: Show the assisted installer detail card expanded by default

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusterDetail/ClusterInstallationProgressCard.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterDetail/ClusterInstallationProgressCard.tsx
@@ -17,7 +17,7 @@ import ClusterDetailStatusVarieties, {
 } from './ClusterDetailStatusVarieties';
 
 const ClusterInstallationProgressCard: React.FC<{ cluster: Cluster }> = ({ cluster }) => {
-  const [isCardExpanded, setIsCardExpanded] = React.useState(cluster.status !== 'installed');
+  const [isCardExpanded, setIsCardExpanded] = React.useState(true);
   const clusterVarieties = useClusterStatusVarieties(cluster);
 
   return (


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-14284

Before changes assisted installer detail card was collapsed by default:
![image](https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/20853428-43cc-4d8f-b329-81294196aa23)


After changes assisted installer detail card will be expanded by default:
![image](https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/a8539f95-0887-46b3-98cd-f209e111216a)
