### PR TITLE
OCPBUGS-16077: Problems base domain validation - new version

### DIFF
--- a/libs/ui-lib/lib/common/components/ui/formik/validationSchemas.test.ts
+++ b/libs/ui-lib/lib/common/components/ui/formik/validationSchemas.test.ts
@@ -332,6 +332,8 @@ describe('validationSchemas', () => {
       'a--aa.com',
       'aa.com.com.com.com',
       'red.cat--rahul.com',
+      '1234567890.1234567890.com1',
+      'aaaaaaaaaa.ccccccc.cccccc--cccccc.cc.dddd.dddd.ddd.cccccccccc',
     ];
     const invalid = [
       'a',

--- a/libs/ui-lib/lib/common/components/ui/formik/validationSchemas.test.ts
+++ b/libs/ui-lib/lib/common/components/ui/formik/validationSchemas.test.ts
@@ -343,6 +343,8 @@ describe('validationSchemas', () => {
       'aaa.c',
       'DNSnamescancontainonlyalphabeticalcharactersa-znumericcharacters0-9theminussign-andtheperiod',
       'DNSnamescancontainonlyalphabeticalcharactersa-znumericcharacters0-9theminussign-andtheperiod.com',
+      'iamnotavaliddnsdomain-iamnotavaliddnsdomain-iamnotavaliddnsdomain',
+      'aaaa--comaaaa.aaaa--comaaaa.aaaa--comaaaa',
     ];
 
     await Promise.all(

--- a/libs/ui-lib/lib/common/components/ui/formik/validationSchemas.ts
+++ b/libs/ui-lib/lib/common/components/ui/formik/validationSchemas.ts
@@ -39,7 +39,7 @@ const SSH_PUBLIC_KEY_REGEX =
   /^(ssh-rsa|ssh-ed25519|ecdsa-[-a-z0-9]*) AAAA[0-9A-Za-z+/]+[=]{0,3}( .+)?$/;
 const DNS_NAME_REGEX = /^([a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,}$/;
 const BASE_DOMAIN_REGEX = /^[a-z\d][\-]*[a-z\d]+$/;
-const DNS_NAME_REGEX_OCM = /^([a-z\d]([\-]*[a-z\d]+)*\.)+[a-z\d]+[\-]*[a-z\d]+$/;
+const DNS_NAME_REGEX_OCM = /^((?!-)[A-Za-z0-9-]{1,63}(?<!-)\.)+[A-Za-z]{2,6}$/;
 
 const PROXY_DNS_REGEX =
   /(^\.?([a-zA-Z0-9_]{1}[a-zA-Z0-9_-]{0,62}){1}(\.[a-zA-Z0-9_]{1}[a-zA-Z0-9_-]{0,62})*$)/;

--- a/libs/ui-lib/lib/common/components/ui/formik/validationSchemas.ts
+++ b/libs/ui-lib/lib/common/components/ui/formik/validationSchemas.ts
@@ -39,7 +39,7 @@ const SSH_PUBLIC_KEY_REGEX =
   /^(ssh-rsa|ssh-ed25519|ecdsa-[-a-z0-9]*) AAAA[0-9A-Za-z+/]+[=]{0,3}( .+)?$/;
 const DNS_NAME_REGEX = /^([a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,}$/;
 const BASE_DOMAIN_REGEX = /^[a-z\d][\-]*[a-z\d]+$/;
-const DNS_NAME_REGEX_OCM = /^((?!-)[A-Za-z0-9-]{1,63}(?<!-)\.)+[A-Za-z]{2,6}$/;
+const DNS_NAME_REGEX_OCM = /^(([a-z\d]+[\-]*[a-z\d]+)\.)+[a-z\d]{2,63}$/;
 
 const PROXY_DNS_REGEX =
   /(^\.?([a-zA-Z0-9_]{1}[a-zA-Z0-9_-]{0,62}){1}(\.[a-zA-Z0-9_]{1}[a-zA-Z0-9_-]{0,62})*$)/;


### PR DESCRIPTION
Solving problems with regexp for base domain validation. 

New regexp:
/^(([a-z\d]+[\-]*[a-z\d]+)\.)+[a-z\d]{2,63}$/

