### PR TITLE
MGMT-15328: External partners remains selected after OCP < v4.14 is selected

### DIFF
--- a/libs/ui-lib-tests/cypress/fixtures/infra-envs/feature-support.ts
+++ b/libs/ui-lib-tests/cypress/fixtures/infra-envs/feature-support.ts
@@ -14,6 +14,7 @@ const featureSupportLevels = {
       USER_MANAGED_NETWORKING: 'supported',
       VIP_AUTO_ALLOC: 'dev-preview',
       VSPHERE_INTEGRATION: 'supported',
+      EXTERNAL_PLATFORM_OCI: 'unavailable',
     },
   },
   '4.9': {
@@ -31,6 +32,7 @@ const featureSupportLevels = {
       USER_MANAGED_NETWORKING: 'supported',
       VIP_AUTO_ALLOC: 'dev-preview',
       VSPHERE_INTEGRATION: 'supported',
+      EXTERNAL_PLATFORM_OCI: 'unavailable',
     },
   },
   '4.10': {
@@ -48,6 +50,7 @@ const featureSupportLevels = {
       USER_MANAGED_NETWORKING: 'supported',
       VIP_AUTO_ALLOC: 'dev-preview',
       VSPHERE_INTEGRATION: 'supported',
+      EXTERNAL_PLATFORM_OCI: 'unavailable',
     },
   },
   '4.11': {
@@ -65,6 +68,7 @@ const featureSupportLevels = {
       USER_MANAGED_NETWORKING: 'supported',
       VIP_AUTO_ALLOC: 'dev-preview',
       VSPHERE_INTEGRATION: 'supported',
+      EXTERNAL_PLATFORM_OCI: 'unavailable',
     },
   },
   '4.12': {
@@ -82,6 +86,7 @@ const featureSupportLevels = {
       USER_MANAGED_NETWORKING: 'supported',
       VIP_AUTO_ALLOC: 'dev-preview',
       VSPHERE_INTEGRATION: 'supported',
+      EXTERNAL_PLATFORM_OCI: 'unavailable',
     },
   },
   '4.13': {
@@ -99,6 +104,25 @@ const featureSupportLevels = {
       USER_MANAGED_NETWORKING: 'supported',
       VIP_AUTO_ALLOC: 'dev-preview',
       VSPHERE_INTEGRATION: 'supported',
+      EXTERNAL_PLATFORM_OCI: 'unavailable',
+    },
+  },
+  '4.14': {
+    features: {
+      CLUSTER_MANAGED_NETWORKING: 'supported',
+      CNV: 'supported',
+      CUSTOM_MANIFEST: 'supported',
+      DUAL_STACK_VIPS: 'supported',
+      LVM: 'supported',
+      MINIMAL_ISO: 'supported',
+      NUTANIX_INTEGRATION: 'supported',
+      ODF: 'supported',
+      SINGLE_NODE_EXPANSION: 'supported',
+      SNO: 'supported',
+      USER_MANAGED_NETWORKING: 'supported',
+      VIP_AUTO_ALLOC: 'dev-preview',
+      VSPHERE_INTEGRATION: 'supported',
+      EXTERNAL_PLATFORM_OCI: 'supported',
     },
   },
 };

--- a/libs/ui-lib-tests/cypress/fixtures/infra-envs/openshift-versions.ts
+++ b/libs/ui-lib-tests/cypress/fixtures/infra-envs/openshift-versions.ts
@@ -45,6 +45,11 @@ const versions: Record<string, Version> = {
     display_name: '4.13.0-rc.6',
     support_level: 'beta',
   },
+  '4.14': {
+    cpu_architectures: [x86, arm64],
+    display_name: '4.14.0-ec.3',
+    support_level: 'beta',
+  },
 };
 
 expect(

--- a/libs/ui-lib-tests/cypress/integration/use-cases/create-cluster/with-external-partner-integrations.cy.ts
+++ b/libs/ui-lib-tests/cypress/integration/use-cases/create-cluster/with-external-partner-integrations.cy.ts
@@ -1,3 +1,4 @@
+import { clusterDetailsPage } from '../../../views/clusterDetails';
 import ClusterDetailsForm from '../../../views/forms/ClusterDetailsForm';
 import NewClusterPage from '../../../views/pages/NewClusterPage';
 
@@ -40,6 +41,12 @@ describe('Create a new cluster with external partner integrations', () => {
     it('Selecting external partner integrations checkbox enables custom manifests as well', () => {
       ClusterDetailsForm.externalPartnerIntegrationsControl.findLabel().click();
       ClusterDetailsForm.customManifestsControl.findCheckbox().should('be.checked');
+    });
+
+    it('External partner integrations checkbox is unselected after OCP < v4.14 is selected', () => {
+      ClusterDetailsForm.externalPartnerIntegrationsControl.findLabel().click();
+      clusterDetailsPage.inputOpenshiftVersion('4.13');
+      ClusterDetailsForm.externalPartnerIntegrationsControl.findCheckbox().should('not.be.checked');
     });
 
     xit('The minimal ISO is presented by default', () => {

--- a/libs/ui-lib-tests/cypress/integration/use-cases/create-cluster/with-external-partner-integrations.cy.ts
+++ b/libs/ui-lib-tests/cypress/integration/use-cases/create-cluster/with-external-partner-integrations.cy.ts
@@ -39,11 +39,13 @@ describe('Create a new cluster with external partner integrations', () => {
     });
 
     it('Selecting external partner integrations checkbox enables custom manifests as well', () => {
+      clusterDetailsPage.inputOpenshiftVersion('4.14');
       ClusterDetailsForm.externalPartnerIntegrationsControl.findLabel().click();
       ClusterDetailsForm.customManifestsControl.findCheckbox().should('be.checked');
     });
 
     it('External partner integrations checkbox is unselected after OCP < v4.14 is selected', () => {
+      clusterDetailsPage.inputOpenshiftVersion('4.14');
       ClusterDetailsForm.externalPartnerIntegrationsControl.findLabel().click();
       clusterDetailsPage.inputOpenshiftVersion('4.13');
       ClusterDetailsForm.externalPartnerIntegrationsControl.findCheckbox().should('not.be.checked');

--- a/libs/ui-lib-tests/cypress/views/forms/ClusterDetailsForm.ts
+++ b/libs/ui-lib-tests/cypress/views/forms/ClusterDetailsForm.ts
@@ -75,6 +75,12 @@ class ExternalPartnerIntegrationsControl {
       /integrate with other platforms using custom manifests\./i,
     );
   }
+
+  static findCheckbox() {
+    return ExternalPartnerIntegrationsControl.body.findByRole('checkbox', {
+      name: /external partner integrations/i,
+    });
+  }
 }
 
 /** @private */

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/OcmClusterDetailsFormFields.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/OcmClusterDetailsFormFields.tsx
@@ -114,6 +114,12 @@ export const OcmClusterDetailsFormFields = ({
     nameInputRef.current?.focus();
   }, []);
 
+  React.useEffect(() => {
+    if (!externalPartnerIntegrationsCheckboxState?.isSupported) {
+      setFieldValue('externalPartnerIntegrations', false);
+    }
+  }, [externalPartnerIntegrationsCheckboxState?.isSupported, setFieldValue]);
+
   const handleExternalPartnerIntegrationsChange = React.useCallback<
     NonNullable<OcmCheckboxFieldProps['onChange']>
   >(


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-15328

- Before the change:

https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/d03daeb5-60dd-425f-ae08-1846fdd3d422

- After the change:

https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/6107d5eb-fc73-4ed6-8b67-673330d1b839

