### PR TITLE
MGMT-15367: Custom manifests names should be unique

### DIFF
--- a/libs/ui-lib-tests/cypress/integration/custom-manifests/3-removing-adding-custom-manifests.cy.ts
+++ b/libs/ui-lib-tests/cypress/integration/custom-manifests/3-removing-adding-custom-manifests.cy.ts
@@ -41,6 +41,25 @@ describe(`Assisted Installer Custom manifests step`, () => {
       });
     });
 
+    it('Validate that custom manifests names are unique', () => {
+      customManifestsPage.getStartFromScratch().click();
+      customManifestsPage.fileUpload(0).attachFile(`custom-manifests/files/manifest1.yaml`);
+      customManifestsPage.getLinkToAdd().should('be.enabled');
+      customManifestsPage.getLinkToAdd().click();
+      // Now we can add a new manifest
+      customManifestsPage.getFileName(1).type('manifest1.yaml');
+      customManifestsPage.fileUpload(1).attachFile(`custom-manifests/files/manifest1.yaml`);
+      customManifestsPage
+        .getFileNameError()
+        .should('contain.text', 'Ensure unique file names to avoid conflicts and errors.');
+      customManifestsPage
+        .getAlertTitle()
+        .should(
+          'contain.text',
+          'Custom manifests configuration contains missing or invalid fields',
+        );
+    });
+
     it('Can delete custom manifest', () => {
       utils.setLastWizardSignal('CUSTOM_MANIFEST_ADDED');
       commonActions.startAtWizardStep('Custom manifests');

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/manifestsConfiguration/components/customManifestsValidationSchema.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/manifestsConfiguration/components/customManifestsValidationSchema.tsx
@@ -37,7 +37,7 @@ export const getUniqueValidationSchema = <FormValues,>(
 };
 
 const getAllManifests: UniqueStringArrayExtractor<ManifestFormData> = (values: ManifestFormData) =>
-  values.manifests.map((manifest) => `${manifest.filename}`);
+  values.manifests.map((manifest) => manifest.filename);
 
 export const getFormViewManifestsValidationSchema = Yup.object<ManifestFormData>().shape({
   manifests: Yup.array<CustomManifestValues>().of(

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/manifestsConfiguration/components/customManifestsValidationSchema.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/manifestsConfiguration/components/customManifestsValidationSchema.tsx
@@ -10,8 +10,7 @@ import {
 } from '../../../../../common/utils';
 const INCORRECT_FILENAME = 'Must have a yaml, yml or json extension and can not contain /.';
 
-const UNIQUE_FOLDER_FILENAME =
-  'Ensure unique file names within each folder to avoid conflicts and errors.';
+const UNIQUE_FOLDER_FILENAME = 'Ensure unique file names to avoid conflicts and errors.';
 
 export const getUniqueValidationSchema = <FormValues,>(
   uniqueStringArrayExtractor: UniqueStringArrayExtractor<FormValues>,
@@ -38,7 +37,7 @@ export const getUniqueValidationSchema = <FormValues,>(
 };
 
 const getAllManifests: UniqueStringArrayExtractor<ManifestFormData> = (values: ManifestFormData) =>
-  values.manifests.map((manifest) => `${manifest.folder}_${manifest.filename}`);
+  values.manifests.map((manifest) => `${manifest.filename}`);
 
 export const getFormViewManifestsValidationSchema = Yup.object<ManifestFormData>().shape({
   manifests: Yup.array<CustomManifestValues>().of(


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-15367

Custom manifest files should be unique as openshift folder files are merged to manifests.

Before changes you can have same file name in different folders for custom manifests:
![Captura desde 2023-07-26 08-06-19](https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/962ccb9c-fd35-4a2d-8700-4b6b2942d950)

After changes you custom manifests file names should be unique regardless folder:
![Captura desde 2023-07-26 08-08-09](https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/a4b17c52-aa2e-4d8b-8bef-3929236c9b37)
