### PR TITLE
MGMT-15530: external platform integration dropdown - disable Nutanix  and Vsphere when sno is selected

### DIFF
--- a/libs/ui-lib-tests/cypress/integration/use-cases/create-cluster/with-external-partner-integrations.cy.ts
+++ b/libs/ui-lib-tests/cypress/integration/use-cases/create-cluster/with-external-partner-integrations.cy.ts
@@ -97,6 +97,13 @@ describe('Create a new cluster with external partner integrations', () => {
         .findDropdownItem('Nutanix')
         .should('have.class', 'pf-m-aria-disabled');
     });
+
+    it('Validate that Nutanix option is disabled when we choose SNO option', () => {
+      ClusterDetailsForm.snoField.findCheckbox().click();
+      ClusterDetailsForm.externalPartnerIntegrationsField
+        .findDropdownItem('Nutanix')
+        .should('have.class', 'pf-m-aria-disabled');
+    });
   });
 
   describe('After the cluster is created', () => {

--- a/libs/ui-lib-tests/cypress/views/forms/ClusterDetails/ClusterDetailsForm.ts
+++ b/libs/ui-lib-tests/cypress/views/forms/ClusterDetails/ClusterDetailsForm.ts
@@ -6,6 +6,7 @@ import { HostsNetworkConfigurationField } from './Fields/HostsNetworkConfigurati
 import { OpenShiftVersionField } from './Fields/OpenShiftVersionField';
 import { PullSecretField } from './Fields/PullSecretField';
 import { CpuArchitectureField } from './Fields/CpuArchitectureField';
+import { SnoField } from './Fields/SnoField';
 
 export class ClusterDetailsForm {
   static readonly alias = `@${ClusterDetailsForm.name}`;
@@ -46,5 +47,9 @@ export class ClusterDetailsForm {
 
   static get cpuArchitectureField() {
     return CpuArchitectureField.init(ClusterDetailsForm.alias);
+  }
+
+  static get snoField() {
+    return SnoField.init(ClusterDetailsForm.alias);
   }
 }

--- a/libs/ui-lib-tests/cypress/views/forms/ClusterDetails/Fields/SnoField.ts
+++ b/libs/ui-lib-tests/cypress/views/forms/ClusterDetails/Fields/SnoField.ts
@@ -1,0 +1,13 @@
+export class SnoField {
+  static readonly alias = `@${SnoField.name}`;
+  static readonly selector = '#form-control__form-input-highAvailabilityMode-field';
+
+  static init(ancestorAlias?: string) {
+    cy.findWithinOrGet(SnoField.selector, ancestorAlias).as(SnoField.name);
+    return SnoField;
+  }
+
+  static findCheckbox() {
+    return cy.get(SnoField.alias).find('#form-input-highAvailabilityMode-field');
+  }
+}

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/OcmClusterDetailsFormFields.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/OcmClusterDetailsFormFields.tsx
@@ -174,6 +174,7 @@ export const OcmClusterDetailsFormFields = ({
           cpuArchitecture={values.cpuArchitecture}
           showOciOption={isOracleCloudPlatformIntegrationEnabled}
           featureSupportLevelData={featureSupportLevelData}
+          isSNO={isSNO({ highAvailabilityMode })}
         />
       )}
 

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/platformIntegration/ExternalPlatformDropdown.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/platformIntegration/ExternalPlatformDropdown.tsx
@@ -45,22 +45,20 @@ export type ExternalPlatformInfo = {
 };
 
 const getDisabledReasonForExternalPlatform = (
-  featureId: FeatureId,
   isSNO: boolean,
-  isNutanixOrVsphere: boolean,
-  label: string,
   newFeatureSupportLevelContext: NewFeatureSupportLevelData,
+  platform: PlatformType,
   featureSupportLevelData?: NewFeatureSupportLevelMap | null,
   cpuArchitecture?: string,
 ): string | undefined => {
   if (!isSNO) {
     return newFeatureSupportLevelContext.getFeatureDisabledReason(
-      featureId,
+      ExternalPlaformIds[platform] as FeatureId,
       featureSupportLevelData ?? undefined,
       cpuArchitecture,
     );
-  } else if (isSNO && isNutanixOrVsphere) {
-    return `${label} integration is not supported for Single-Node OpenShift`;
+  } else if (platform === 'nutanix' || platform === 'vsphere') {
+    return `${ExternalPlatformLabels[platform]} integration is not supported for Single-Node OpenShift`;
   }
 };
 
@@ -81,11 +79,9 @@ const getExternalPlatformTypes = (
         href: ExternalPlatformLinks[platform],
         tooltip: ExternalPlatformTooltips[platform],
         disabledReason: getDisabledReasonForExternalPlatform(
-          ExternalPlaformIds[platform] as FeatureId,
           isSNO,
-          platform === 'nutanix' || platform === 'vsphere',
-          ExternalPlatformLabels[platform],
           newFeatureSupportLevelContext,
+          platform,
           featureSupportLevelData ?? undefined,
           cpuArchitecture,
         ),


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-15530

When SNO option is selected, we need to disable Nutanix and vSphere options in external platform integration dropdown:

![Captura desde 2023-08-29 09-41-04](https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/410e3751-370a-4455-9aaf-7bab39f6f06e)
