### PR TITLE
MGMT-13852: Change base domain helper text

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/OcmBaseDomainField.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/OcmBaseDomainField.tsx
@@ -21,10 +21,11 @@ export const BaseDnsHelperText = ({
   baseDnsDomain?: string;
 }) => (
   <HelperText fieldId={fieldId}>
-    All DNS records must be subdomains of this base and include the cluster name. This cannot be
-    changed after cluster installation. The full cluster address will be: <br />
+    Enter the name of your local host [localhost] or [localhost.com]. This cannot be changed after
+    creation. All DNS records must include the cluster name and be subdomains of the base you enter.
+    The full cluster address will be: <br />
     <strong>
-      {name || '[Cluster Name]'}.{baseDnsDomain || '[example.com]'}
+      {name || '[Cluster Name]'}.{baseDnsDomain || '[localhost.com]'}
     </strong>
   </HelperText>
 );
@@ -98,7 +99,7 @@ export const OcmBaseDomainField = ({ managedDomains }: { managedDomains: Managed
         ) : (
           <OcmInputField
             name={INPUT_NAME}
-            placeholder="example.com"
+            placeholder="localhost.com"
             isDisabled={useRedHatDnsService}
             isRequired
           />


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-13852

New helper text in base domain field in Cluster Details page:
![Captura desde 2023-09-15 11-32-09](https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/a3764fa3-436e-4619-942e-b021c4b0f386)
