### PR TITLE
MGMT-15714: Allow to load multi-yaml files in custom manifests page

### DIFF
--- a/libs/ui-lib-tests/cypress/fixtures/custom-manifests/files/manifest_multiple.yaml
+++ b/libs/ui-lib-tests/cypress/fixtures/custom-manifests/files/manifest_multiple.yaml
@@ -1,0 +1,19 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: master
+  name: 99-openshift-machineconfig-master-kargs
+spec:
+  kernelArguments:
+    - loglevel=7
+---
+apiVersion: machineconfiguration.openshift.io/v2
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: master
+  name: 98-openshift-machineconfig-master-kargs
+spec:
+  kernelArguments:
+    - loglevel=5

--- a/libs/ui-lib-tests/cypress/integration/custom-manifests/2-modifying-existing-custom-manifest.cy.ts
+++ b/libs/ui-lib-tests/cypress/integration/custom-manifests/2-modifying-existing-custom-manifest.cy.ts
@@ -77,5 +77,13 @@ describe(`Assisted Installer Custom manifests step`, () => {
       );
       commonActions.verifyNextIsDisabled();
     });
+
+    it('Adding multi-yaml file to dummy manifest enables next button', () => {
+      CustomManifestsForm.initManifest(0);
+      CustomManifestsForm.expandedManifest(0)
+        .fileUpload()
+        .attachFile(`custom-manifests/files/manifest_multiple.yaml`);
+      commonActions.verifyNextIsEnabled();
+    });
   });
 });

--- a/libs/ui-lib-tests/cypress/views/common.ts
+++ b/libs/ui-lib-tests/cypress/views/common.ts
@@ -26,7 +26,8 @@ type Day1Steps =
   | 'Storage'
   | 'Networking'
   | 'Review and create'
-  | 'Operators';
+  | 'Operators'
+  | 'Custom manifests';
 
 type Day1StaticIpSteps =
   | 'Cluster details'

--- a/libs/ui-lib/lib/common/utils.ts
+++ b/libs/ui-lib/lib/common/utils.ts
@@ -1,7 +1,7 @@
 import filesize from 'filesize.js';
 import camelCase from 'lodash-es/camelCase.js';
 import isString from 'lodash-es/isString.js';
-import { load } from 'js-yaml';
+import { loadAll } from 'js-yaml';
 import { MAX_FILE_SIZE_BYTES, MAX_FILE_SIZE_OFFSET_FACTOR } from './configurations';
 
 export const FILENAME_REGEX = /^[^\/]*\.(yaml|yml|json)$/;
@@ -32,7 +32,7 @@ export const validateFileType = (value: string) => {
 
 export const isStringValidYAML = (input: string): boolean => {
   try {
-    load(input);
+    loadAll(input);
     return true;
   } catch {
     return false;


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-15714

We change the code of UI to allow users to load multi-yaml files in custom manifests page:

![image](https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/e1e826a9-131f-422a-9c14-67a0c990deb8)