### PR TITLE
MGMT-15599: Add  message when platform-requirements-satisfied validation fails

### DIFF
--- a/libs/locales/lib/en/translation.json
+++ b/libs/locales/lib/en/translation.json
@@ -578,6 +578,7 @@
   "ai:Pending input": "Pending input",
   "ai:Pending validations:": "Pending validations:",
   "ai:Platform network settings": "Platform network settings",
+  "ai:Platform requirements": "Platform requirements",
   "ai:Please note that this version is not production-ready.": "Note that this version is not production-ready.",
   "ai:Please refer to the <2>OpenShift networking documentation</2> to configure your cluster's networking, including:": "Refer to the <2>OpenShift networking documentation</2> to configure your cluster's networking, including:",
   "ai:Please select a subnet. ({{hostSubnetLength}} available)": "Select a subnet. ({{hostSubnetLength}} available)",

--- a/libs/ui-lib/lib/common/components/clusterWizard/ReviewValidations.tsx
+++ b/libs/ui-lib/lib/common/components/clusterWizard/ReviewValidations.tsx
@@ -112,6 +112,9 @@ const FailingValidation = <S extends string>({
       </>
     );
   } else {
+    if (validation.id === 'platform-requirements-satisfied') {
+      fix = validation.message;
+    }
     // console.error(
     //   'Unknown validation ID detected in the ',
     //   clusterGroup || hostGroup,

--- a/libs/ui-lib/lib/common/config/constants.ts
+++ b/libs/ui-lib/lib/common/config/constants.ts
@@ -250,6 +250,7 @@ export const clusterValidationLabels = (
   'lvm-requirements-satisfied': t('ai:Logical Volume Manager requirements'),
   'cnv-requirements-satisfied': t('ai:CNV requirements'),
   'mce-requirements-satisfied': t('ai:MCE requirements'),
+  'platform-requirements-satisfied': t('ai:Platform requirements'),
 });
 
 export const clusterValidationGroupLabels = (


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-15599

In R&C page,failed validations in preflight check shows only the validation ID but not the message itself.
We change it for platform-requirements satisfied validation:

![image](https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/5d23dc1c-6ba2-4384-981f-d8302a8a3e82)
