### PR TITLE
MGMT-14774: Add hosts cluster events - no events related to previous added hosts

### DIFF
--- a/libs/ui-lib/lib/common/components/ui/ClusterEventsToolbar.tsx
+++ b/libs/ui-lib/lib/common/components/ui/ClusterEventsToolbar.tsx
@@ -231,7 +231,6 @@ const ClusterEventsToolbar = ({
               customBadgeText={hostChips.length}
               isOpen={isHostExpanded}
               placeholderText={<Placeholder text="Hosts" />}
-              isDisabled={allHosts.length === 0}
               maxHeight={280}
               zIndex={600}
             >


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-14774

The issue with different sessions showing different clusters should be resolved by https://github.com/openshift-assisted/assisted-installer-ui/pull/2292.

However, I noticed that if there are no active (non-deleted) hosts in the cluster, the hosts dropdown in the cluster events modal is disabled and the users cannot filter cluster-level and deleted-hosts events. I think we should keep the dropdown enabled at all times.