### PR TITLE
Adding tests to validate if dropdown use patternfly style

### DIFF
--- a/libs/ui-lib-tests/cypress/integration/use-cases/create-cluster/with-external-partner-integrations.cy.ts
+++ b/libs/ui-lib-tests/cypress/integration/use-cases/create-cluster/with-external-partner-integrations.cy.ts
@@ -21,6 +21,10 @@ describe('Create a new cluster with external partner integrations', () => {
       ClusterDetailsForm.init();
     });
 
+    it('External partner integrations field use Pattenfly Style', () => {
+      ClusterDetailsForm.externalPartnerIntegrationsField.isPatternflyDropdown();
+    });
+
     it('Should display correct items in the external platform integration dropdown', () => {
       ClusterDetailsForm.externalPartnerIntegrationsField.findDropdownItems().each((item) => {
         // Get the expected values from the externalPlatformTypes object

--- a/libs/ui-lib-tests/cypress/views/forms/ClusterDetails/Fields/CpuArchitectureField.ts
+++ b/libs/ui-lib-tests/cypress/views/forms/ClusterDetails/Fields/CpuArchitectureField.ts
@@ -22,4 +22,8 @@ export class CpuArchitectureField {
       cy.findByRole('menuitem', { name: new RegExp(`${cpuArch}`, 'i') }).click();
     });
   }
+
+  static isPatternflyDropdown() {
+    CpuArchitectureField.findDropdown().should('have.class', 'pf-c-dropdown');
+  }
 }

--- a/libs/ui-lib-tests/cypress/views/forms/ClusterDetails/Fields/ExternalPartnerIntegrationsField.ts
+++ b/libs/ui-lib-tests/cypress/views/forms/ClusterDetails/Fields/ExternalPartnerIntegrationsField.ts
@@ -36,4 +36,8 @@ export class ExternalPartnerIntegrationsField {
       cy.findByRole('menuitem', { name: new RegExp(`${platform}`, 'i') }).click();
     });
   }
+
+  static isPatternflyDropdown() {
+    ExternalPartnerIntegrationsField.findDropdown().should('have.class', 'pf-c-dropdown');
+  }
 }

--- a/libs/ui-lib-tests/cypress/views/forms/ClusterDetails/Fields/OpenShiftVersionField.ts
+++ b/libs/ui-lib-tests/cypress/views/forms/ClusterDetails/Fields/OpenShiftVersionField.ts
@@ -24,4 +24,8 @@ export class OpenShiftVersionField {
       cy.findByRole('menuitem', { name: new RegExp(`openshift ${version}`, 'i') }).click();
     });
   }
+
+  static isPatternflyDropdown() {
+    OpenShiftVersionField.findDropdown().should('have.class', 'pf-c-dropdown');
+  }
 }


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-11177

To test if a dropdown use Patternfly style, in the integration tests for each field we can add this function:

  static isPatternflyDropdown() {
    OpenShiftVersionField.findDropdown().should('have.class', 'pf-c-dropdown');
  }
  
  With this we are validating that the component use Patternfly.