### PR TITLE
MGMT-15708:  cluster details page - block power/z + SNO + OCI platform

### DIFF
--- a/libs/ui-lib-tests/cypress/integration/use-cases/create-cluster/with-external-partner-integrations.cy.ts
+++ b/libs/ui-lib-tests/cypress/integration/use-cases/create-cluster/with-external-partner-integrations.cy.ts
@@ -104,6 +104,14 @@ describe('Create a new cluster with external partner integrations', () => {
         .findDropdownItem('Nutanix')
         .should('have.class', 'pf-m-aria-disabled');
     });
+    it('Validate that all dropdown is disabled in case we choose IBM/Z(s390x) architecture + SNO', () => {
+      ClusterDetailsForm.openshiftVersionField.selectVersion('4.14');
+      ClusterDetailsForm.cpuArchitectureField.selectCpuArchitecture('s390x');
+      ClusterDetailsForm.snoField.findCheckbox().click();
+      ClusterDetailsForm.externalPartnerIntegrationsField
+        .findDropdownToggle()
+        .should('be.disabled');
+    });
   });
 
   describe('After the cluster is created', () => {

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/platformIntegration/ExternalPlatformDropdown.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/platformIntegration/ExternalPlatformDropdown.tsx
@@ -12,7 +12,7 @@ import {
 } from '@patternfly/react-core';
 import { CaretDownIcon } from '@patternfly/react-icons';
 import { useField } from 'formik';
-import { FeatureId, getFieldId } from '../../../../common';
+import { CpuArchitecture, FeatureId, getFieldId } from '../../../../common';
 import {
   ExternalPlaformIds,
   ExternalPlatformLabels,
@@ -57,7 +57,12 @@ const getDisabledReasonForExternalPlatform = (
       cpuArchitecture,
     );
   } else if (platform === 'nutanix' || platform === 'vsphere') {
-    return `${ExternalPlatformLabels[platform]} integration is not supported for Single-Node OpenShift`;
+    return `${ExternalPlatformLabels[platform]} integration is not supported for Single-Node OpenShift.`;
+  } else if (
+    cpuArchitecture === CpuArchitecture.ppc64le ||
+    cpuArchitecture === CpuArchitecture.s390x
+  ) {
+    return `Plaform integration is not supported for Single-Node OpenShift with the selected CPU architecture.`;
   }
 };
 
@@ -145,6 +150,7 @@ export const ExternalPlatformDropdown = ({
     }
     if (dropdownIsDisabled || isCurrentValueDisabled) {
       setValue('none');
+      onChange('none');
     }
 
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-15708

UI should block the option to select power/z cpu arch + SNO + OCI platform.

Before changes:
![image](https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/84d0f2de-12db-4847-96b1-d63532c077da)

After changes:
![image](https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/b36871bb-945f-45f7-b6eb-ef7f366b5d68)
