### PR TITLE
MGMT-15666: Clear alerts when user clicks next button in cluster details form

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusterWizard/ClusterDetailsForm.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/ClusterDetailsForm.tsx
@@ -10,6 +10,7 @@ import {
   getClusterDetailsValidationSchema,
   getRichTextValidation,
   CpuArchitecture,
+  useAlerts,
 } from '../../../common';
 import { canNextClusterDetails } from './wizardTransition';
 import { OpenshiftVersionOptionType, getFormikErrorFields } from '../../../common';
@@ -71,7 +72,7 @@ const ClusterDetailsForm = (props: ClusterDetailsFormProps) => {
   const { search } = useLocation();
   const { isViewerMode } = useSelector(selectCurrentClusterPermissionsState);
   const featureSupportLevels = useNewFeatureSupportLevel();
-
+  const { clearAlerts } = useAlerts();
   const handleSubmit = React.useCallback(
     async (values: OcmClusterDetailsValues) => {
       if (cluster) {
@@ -108,6 +109,7 @@ const ClusterDetailsForm = (props: ClusterDetailsFormProps) => {
       cluster?: Cluster,
     ): (() => void) => {
       if (isViewerMode || (!dirty && !isUndefined(cluster) && canNextClusterDetails({ cluster }))) {
+        clearAlerts();
         return moveNext;
       }
 
@@ -115,7 +117,7 @@ const ClusterDetailsForm = (props: ClusterDetailsFormProps) => {
         void submitForm();
       };
     },
-    [isViewerMode, moveNext],
+    [isViewerMode, moveNext, clearAlerts],
   );
 
   const initialValues = React.useMemo(


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-15666
We have some problems in cluster details form because we don't clear alerts correctly.

Workflow that didn't work previously:

1. Create new cluster with this values:
name: 123456
domain:
aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aaaaaaaaaaaaa
2. Press next -> Works.
3. Press back
4. Changed name to 123456777  ---> next fails message
5. Revert to 123456  --> window passed but alerts appears in Operators page.