### PR TITLE
MGMT-15816: Use platform type to call support-levels API in Networking page - nutanix and vsphere leftovers

### DIFF
--- a/libs/ui-lib/lib/ocm/components/featureSupportLevels/featureStateUtils.ts
+++ b/libs/ui-lib/lib/ocm/components/featureSupportLevels/featureStateUtils.ts
@@ -12,6 +12,7 @@ import {
   PlatformType,
   SupportLevel,
 } from '@openshift-assisted/types/assisted-installer-service';
+import { ExternalPlatformLabels } from '../clusterConfiguration/platformIntegration/constants';
 
 const CNV_OPERATOR_LABEL = 'Openshift Virtualization';
 const LVMS_OPERATOR_LABEL = 'Logical Volume Manager Storage';
@@ -176,7 +177,9 @@ export const getNewFeatureDisabledReason = (
       return getNetworkTypeSelectionDisabledReason(cluster);
     }
     case 'CLUSTER_MANAGED_NETWORKING': {
-      return 'Cluster-managed networking is not supported for ARM architecture with this version of OpenShift.';
+      return `Cluster-managed networking is not supported when using ${
+        platformType ? ExternalPlatformLabels[platformType] : ''
+      }`;
     }
     case 'EXTERNAL_PLATFORM_OCI': {
       return getOciDisabledReason(cpuArchitecture, isSupported);
@@ -196,9 +199,11 @@ export const getNewFeatureDisabledReason = (
         return `Integration with vSphere is not available with the selected CPU architecture.`;
       }
     }
-    case 'PLATFORM_MANAGED_NETWORKING': {
+    case 'USER_MANAGED_NETWORKING': {
       if (!isSupported) {
-        return `User-Managed Networking is not supported when using ${platformType || ''}`;
+        return `User-Managed Networking is not supported when using ${
+          platformType ? ExternalPlatformLabels[platformType] : ''
+        }`;
       }
     }
     default: {


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-15816

Now, in Networking Page we disable/enable UMN or CMN depending calls of feature support levels API using new param platform_type:
1. For example, for 'Nutanix' cluster:
![image](https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/fc198503-bdd2-492e-828d-8376acad7664)

Then we can see this in Networking Page:
![image](https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/a3ee85ac-9494-4f4a-a750-e063291d7d84)

