### PR TITLE
MGMT-15816: Use platform type to call support-levels API in Networking page - nutanix and vsphere leftovers -2.25

### DIFF
--- a/libs/ui-lib/lib/ocm/components/featureSupportLevels/featureStateUtils.ts
+++ b/libs/ui-lib/lib/ocm/components/featureSupportLevels/featureStateUtils.ts
@@ -12,6 +12,7 @@ import {
   PlatformType,
   SupportLevel,
 } from '@openshift-assisted/types/assisted-installer-service';
+import { ExternalPlatformLabels } from '../clusterConfiguration/platformIntegration/constants';
 
 const CNV_OPERATOR_LABEL = 'Openshift Virtualization';
 const LVMS_OPERATOR_LABEL = 'Logical Volume Manager Storage';
@@ -176,7 +177,9 @@ export const getNewFeatureDisabledReason = (
       return getNetworkTypeSelectionDisabledReason(cluster);
     }
     case 'CLUSTER_MANAGED_NETWORKING': {
-      return 'Cluster-managed networking is not supported for ARM architecture with this version of OpenShift.';
+      return `Cluster-managed networking is not supported when using ${
+        platformType ? ExternalPlatformLabels[platformType] : ''
+      }`;
     }
     case 'EXTERNAL_PLATFORM_OCI': {
       return getOciDisabledReason(cpuArchitecture, isSupported);
@@ -196,9 +199,11 @@ export const getNewFeatureDisabledReason = (
         return `Integration with vSphere is not available with the selected CPU architecture.`;
       }
     }
-    case 'PLATFORM_MANAGED_NETWORKING': {
+    case 'USER_MANAGED_NETWORKING': {
       if (!isSupported) {
-        return `User-Managed Networking is not supported when using ${platformType || ''}`;
+        return `User-Managed Networking is not supported when using ${
+          platformType ? ExternalPlatformLabels[platformType] : ''
+        }`;
       }
     }
     default: {


### PR DESCRIPTION
backport of #2372 