### PR TITLE
MGMT-15262: Remove deprecated warning in OCM tests

### DIFF
--- a/libs/ui-lib/lib/ocm/store/slices/infraEnvs/slice.ts
+++ b/libs/ui-lib/lib/ocm/store/slices/infraEnvs/slice.ts
@@ -7,7 +7,6 @@ const infraEnvsSlice = createSlice({
   name: 'infraEnvs',
   initialState: [] as InfraEnv[],
   reducers: {},
-  extraReducers: {},
 });
 
 export const infraEnvsActions = infraEnvsSlice.actions;


### PR DESCRIPTION
The warning 
```
The object notation for `createSlice.extraReducers` is deprecated, and will be removed in RTK 2.0. Please use the 'builder callback' notation instead: https://redux-toolkit.js.org/api/createSlice
```
appears in all OCM tests that import something from Assisted UI.

Since the only place where this is used, it actually doesn't add any reducer, and it's an optional parameter, it's a very simple fix.