### PR TITLE
MGMT-15974: [PSI / On-prem] - Day2 - After adding new host, day1 hosts move to Finalizing status

### DIFF
--- a/libs/ui-lib/lib/common/components/hosts/utils.ts
+++ b/libs/ui-lib/lib/common/components/hosts/utils.ts
@@ -13,6 +13,7 @@ import {
   ValidationsInfo as HostValidationsInfo,
   ValidationGroup as HostValidationGroup,
 } from '../../types/hosts';
+import { isInOcm } from '../../api';
 
 export const canEnable = (clusterStatus: Cluster['status'], status: Host['status']) =>
   ['pending-for-input', 'insufficient', 'ready', 'adding-hosts'].includes(clusterStatus) &&
@@ -97,7 +98,7 @@ export const getHostStatus = (
   hostStatus: Host['status'],
   clusterStatus: Cluster['status'],
 ): Host['status'] | 'finalizing' => {
-  if (hostStatus === 'installed' && clusterStatus !== 'installed') {
+  if (isInOcm && hostStatus === 'installed' && clusterStatus !== 'installed') {
     return 'finalizing';
   }
   return hostStatus;


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-15974

The fact that the Day1 hosts keep displaying status "Finalizing" when you transform the cluster to Day2 could be confusing. The solution here is not do this override outside of OCM.

Before changes:
![image](https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/37b57a6f-76f4-4b5c-a1aa-37da91c60039)

After changes:
![image](https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/3d9afb86-13bf-44bd-ad70-dce12d2e947b)

