### PR TITLE
MGMT-15075: Day2 - Do not request custom manifests

### DIFF
--- a/libs/ui-lib/lib/ocm/components/HostsClusterDetailTab/HostsClusterDetailTabContent.tsx
+++ b/libs/ui-lib/lib/ocm/components/HostsClusterDetailTab/HostsClusterDetailTabContent.tsx
@@ -15,7 +15,6 @@ import { isApiError } from '../../../common/api/utils';
 import { AddHosts } from '../AddHosts';
 import { HostsClusterDetailTabProps } from './types';
 import { NewFeatureSupportLevelProvider } from '../featureSupportLevels';
-import { ClusterWizardContextProvider } from '../clusterWizard';
 import {
   AddHostsApiError,
   ReloadFailedError,
@@ -174,22 +173,20 @@ export const HostsClusterDetailTabContent = ({
   }
 
   return (
-    <ClusterWizardContextProvider cluster={day2Cluster} infraEnv={infraEnv}>
-      <AddHostsContextProvider
+    <AddHostsContextProvider
+      cluster={day2Cluster}
+      resetCluster={refreshCluster}
+      ocpConsoleUrl={ocmCluster?.console?.url}
+      canEdit={ocmCluster.canEdit}
+    >
+      <NewFeatureSupportLevelProvider
+        loadingUi={<LoadingState />}
         cluster={day2Cluster}
-        resetCluster={refreshCluster}
-        ocpConsoleUrl={ocmCluster?.console?.url}
-        canEdit={ocmCluster.canEdit}
+        cpuArchitecture={infraEnv?.cpuArchitecture}
+        openshiftVersion={day2Cluster.openshiftVersion}
       >
-        <NewFeatureSupportLevelProvider
-          loadingUi={<LoadingState />}
-          cluster={day2Cluster}
-          cpuArchitecture={infraEnv?.cpuArchitecture}
-          openshiftVersion={day2Cluster.openshiftVersion}
-        >
-          <AddHosts />
-        </NewFeatureSupportLevelProvider>
-      </AddHostsContextProvider>
-    </ClusterWizardContextProvider>
+        <AddHosts />
+      </NewFeatureSupportLevelProvider>
+    </AddHostsContextProvider>
   );
 };

--- a/libs/ui-lib/lib/ocm/components/clusterDetail/AssistedInstallerDetailCard.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterDetail/AssistedInstallerDetailCard.tsx
@@ -119,14 +119,12 @@ const AssistedInstallerDetailCard = ({
 
   const showWizard = ['insufficient', 'ready', 'pending-for-input'].includes(cluster.status);
 
-  const content = (
+  const content = showWizard ? (
     <ClusterWizardContextProvider cluster={cluster} infraEnv={infraEnv} permissions={permissions}>
-      {showWizard ? (
-        <ClusterWizard cluster={cluster} infraEnv={infraEnv} updateInfraEnv={updateInfraEnv} />
-      ) : (
-        <ClusterInstallationProgressCard cluster={cluster} />
-      )}
+      <ClusterWizard cluster={cluster} infraEnv={infraEnv} updateInfraEnv={updateInfraEnv} />
     </ClusterWizardContextProvider>
+  ) : (
+    <ClusterInstallationProgressCard cluster={cluster} />
   );
 
   const isOutdatedClusterData = uiState === ResourceUIState.POLLING_ERROR;

--- a/libs/ui-lib/lib/ocm/components/clusterWizard/ClusterWizardContext.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/ClusterWizardContext.tsx
@@ -17,7 +17,7 @@ export type ClusterWizardContextType = {
   setWizardPerPage: (perPage: number) => void;
 };
 
-const ClusterWizardContext = React.createContext<ClusterWizardContextType | null>(null);
+export const ClusterWizardContext = React.createContext<ClusterWizardContextType | null>(null);
 
 export const useClusterWizardContext = () => {
   const context = React.useContext(ClusterWizardContext);
@@ -26,5 +26,3 @@ export const useClusterWizardContext = () => {
   }
   return context;
 };
-
-export default ClusterWizardContext;

--- a/libs/ui-lib/lib/ocm/components/clusterWizard/ClusterWizardContextProvider.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/ClusterWizardContextProvider.tsx
@@ -1,6 +1,6 @@
 import React, { PropsWithChildren } from 'react';
 import { useLocation } from 'react-router-dom';
-import ClusterWizardContext, { ClusterWizardContextType } from './ClusterWizardContext';
+import { ClusterWizardContextType, ClusterWizardContext } from './ClusterWizardContext';
 import {
   ClusterWizardFlowStateType,
   ClusterWizardStepsType,

--- a/libs/ui-lib/lib/ocm/components/hosts/ClusterHostsTable.tsx
+++ b/libs/ui-lib/lib/ocm/components/hosts/ClusterHostsTable.tsx
@@ -23,7 +23,7 @@ import {
   useHostsTableDetailContext,
 } from '../../../common/components/hosts/HostsTableDetailContext';
 import { TableVariant } from '@patternfly/react-table';
-import { useClusterWizardContext } from '../clusterWizard/ClusterWizardContext';
+import { ClusterWizardContext } from '../clusterWizard/ClusterWizardContext';
 import { Cluster, Host } from '@openshift-assisted/types/assisted-installer-service';
 
 export function ExpandComponent({ obj: host }: ExpandComponentProps<Host>) {
@@ -46,7 +46,7 @@ export interface ClusterHostsTableProps {
 }
 
 const ClusterHostsTable = ({ cluster, skipDisabled }: ClusterHostsTableProps) => {
-  const { wizardPerPage, setWizardPerPage } = useClusterWizardContext();
+  const { wizardPerPage, setWizardPerPage } = React.useContext(ClusterWizardContext) || {};
   const {
     onEditHost,
     onEditRole,

--- a/libs/ui-lib/lib/ocm/components/hosts/use-hosts-table.tsx
+++ b/libs/ui-lib/lib/ocm/components/hosts/use-hosts-table.tsx
@@ -49,7 +49,7 @@ import { usePagination } from '../../../common/components/hosts/usePagination';
 import { useTranslation } from '../../../common/hooks/use-translation-wrapper';
 import { selectCurrentClusterPermissionsState, selectCurrentClusterState } from '../../selectors';
 import { hardwareStatusColumn } from './HardwareStatus';
-import { useClusterWizardContext } from '../clusterWizard/ClusterWizardContext';
+import { ClusterWizardContext } from '../clusterWizard/ClusterWizardContext';
 import {
   Cluster,
   Disk,
@@ -446,7 +446,7 @@ export const HostsTableModals = ({
   onAdditionalNtpSource,
   onUpdateDay2ApiVip,
 }: HostsTableModalsProps) => {
-  const { wizardPerPage, setWizardPerPage } = useClusterWizardContext();
+  const { wizardPerPage, setWizardPerPage } = React.useContext(ClusterWizardContext) || {};
   const dispatch = useDispatch();
   const { resetCluster } = React.useContext(AddHostsContext);
   const { uiState } = useSelector(selectCurrentClusterState);


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-15075

The custom manifests requests were coming from the `ClusterWizardContext`. (Which is not needed in day2 as there is no wizard.)