### PR TITLE
MGMT-13220: Add disabled field tooltip on encryption type components

### DIFF
--- a/libs/ui-lib/lib/common/components/clusterConfiguration/DiskEncryptionFields/DiskEncryptionControlGroup.tsx
+++ b/libs/ui-lib/lib/common/components/clusterConfiguration/DiskEncryptionFields/DiskEncryptionControlGroup.tsx
@@ -104,7 +104,11 @@ const DiskEncryptionControlGroup = ({
           condition={enableDiskEncryptionOnMasters || (enableDiskEncryptionOnWorkers && !isSNO)}
         >
           <StackItem>
-            <DiskEncryptionMode diskEncryptionMode={diskEncryptionMode} isDisabled={isDisabled} />
+            <DiskEncryptionMode
+              diskEncryptionMode={diskEncryptionMode}
+              isDisabled={isDisabled}
+              tooltipProps={tooltipProps}
+            />
           </StackItem>
         </RenderIf>
       </Stack>

--- a/libs/ui-lib/lib/common/components/clusterConfiguration/DiskEncryptionFields/DiskEncryptionMode.tsx
+++ b/libs/ui-lib/lib/common/components/clusterConfiguration/DiskEncryptionFields/DiskEncryptionMode.tsx
@@ -8,6 +8,8 @@ import {
   Text,
   TextVariants,
   TextContent,
+  TooltipProps,
+  Tooltip,
 } from '@patternfly/react-core';
 import { ENCRYPTING_DISK_DURING_INSTALLATION } from '../../../config';
 import PopoverIcon from '../../ui/PopoverIcon';
@@ -64,31 +66,40 @@ const DiskEncryptionModeTang = () => {
 export interface DiskEncryptionModeProps {
   isDisabled: boolean;
   diskEncryptionMode: DiskEncryption['mode'];
+  tooltipProps: TooltipProps;
 }
 
-export const DiskEncryptionMode = ({ diskEncryptionMode, isDisabled }: DiskEncryptionModeProps) => {
+export const DiskEncryptionMode = ({
+  diskEncryptionMode,
+  isDisabled,
+  tooltipProps,
+}: DiskEncryptionModeProps) => {
   const { t } = useTranslation();
   return (
     <Stack>
       <StackItem>
         <Flex>
           <FlexItem spacer={{ default: 'spacer3xl' }}>
-            <RadioField
-              isDisabled={isDisabled}
-              name="diskEncryptionMode"
-              label={<DiskEncryptionModeTPMv2 />}
-              id="TPMV2-button"
-              value="tpmv2"
-            />
+            <Tooltip {...tooltipProps}>
+              <RadioField
+                isDisabled={isDisabled}
+                name="diskEncryptionMode"
+                label={<DiskEncryptionModeTPMv2 />}
+                id="TPMV2-button"
+                value="tpmv2"
+              />
+            </Tooltip>
           </FlexItem>
           <FlexItem spacer={{ default: 'spacer3xl' }}>
-            <RadioField
-              isDisabled={isDisabled}
-              name="diskEncryptionMode"
-              label={<DiskEncryptionModeTang />}
-              id="tang-button"
-              value="tang"
-            />
+            <Tooltip {...tooltipProps}>
+              <RadioField
+                isDisabled={isDisabled}
+                name="diskEncryptionMode"
+                label={<DiskEncryptionModeTang />}
+                id="tang-button"
+                value="tang"
+              />
+            </Tooltip>
           </FlexItem>
         </Flex>
       </StackItem>
@@ -101,7 +112,7 @@ export const DiskEncryptionMode = ({ diskEncryptionMode, isDisabled }: DiskEncry
             </TextContent>
           </StackItem>
           &nbsp;
-          <TangServers isDisabled={isDisabled} />
+          <TangServers isDisabled={isDisabled} tooltipProps={tooltipProps} />
         </Stack>
       )}
     </Stack>

--- a/libs/ui-lib/lib/common/components/clusterConfiguration/DiskEncryptionFields/TangServers.tsx
+++ b/libs/ui-lib/lib/common/components/clusterConfiguration/DiskEncryptionFields/TangServers.tsx
@@ -1,12 +1,18 @@
 import React from 'react';
 import { FieldArray, useFormikContext } from 'formik';
-import { Stack, StackItem, TextInputTypes } from '@patternfly/react-core';
+import { Stack, StackItem, TextInputTypes, Tooltip, TooltipProps } from '@patternfly/react-core';
 import { ClusterDetailsValues } from '../../clusterWizard';
 import { InputField } from '../../ui';
 import { AddButton, RemovableField } from '../../ui/formik';
 import { useTranslation } from '../../../hooks/use-translation-wrapper';
 
-export const TangServers = ({ isDisabled = false }: { isDisabled: boolean }) => {
+export const TangServers = ({
+  isDisabled = false,
+  tooltipProps,
+}: {
+  isDisabled: boolean;
+  tooltipProps: TooltipProps;
+}) => {
   const { values } = useFormikContext<ClusterDetailsValues>();
   const { t } = useTranslation();
   return (
@@ -20,22 +26,26 @@ export const TangServers = ({ isDisabled = false }: { isDisabled: boolean }) => 
                 onRemove={() => remove(index)}
               >
                 <div>
-                  <InputField
-                    type={TextInputTypes.url}
-                    name={`diskEncryptionTangServers.${index}.url`}
-                    helperText={`Must start with "http://" or "https://". Optionally, end with ":<port>"`}
-                    label="Server URL"
-                    isRequired
-                    isDisabled={isDisabled}
-                  />
+                  <Tooltip {...tooltipProps}>
+                    <InputField
+                      type={TextInputTypes.url}
+                      name={`diskEncryptionTangServers.${index}.url`}
+                      helperText={`Must start with "http://" or "https://". Optionally, end with ":<port>"`}
+                      label="Server URL"
+                      isRequired
+                      isDisabled={isDisabled}
+                    />
+                  </Tooltip>
                   &thinsp;
-                  <InputField
-                    type={TextInputTypes.text}
-                    name={`diskEncryptionTangServers.${index}.thumbprint`}
-                    label="Server Thumbprint"
-                    isRequired
-                    isDisabled={isDisabled}
-                  />
+                  <Tooltip {...tooltipProps}>
+                    <InputField
+                      type={TextInputTypes.text}
+                      name={`diskEncryptionTangServers.${index}.thumbprint`}
+                      label="Server Thumbprint"
+                      isRequired
+                      isDisabled={isDisabled}
+                    />
+                  </Tooltip>
                 </div>
               </RemovableField>{' '}
             </StackItem>


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-13220

After setting encryption on the cluster details screen and clicking "Next" and then "Back", we have to show the disabled tooltip:

![image](https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/eeeeb909-f984-4638-9bf9-cb1949f76307)

![image](https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/577d72fb-e73d-418e-a14b-cc095855a3e7)

![image](https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/35c5cc61-e664-4258-bd34-d6a9bb433beb)

![image](https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/c1e50117-a3b7-48b4-a5b1-ba40d879394a)

