### PR TITLE
MGMT-14741: host status went from Starting installation directly to Installed with no steps in the middle

### DIFF
--- a/libs/ui-lib/lib/ocm/components/HostsClusterDetailTab/HostsClusterDetailTabContent.tsx
+++ b/libs/ui-lib/lib/ocm/components/HostsClusterDetailTab/HostsClusterDetailTabContent.tsx
@@ -153,10 +153,10 @@ export const HostsClusterDetailTabContent = ({
   }, [day2Cluster?.id, handleClickTryAgainLink, ocmCluster, setDay2Cluster]);
 
   React.useEffect(() => {
-    const id = setTimeout(() => {
+    const id = setInterval(() => {
       void refreshCluster();
     }, POLLING_INTERVAL);
-    return () => clearTimeout(id);
+    return () => clearInterval(id);
   }, [refreshCluster]);
 
   if (error) {


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-14741

Let's try actually polling for the Day2 cluster, not just fetching it once 10 seconds after the UI refreshes.