### PR TITLE
MGMT-15616: Hide OCI platform integration "learn more" link until we have correct link

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/platformIntegration/PlatformIntegrationNote.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/platformIntegration/PlatformIntegrationNote.tsx
@@ -10,14 +10,16 @@ const PlatformIntegrationNote = ({ platformType }: { platformType: SupportedPlat
     <p>
       <ExclamationTriangleIcon color={warningColor.value} size="sm" /> You will need to modify your
       platform configuration after cluster installation is completed.{' '}
-      <a
-        href={integrationPlatformLink || ''}
-        target="_blank"
-        rel="noopener noreferrer"
-        data-ouia-component-id="vm-integration-kb-page"
-      >
-        Learn more <i className="fas fa-external-link-alt" />
-      </a>
+      {!!integrationPlatformLink && (
+        <a
+          href={integrationPlatformLink || ''}
+          target="_blank"
+          rel="noopener noreferrer"
+          data-ouia-component-id="vm-integration-kb-page"
+        >
+          Learn more <i className="fas fa-external-link-alt" />
+        </a>
+      )}
     </p>
   );
 };


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-15616

Until we have a correct link for OCI platform integration, we hide it.

![image-2023-08-21-21-00-00-589](https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/e2b1e719-e586-42ab-b18b-19c017830f03)
