### PR TITLE
MGMT-15597: Custom manifests - when renaming custom manifest, fakeId should be replaced too

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/manifestsConfiguration/components/CustomManifestsForm.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/manifestsConfiguration/components/CustomManifestsForm.tsx
@@ -104,13 +104,6 @@ const handleApiErrorInForm = (
   actions.setErrors(errors);
 };
 
-const updateAllFakeIds = (manifests: CustomManifestValues[]): CustomManifestValues[] => {
-  manifests.forEach((manifest) => {
-    manifest.fakeId = getManifestFakeId(manifest.folder, manifest.filename);
-  });
-  return manifests;
-};
-
 export const CustomManifestsForm = ({
   onFormStateChange,
   getEmptyValues,
@@ -144,18 +137,17 @@ export const CustomManifestsForm = ({
         });
       } else {
         customManifestsLocalRef.current?.forEach((customManifest) => {
-          const updatedManifest: CustomManifestValues | undefined = updatedManifests.find(
+          const updatedManifestFounded: CustomManifestValues | undefined = updatedManifests.find(
             (updatedManifest) =>
               getManifestFakeId(
                 customManifest.folder || 'manifests',
                 customManifest.fileName || '',
               ) === updatedManifest.fakeId || '',
           );
-
-          if (updatedManifest) {
-            customManifest.folder = updatedManifest.folder;
-            customManifest.fileName = updatedManifest.filename;
-            customManifest.yamlContent = updatedManifest.manifestYaml;
+          if (updatedManifestFounded) {
+            customManifest.folder = updatedManifestFounded.folder;
+            customManifest.fileName = updatedManifestFounded.filename;
+            customManifest.yamlContent = updatedManifestFounded.manifestYaml;
           }
         });
       }
@@ -219,7 +211,7 @@ export const CustomManifestsForm = ({
               filename: fileName || '',
               manifestYaml: '',
             };
-            values.manifests = updateAllFakeIds(values.manifests);
+
             return ClustersService.updateCustomManifest(
               existingManifest,
               updatedManifest,

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/manifestsConfiguration/components/CustomManifestsForm.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/manifestsConfiguration/components/CustomManifestsForm.tsx
@@ -104,6 +104,13 @@ const handleApiErrorInForm = (
   actions.setErrors(errors);
 };
 
+const updateAllFakeIds = (manifests: CustomManifestValues[]): CustomManifestValues[] => {
+  manifests.forEach((manifest) => {
+    manifest.fakeId = getManifestFakeId(manifest.folder, manifest.filename);
+  });
+  return manifests;
+};
+
 export const CustomManifestsForm = ({
   onFormStateChange,
   getEmptyValues,
@@ -212,7 +219,7 @@ export const CustomManifestsForm = ({
               filename: fileName || '',
               manifestYaml: '',
             };
-
+            values.manifests = updateAllFakeIds(values.manifests);
             return ClustersService.updateCustomManifest(
               existingManifest,
               updatedManifest,


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-15597

When renaming custom manifest, fakeId should be replaced too. If not changing fakeId, UI duplicates custom manifest name and content to be the same