### PR TITLE
MGMT-13396: Cluster with multiple infra-envs - UI throws "cluster not found error"

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusterDetail/AssistedInstallerDetailCard.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterDetail/AssistedInstallerDetailCard.tsx
@@ -49,7 +49,7 @@ const LoadingCard = () => (
   </Card>
 );
 
-const ClusterLoadFailed = ({ clusterId }: { clusterId: Cluster['id'] }) => {
+const ClusterLoadFailed = ({ clusterId, error }: { clusterId: Cluster['id']; error?: string }) => {
   const fetchCluster = useFetchCluster(clusterId);
   return (
     <Card data-testid="ai-cluster-details-card">
@@ -63,6 +63,7 @@ const ClusterLoadFailed = ({ clusterId }: { clusterId: Cluster['id'] }) => {
           title="Failed to fetch the cluster"
           fetchData={fetchCluster}
           actions={[<BackButton key={'cancel'} to={OCM_CLUSTER_LIST_LINK} />]}
+          content={error}
         />
       </CardBody>
     </Card>
@@ -106,10 +107,11 @@ const AssistedInstallerDetailCard = ({
     pullSecret,
     cluster?.openshiftVersion,
   );
+
   if (uiState === ResourceUIState.LOADING || infraEnvLoading) {
     return <LoadingCard />;
   } else if ((uiState === ResourceUIState.POLLING_ERROR && !cluster) || infraEnvError) {
-    return <ClusterLoadFailed clusterId={aiClusterId} />;
+    return <ClusterLoadFailed clusterId={aiClusterId} error={infraEnvError} />;
   }
 
   if (!cluster || !infraEnv || cluster.status === 'adding-hosts') {


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-13396

This pretty much only happens when users mess with the API and add another infraEnv to their Day1 cluster.

**Before:**
![image](https://github.com/openshift-assisted/assisted-installer-ui/assets/87187179/d887ffc6-08b6-4a40-9d8d-982a7380c3ec)

**After:**
![image](https://github.com/openshift-assisted/assisted-installer-ui/assets/87187179/de6845c2-4738-4c2d-a8a5-c9f9769c0ad9)
