### PR TITLE
MGMT-15016:  Block static ip if oci is selected

### DIFF
--- a/libs/ui-lib-tests/cypress/integration/use-cases/create-cluster/with-external-partner-integrations.cy.ts
+++ b/libs/ui-lib-tests/cypress/integration/use-cases/create-cluster/with-external-partner-integrations.cy.ts
@@ -41,7 +41,10 @@ describe('Create a new cluster with external partner integrations', () => {
     it('Selecting external partner integrations checkbox enables custom manifests as well', () => {
       clusterDetailsPage.inputOpenshiftVersion('4.14');
       ClusterDetailsForm.externalPartnerIntegrationsControl.findLabel().click();
-      ClusterDetailsForm.customManifestsControl.findCheckbox().should('be.checked');
+      ClusterDetailsForm.customManifestsControl
+        .findCheckbox()
+        .should('be.checked')
+        .and('be.disabled');
     });
 
     it('External partner integrations checkbox is unselected after OCP < v4.14 is selected', () => {

--- a/libs/ui-lib-tests/cypress/integration/use-cases/create-cluster/with-external-partner-integrations.cy.ts
+++ b/libs/ui-lib-tests/cypress/integration/use-cases/create-cluster/with-external-partner-integrations.cy.ts
@@ -52,6 +52,7 @@ describe('Create a new cluster with external partner integrations', () => {
     });
 
     it("Hosts' Network Configuration control is disabled when external partner integration is selected", () => {
+      clusterDetailsPage.getStaticIpNetworkConfig().click();
       clusterDetailsPage.inputOpenshiftVersion('4.14');
       ClusterDetailsForm.externalPartnerIntegrationsControl.findLabel().click();
       clusterDetailsPage.getStaticIpNetworkConfig().should('be.disabled').and('not.be.checked');

--- a/libs/ui-lib-tests/cypress/integration/use-cases/create-cluster/with-external-partner-integrations.cy.ts
+++ b/libs/ui-lib-tests/cypress/integration/use-cases/create-cluster/with-external-partner-integrations.cy.ts
@@ -51,6 +51,12 @@ describe('Create a new cluster with external partner integrations', () => {
       ClusterDetailsForm.externalPartnerIntegrationsControl.findCheckbox().should('not.be.checked');
     });
 
+    it("Hosts' Network Configuration control is disabled when external partner integration is selected", () => {
+      clusterDetailsPage.inputOpenshiftVersion('4.14');
+      ClusterDetailsForm.externalPartnerIntegrationsControl.findLabel().click();
+      clusterDetailsPage.getStaticIpNetworkConfig().should('be.disabled').and('not.be.checked');
+    });
+
     xit('The minimal ISO is presented by default', () => {
       // TODO(jkilzi): WIP...
       // ClusterDetailsForm.clusterNameControl

--- a/libs/ui-lib/lib/common/components/clusterWizard/clusterDetailsValidation.ts
+++ b/libs/ui-lib/lib/common/components/clusterWizard/clusterDetailsValidation.ts
@@ -75,6 +75,7 @@ export const getClusterDetailsInitialValues = ({
     diskEncryptionTangServers: parseTangServers(cluster?.diskEncryption?.tangServers),
     diskEncryption: cluster?.diskEncryption ?? {},
     cpuArchitecture: cluster?.cpuArchitecture || getDefaultCpuArchitecture(),
+    externalPartnerIntegrations: cluster?.platform?.type === 'oci',
   };
 };
 

--- a/libs/ui-lib/lib/common/components/clusterWizard/types.ts
+++ b/libs/ui-lib/lib/common/components/clusterWizard/types.ts
@@ -25,6 +25,7 @@ export type ClusterDetailsValues = {
   diskEncryptionTangServers: TangServer[];
   diskEncryption: DiskEncryption;
   cpuArchitecture: string;
+  externalPartnerIntegrations: boolean;
 };
 
 export type HostsValidationsProps<S extends string, V extends string[]> = {

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/CustomManifestCheckbox.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/CustomManifestCheckbox.tsx
@@ -24,9 +24,9 @@ const Label = () => {
   );
 };
 
-type CustomManifestCheckboxProps = { clusterId: string };
+type CustomManifestCheckboxProps = { clusterId: string; isDisabled: boolean };
 
-const CustomManifestCheckbox = ({ clusterId }: CustomManifestCheckboxProps) => {
+const CustomManifestCheckbox = ({ clusterId, isDisabled }: CustomManifestCheckboxProps) => {
   const [{ name }, , { setValue }] = useField('addCustomManifest');
   const fieldId = getFieldId(name, 'input');
   const clusterWizardContext = useClusterWizardContext();
@@ -87,6 +87,7 @@ const CustomManifestCheckbox = ({ clusterId }: CustomManifestCheckboxProps) => {
           onChange={(checked: boolean) => onChanged(checked)}
           className="with-tooltip"
           isChecked={manifestsRemoved ? false : customManifestsActivated}
+          isDisabled={isDisabled}
         />
         <DeleteCustomManifestModal
           isOpen={isDeleteCustomManifestsOpen}

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/HostsNetworkConfigurationControlGroup.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/HostsNetworkConfigurationControlGroup.tsx
@@ -5,22 +5,27 @@ import { HostsNetworkConfigurationType } from '../../services/types';
 import { useField } from 'formik';
 import { useClusterWizardContext } from '../clusterWizard/ClusterWizardContext';
 import RadioFieldWithTooltip from '../../../common/components/ui/formik/RadioFieldWithTooltip';
-import { clusterExistsReason } from '../featureSupportLevels/featureStateUtils';
+import {
+  clusterExistsReason,
+  hostsNetworkConfigurationDisabledReason,
+} from '../featureSupportLevels/featureStateUtils';
 
 export interface HostsNetworkConfigurationControlGroupProps {
   clusterExists: boolean;
+  isDisabled: boolean;
 }
 
 export const HostsNetworkConfigurationControlGroup = ({
   clusterExists,
+  isDisabled = false,
 }: HostsNetworkConfigurationControlGroupProps) => {
   const GROUP_NAME = 'hostsNetworkConfigurationType';
   const clusterWizardContext = useClusterWizardContext();
   const [{ value }] = useField<HostsNetworkConfigurationType>(GROUP_NAME);
   const fieldId = getFieldId(GROUP_NAME, 'radio');
   const tooltipProps: TooltipProps = {
-    hidden: !clusterExists,
-    content: clusterExistsReason,
+    hidden: !clusterExists && !isDisabled,
+    content: !isDisabled ? clusterExistsReason : hostsNetworkConfigurationDisabledReason,
     position: 'top',
   };
 
@@ -41,14 +46,14 @@ export const HostsNetworkConfigurationControlGroup = ({
     >
       <RadioFieldWithTooltip
         name={GROUP_NAME}
-        isDisabled={clusterExists}
+        isDisabled={clusterExists || isDisabled}
         value={HostsNetworkConfigurationType.DHCP}
         label="DHCP only"
         tooltipProps={tooltipProps}
       />
       <RadioFieldWithTooltip
         name={GROUP_NAME}
-        isDisabled={clusterExists}
+        isDisabled={clusterExists || isDisabled}
         value={HostsNetworkConfigurationType.STATIC}
         label="Static IP, bridges, and bonds"
         tooltipProps={tooltipProps}

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/OcmClusterDetailsFormFields.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/OcmClusterDetailsFormFields.tsx
@@ -40,6 +40,7 @@ import {
   ExternalPartnerIntegrationsCheckbox,
   useExternalPartnerIntegrationsCheckboxState,
 } from './ExternalPartnerIntegrationsCheckbox';
+import { HostsNetworkConfigurationType } from '../../services';
 
 export type OcmClusterDetailsFormFieldsProps = {
   forceOpenshiftVersion?: string;
@@ -124,7 +125,7 @@ export const OcmClusterDetailsFormFields = ({
       const checked = Boolean(value);
       setFieldValue('addCustomManifest', checked, false);
       clusterWizardContext.setAddCustomManifests(checked);
-      setFieldValue('hostsNetworkConfigurationType', 'dhcp');
+      setFieldValue('hostsNetworkConfigurationType', HostsNetworkConfigurationType.DHCP);
     },
     [clusterWizardContext, setFieldValue],
   );

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/OcmClusterDetailsFormFields.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/OcmClusterDetailsFormFields.tsx
@@ -14,7 +14,6 @@ import {
   CLUSTER_NAME_MAX_LENGTH,
   StaticTextField,
   useFeature,
-  ClusterCreateParams,
   getSupportedCpuArchitectures,
 } from '../../../common';
 import DiskEncryptionControlGroup from '../../../common/components/clusterConfiguration/DiskEncryptionFields/DiskEncryptionControlGroup';
@@ -87,9 +86,7 @@ export const OcmClusterDetailsFormFields = ({
   const isSingleClusterFeatureEnabled = useFeature('ASSISTED_INSTALLER_SINGLE_CLUSTER_FEATURE');
   const isMultiArchSupported = useFeature('ASSISTED_INSTALLER_MULTIARCH_SUPPORTED');
   const isOracleCloudPlatformIntegrationEnabled = useFeature('ASSISTED_INSTALLER_PLATFORM_OCI');
-  const {
-    values: { openshiftVersion },
-  } = useFormikContext<ClusterCreateParams>();
+  const { openshiftVersion, externalPartnerIntegrations } = values;
   const { getCpuArchitectures } = useOpenshiftVersions();
   const cpuArchitecturesByVersionImage = getCpuArchitectures(openshiftVersion);
   const clusterWizardContext = useClusterWizardContext();
@@ -109,8 +106,6 @@ export const OcmClusterDetailsFormFields = ({
     clusterExists,
     featureSupportLevelData,
   );
-  const [isDisabledHostsNetworkConfiguration, setIsDisabledHostsNetworkConfiguration] =
-    React.useState<boolean>(false);
 
   React.useEffect(() => {
     nameInputRef.current?.focus();
@@ -129,7 +124,7 @@ export const OcmClusterDetailsFormFields = ({
       const checked = Boolean(value);
       setFieldValue('addCustomManifest', checked, false);
       clusterWizardContext.setAddCustomManifests(checked);
-      setIsDisabledHostsNetworkConfiguration(checked);
+      setFieldValue('hostsNetworkConfigurationType', 'dhcp');
     },
     [clusterWizardContext, setFieldValue],
   );
@@ -230,7 +225,7 @@ export const OcmClusterDetailsFormFields = ({
         !isSingleClusterFeatureEnabled && (
           <HostsNetworkConfigurationControlGroup
             clusterExists={clusterExists}
-            isDisabled={isDisabledHostsNetworkConfiguration}
+            isDisabled={externalPartnerIntegrations}
           />
         )
       }

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/OcmClusterDetailsFormFields.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/OcmClusterDetailsFormFields.tsx
@@ -109,6 +109,8 @@ export const OcmClusterDetailsFormFields = ({
     clusterExists,
     featureSupportLevelData,
   );
+  const [isDisabledHostsNetworkConfiguration, setIsDisabledHostsNetworkConfiguration] =
+    React.useState<boolean>(false);
 
   React.useEffect(() => {
     nameInputRef.current?.focus();
@@ -127,6 +129,7 @@ export const OcmClusterDetailsFormFields = ({
       const checked = Boolean(value);
       setFieldValue('addCustomManifest', checked, false);
       clusterWizardContext.setAddCustomManifests(checked);
+      setIsDisabledHostsNetworkConfiguration(checked);
     },
     [clusterWizardContext, setFieldValue],
   );
@@ -225,7 +228,10 @@ export const OcmClusterDetailsFormFields = ({
       {
         // Reason: In the single-cluster flow, the Host discovery phase is replaced by a single one-fits-all ISO download
         !isSingleClusterFeatureEnabled && (
-          <HostsNetworkConfigurationControlGroup clusterExists={clusterExists} />
+          <HostsNetworkConfigurationControlGroup
+            clusterExists={clusterExists}
+            isDisabled={isDisabledHostsNetworkConfiguration}
+          />
         )
       }
 

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/OcmClusterDetailsFormFields.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/OcmClusterDetailsFormFields.tsx
@@ -218,7 +218,10 @@ export const OcmClusterDetailsFormFields = ({
         />
       )}
 
-      <CustomManifestCheckbox clusterId={clusterId || ''} />
+      <CustomManifestCheckbox
+        clusterId={clusterId || ''}
+        isDisabled={externalPartnerIntegrations}
+      />
 
       {
         // Reason: In the single-cluster flow, the Host discovery phase is replaced by a single one-fits-all ISO download

--- a/libs/ui-lib/lib/ocm/components/featureSupportLevels/featureStateUtils.ts
+++ b/libs/ui-lib/lib/ocm/components/featureSupportLevels/featureStateUtils.ts
@@ -182,3 +182,6 @@ export const getNewFeatureDisabledReason = (
 export const isFeatureSupportedAndAvailable = (supportLevel: SupportLevel | undefined): boolean => {
   return supportLevel !== 'unsupported' && supportLevel !== 'unavailable';
 };
+
+export const hostsNetworkConfigurationDisabledReason =
+  "DHCP only is the supported hosts' network configuration when external partner integrations is selected";


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-15016

When user select OCI option, the hosts's network configuration should be disabled and we show a tooltip explaining what happens:

![image](https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/9bf63b52-3de5-413c-a923-17901ce7671f)
