### PR TITLE
MGMT-13808: Remove unnecessary cluster validations alert

### DIFF
--- a/libs/locales/lib/en/translation.json
+++ b/libs/locales/lib/en/translation.json
@@ -568,7 +568,6 @@
   "ai:Pending input": "Pending input",
   "ai:Pending validations:": "Pending validations:",
   "ai:Platform network settings": "Platform network settings",
-  "ai:Please hold on till background checks are started.": "Wait until the background checks are started.",
   "ai:Please note that this version is not production-ready.": "Note that this version is not production-ready.",
   "ai:Please refer to the <2>OpenShift networking documentation</2> to configure your cluster's networking, including:": "Refer to the <2>OpenShift networking documentation</2> to configure your cluster's networking, including:",
   "ai:Please select a subnet. ({{hostSubnetLength}} available)": "Select a subnet. ({{hostSubnetLength}} available)",

--- a/libs/ui-lib/lib/common/components/clusterWizard/ClusterWizardStepValidationsAlert.tsx
+++ b/libs/ui-lib/lib/common/components/clusterWizard/ClusterWizardStepValidationsAlert.tsx
@@ -75,11 +75,6 @@ const ClusterWizardStepValidationsAlert = <ClusterWizardStepsType extends string
 
   return (
     <>
-      {!validationsInfo && (
-        <Alert variant={AlertVariant.info} title="Cluster validations are initializing." isInline>
-          {t('ai:Please hold on till background checks are started.')}
-        </Alert>
-      )}
       {!isClusterReady && (
         <AlertGroup>
           {children}


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-13808

The blue alert will not be shown anymore.

![image](https://github.com/openshift-assisted/assisted-installer-ui/assets/87187179/a2b893d5-40d8-41a2-a3de-df439895108a)
