### PR TITLE
MGMT-15062: Remove references to ASSISTED_INSTALLER_MULTIARCH_SUPPORTED feature

### DIFF
--- a/libs/ui-lib/lib/common/features/featureGate.tsx
+++ b/libs/ui-lib/lib/common/features/featureGate.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 // Must conform Unleash constants
 export type AssistedInstallerFeatureType =
   | 'ASSISTED_INSTALLER_SINGLE_CLUSTER_FEATURE'
-  | 'ASSISTED_INSTALLER_MULTIARCH_SUPPORTED'
   | 'ASSISTED_INSTALLER_PLATFORM_OCI';
 
 export type FeatureListType = {
@@ -22,13 +21,11 @@ export type AssistedInstallerPermissionTypesListType = {
 // Hardcoded for ACM
 export const ACM_ENABLED_FEATURES: FeatureListType = {
   ASSISTED_INSTALLER_SINGLE_CLUSTER_FEATURE: false,
-  ASSISTED_INSTALLER_MULTIARCH_SUPPORTED: true,
 };
 
 // Hardcoded outside OCM
 export const STANDALONE_DEPLOYMENT_ENABLED_FEATURES: FeatureListType = {
   ASSISTED_INSTALLER_SINGLE_CLUSTER_FEATURE: false,
-  ASSISTED_INSTALLER_MULTIARCH_SUPPORTED: true,
   ASSISTED_INSTALLER_PLATFORM_OCI: true,
 };
 
@@ -46,7 +43,6 @@ export const FeatureGateContextProvider: React.FC<{
   // hardcoded defaults
   // TODO (mortegag): Remove all multiarch capacity related code in the UI.
   const featuresWithDefaults: FeatureListType = {
-    ASSISTED_INSTALLER_MULTIARCH_SUPPORTED: true,
     ...features,
   };
 

--- a/libs/ui-lib/lib/common/types/cpuArchitecture.ts
+++ b/libs/ui-lib/lib/common/types/cpuArchitecture.ts
@@ -44,29 +44,24 @@ export const getAllCpuArchitectures = (): SupportedCpuArchitecture[] => [
 ];
 
 export const getSupportedCpuArchitectures = (
-  canSelectCpuArch: boolean,
   cpuArchitectures: CpuArchitecture[],
   day1CpuArchitecture?: SupportedCpuArchitecture,
 ): SupportedCpuArchitecture[] => {
   const newSupportedCpuArchs: SupportedCpuArchitecture[] = [];
   //Power/Z clusters can be only homogeneous clusters
   if (
-    (day1CpuArchitecture === CpuArchitecture.ppc64le ||
-      day1CpuArchitecture === CpuArchitecture.s390x) &&
-    canSelectCpuArch
+    day1CpuArchitecture === CpuArchitecture.ppc64le ||
+    day1CpuArchitecture === CpuArchitecture.s390x
   ) {
     newSupportedCpuArchs.push(day1CpuArchitecture);
   } else {
     cpuArchitectures.forEach((cpuArch) => {
       if (
         day1CpuArchitecture === undefined &&
-        (cpuArch === CpuArchitecture.ppc64le || cpuArch === CpuArchitecture.s390x) &&
-        canSelectCpuArch
+        (cpuArch === CpuArchitecture.ppc64le || cpuArch === CpuArchitecture.s390x)
       ) {
         newSupportedCpuArchs.push(cpuArch);
       } else if (
-        day1CpuArchitecture !== CpuArchitecture.ppc64le &&
-        day1CpuArchitecture !== CpuArchitecture.s390x &&
         cpuArch !== CpuArchitecture.MULTI &&
         cpuArch !== CpuArchitecture.USE_DAY1_ARCHITECTURE
       ) {

--- a/libs/ui-lib/lib/ocm/components/AddHosts/AddHosts.tsx
+++ b/libs/ui-lib/lib/ocm/components/AddHosts/AddHosts.tsx
@@ -22,7 +22,6 @@ import {
   AddHostsContext,
   alertsSlice,
   canInstallHost,
-  useFeature,
 } from '../../../common';
 import InventoryAddHosts from './InventoryAddHost';
 import { onFetchEvents } from '../fetching/fetchEvents';
@@ -38,7 +37,6 @@ export const AddHosts = () => {
   const { cluster, resetCluster, canEdit } = React.useContext(AddHostsContext);
   const [isSubmitting, setSubmitting] = React.useState(false);
   const clusterVarieties = useClusterStatusVarieties(cluster);
-  const canSelectCpuArch = useFeature('ASSISTED_INSTALLER_MULTIARCH_SUPPORTED');
   const handleHostsInstall = React.useCallback(async () => {
     setSubmitting(true);
     try {
@@ -89,7 +87,7 @@ export const AddHosts = () => {
               </Grid>
             </StackItem>
             <StackItem>
-              <InventoryAddHosts cluster={cluster} canSelectCpuArch={canSelectCpuArch} />
+              <InventoryAddHosts cluster={cluster} />
             </StackItem>
           </Stack>
         </CardBody>

--- a/libs/ui-lib/lib/ocm/components/AddHosts/InventoryAddHost.tsx
+++ b/libs/ui-lib/lib/ocm/components/AddHosts/InventoryAddHost.tsx
@@ -8,18 +8,12 @@ import Day2DiscoveryImageModalButton from './day2Wizard/Day2DiscoveryImageModalB
 import Day2Wizard from './day2Wizard/Day2Wizard';
 import { Cluster } from '@openshift-assisted/types/assisted-installer-service';
 
-const InventoryAddHosts = ({
-  cluster,
-  canSelectCpuArch,
-}: {
-  cluster?: Cluster;
-  canSelectCpuArch?: boolean;
-}) => {
+const InventoryAddHosts = ({ cluster }: { cluster?: Cluster }) => {
   if (!cluster) {
     return null;
   }
 
-  const showArmOnlyAlert = !canSelectCpuArch && cluster.cpuArchitecture === CpuArchitecture.ARM;
+  const showArmOnlyAlert = cluster.cpuArchitecture === CpuArchitecture.ARM;
   return (
     <Stack hasGutter>
       <StackItem>

--- a/libs/ui-lib/lib/ocm/components/AddHosts/day2Wizard/Day2ClusterDetails.tsx
+++ b/libs/ui-lib/lib/ocm/components/AddHosts/day2Wizard/Day2ClusterDetails.tsx
@@ -12,7 +12,6 @@ import {
   HOW_TO_KNOW_IF_CLUSTER_SUPPORTS_MULTIPLE_CPU_ARCHS,
   LoadingState,
   SupportedCpuArchitecture,
-  useFeature,
 } from '../../../../common';
 import { HostsNetworkConfigurationType, InfraEnvsService } from '../../../services';
 import { useModalDialogsContext } from '../../hosts/ModalDialogsContext';
@@ -86,7 +85,6 @@ const Day2ClusterDetails = () => {
   const [initialValues, setInitialValues] = React.useState<Day2ClusterDetailValues | null>(null);
   const [isSubmitting, setSubmitting] = React.useState(false);
   const [isAlternativeCpuSelected, setIsAlternativeCpuSelected] = React.useState(false);
-  const canSelectCpuArch = useFeature('ASSISTED_INSTALLER_MULTIARCH_SUPPORTED');
   const { getCpuArchitectures } = useOpenshiftVersions();
   const cpuArchitecturesByVersionImage = getCpuArchitectures(day2Cluster.openshiftVersion);
   const day1CpuArchitecture = mapClusterCpuArchToInfraEnvCpuArch(day2Cluster.cpuArchitecture);
@@ -94,13 +92,8 @@ const Day2ClusterDetails = () => {
   const pullSecret = usePullSecret();
 
   const cpuArchitectures = React.useMemo(
-    () =>
-      getSupportedCpuArchitectures(
-        canSelectCpuArch,
-        cpuArchitecturesByVersionImage,
-        day1CpuArchitecture,
-      ),
-    [canSelectCpuArch, cpuArchitecturesByVersionImage, day1CpuArchitecture],
+    () => getSupportedCpuArchitectures(cpuArchitecturesByVersionImage, day1CpuArchitecture),
+    [cpuArchitecturesByVersionImage, day1CpuArchitecture],
   );
   React.useEffect(() => {
     const fetchAndSetInitialValues = async () => {

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/OcmClusterDetailsFormFields.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/OcmClusterDetailsFormFields.tsx
@@ -66,7 +66,6 @@ export const OcmClusterDetailsFormFields = ({
 
   const { t } = useTranslation();
   const isSingleClusterFeatureEnabled = useFeature('ASSISTED_INSTALLER_SINGLE_CLUSTER_FEATURE');
-  const isMultiArchSupported = useFeature('ASSISTED_INSTALLER_MULTIARCH_SUPPORTED');
   const isOracleCloudPlatformIntegrationEnabled = useFeature('ASSISTED_INSTALLER_PLATFORM_OCI');
   const { openshiftVersion, platform } = values;
   const { getCpuArchitectures } = useOpenshiftVersions();
@@ -78,8 +77,8 @@ export const OcmClusterDetailsFormFields = ({
     values.cpuArchitecture as SupportedCpuArchitecture,
   );
   const cpuArchitectures = React.useMemo(
-    () => getSupportedCpuArchitectures(isMultiArchSupported, cpuArchitecturesByVersionImage),
-    [cpuArchitecturesByVersionImage, isMultiArchSupported],
+    () => getSupportedCpuArchitectures(cpuArchitecturesByVersionImage),
+    [cpuArchitecturesByVersionImage],
   );
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-15062

After 2.21.7 we allow all users to use MultiArch capacity. We need to remove the references of ASSISTED_INSTALLER_MULTIARCH_SUPPORTED in the code of assisted-installer-ui.