### PR TITLE
MGMT-15376: Browser gets stuck after selecting OCP version 4.9

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/CpuArchitectureDropdown.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/CpuArchitectureDropdown.tsx
@@ -109,21 +109,14 @@ const CpuArchitectureDropdown = ({
       !isSelectedCpuArchitectureSupported &&
       selectedCpuArchitecture !== getDefaultCpuArchitecture()
     ) {
-      setValue(getDefaultCpuArchitecture());
       setCurrentCpuArch(architectureData[getDefaultCpuArchitecture()].label);
       setOpen(false);
     }
     if (prevVersionRef.current !== openshiftVersion) {
       prevVersionRef.current = openshiftVersion;
     }
-  }, [
-    openshiftVersion,
-    setValue,
-    setOpen,
-    cpuArchitectures,
-    setCurrentCpuArch,
-    selectedCpuArchitecture,
-  ]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [openshiftVersion, selectedCpuArchitecture]);
 
   const toggle = React.useMemo(
     () => (


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-15376

Before changes browser gets stuck:

https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/d0cf5b16-3735-4413-93ce-b1fc9cb4bd68

After changes:

https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/12c08979-b1ad-48b8-80aa-fe9d8152761f

