### PR TITLE
[2.7] Update push-to-master.yaml

### DIFF
--- a/.github/workflows/on-push.yaml
+++ b/.github/workflows/on-push.yaml
@@ -6,6 +6,9 @@ on:
       - master
       - features/*
       - bugs/*
+    tags:
+      - 'v*'
+      - '!v*-cim'
 
 jobs:
   push-to-quay-io:


### PR DESCRIPTION
Do not push assisted-ui quay.io images created after a new CIM release


backport of https://github.com/openshift-assisted/assisted-installer-ui/commit/a3014139bb92f168597e7e3e6ae5e6dc27b4f99d