### PR TITLE
MGMT-16041: Splits the preview badges into one component per module

### DIFF
--- a/libs/ui-lib/lib/common/components/featureSupportLevels/FeatureSupportLevelBadge.tsx
+++ b/libs/ui-lib/lib/common/components/featureSupportLevels/FeatureSupportLevelBadge.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { SupportLevel } from '@openshift-assisted/types/assisted-installer-service';
 import { FeatureId, isPreviewSupportLevel } from '../../types';
-import { TechnologyPreview, DeveloperPreview } from '../ui/PreviewBadge';
+import { TechnologyPreview } from '../ui/TechnologyPreview';
+import { DeveloperPreview } from '../ui/DeveloperPreview';
 import { useFeatureSupportLevel } from './FeatureSupportLevelContext';
 
 export type SupportLevelBadgeProps = {

--- a/libs/ui-lib/lib/common/components/newFeatureSupportLevels/NewFeatureSupportLevelBadge.tsx
+++ b/libs/ui-lib/lib/common/components/newFeatureSupportLevels/NewFeatureSupportLevelBadge.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { SupportLevel } from '@openshift-assisted/types/assisted-installer-service';
 import { FeatureId, isPreviewSupportLevel } from '../../types';
-import { TechnologyPreview, DeveloperPreview } from '../ui/PreviewBadge';
+import { TechnologyPreview } from '../ui/TechnologyPreview';
+import { DeveloperPreview } from '../ui/DeveloperPreview';
 
 export type NewSupportLevelBadgeProps = {
   featureId: FeatureId;

--- a/libs/ui-lib/lib/common/components/ui/DeveloperPreview.tsx
+++ b/libs/ui-lib/lib/common/components/ui/DeveloperPreview.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { useTranslation } from '../../hooks/use-translation-wrapper';
+import { PreviewBadge, PreviewBadgeProps } from './PreviewBadge';
+
+export type DeveloperPreviewProps = Omit<PreviewBadgeProps, 'text' | 'popoverText'>;
+
+export const DeveloperPreview: React.FC<DeveloperPreviewProps> = (props) => {
+  const { t } = useTranslation();
+  return (
+    <PreviewBadge
+      text={t('ai:Developer Preview')}
+      popoverText={t(
+        'ai:Developer preview features are not intended to be used in production environments. The clusters deployed with the developer preview features are considered to be development clusters and are not supported through the Red Hat Customer Portal case management system.',
+      )}
+      {...props}
+    />
+  );
+};
+DeveloperPreview.displayName = 'DeveloperPreview';

--- a/libs/ui-lib/lib/common/components/ui/PreviewBadge.tsx
+++ b/libs/ui-lib/lib/common/components/ui/PreviewBadge.tsx
@@ -1,17 +1,9 @@
 import React from 'react';
 import { Label, Popover } from '@patternfly/react-core';
 import { InfoCircleIcon } from '@patternfly/react-icons';
-import { TECH_SUPPORT_LEVEL_LINK } from '../../config/constants';
 import ExternalLink from './ExternalLink';
 import { WithTestID } from '../../types';
 import { useTranslation } from '../../hooks/use-translation-wrapper';
-
-export type DeveloperPreviewProps = {
-  position?: PreviewBadgePosition;
-  className?: string;
-} & WithTestID;
-
-export type TechnologyPreviewProps = DeveloperPreviewProps;
 
 export enum PreviewBadgePosition {
   default,
@@ -19,13 +11,15 @@ export enum PreviewBadgePosition {
   inlineRight,
 }
 
-type PreviewBadgeProps = DeveloperPreviewProps & {
+export type PreviewBadgeProps = {
+  position?: PreviewBadgePosition;
+  className?: string;
   text: string;
   externalLink?: string;
   popoverText: string;
-};
+} & WithTestID;
 
-const PreviewBadge: React.FC<PreviewBadgeProps> = ({
+export const PreviewBadge: React.FC<PreviewBadgeProps> = ({
   position = PreviewBadgePosition.inline,
   className = 'pf-u-ml-md',
   text,
@@ -69,32 +63,4 @@ const PreviewBadge: React.FC<PreviewBadgeProps> = ({
     </span>
   );
 };
-
-export const DeveloperPreview: React.FC<DeveloperPreviewProps> = (props) => {
-  const { t } = useTranslation();
-  return (
-    <PreviewBadge
-      text={t('ai:Developer Preview')}
-      popoverText={t(
-        'ai:Developer preview features are not intended to be used in production environments. The clusters deployed with the developer preview features are considered to be development clusters and are not supported through the Red Hat Customer Portal case management system.',
-      )}
-      {...props}
-    />
-  );
-};
-DeveloperPreview.displayName = 'DeveloperPreview';
-
-export const TechnologyPreview: React.FC<TechnologyPreviewProps> = (props) => {
-  const { t } = useTranslation();
-  return (
-    <PreviewBadge
-      text={t('ai:Technology Preview')}
-      popoverText={t(
-        'ai:Technology preview features provide early access to upcoming product innovations, enabling you to test functionality and provide feedback during the development process.',
-      )}
-      externalLink={TECH_SUPPORT_LEVEL_LINK}
-      {...props}
-    />
-  );
-};
-TechnologyPreview.displayName = 'TechnologyPreview';
+PreviewBadge.displayName = 'PreviewBadge';

--- a/libs/ui-lib/lib/common/components/ui/TechnologyPreview.tsx
+++ b/libs/ui-lib/lib/common/components/ui/TechnologyPreview.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { TECH_SUPPORT_LEVEL_LINK } from '../../config/constants';
+import { useTranslation } from '../../hooks/use-translation-wrapper';
+import { PreviewBadge, PreviewBadgeProps } from './PreviewBadge';
+
+export type TechnologyPreviewProps = Omit<
+  PreviewBadgeProps,
+  'text' | 'popoverText' | 'externalLink'
+>;
+
+export const TechnologyPreview: React.FC<TechnologyPreviewProps> = (props) => {
+  const { t } = useTranslation();
+
+  return (
+    <PreviewBadge
+      text={t('ai:Technology Preview')}
+      popoverText={t(
+        'ai:Technology preview features provide early access to upcoming product innovations, enabling you to test functionality and provide feedback during the development process.',
+      )}
+      externalLink={TECH_SUPPORT_LEVEL_LINK}
+      {...props}
+    />
+  );
+};
+TechnologyPreview.displayName = 'TechnologyPreview';

--- a/libs/ui-lib/lib/common/components/ui/index.ts
+++ b/libs/ui-lib/lib/common/components/ui/index.ts
@@ -9,6 +9,8 @@ export * from './SimpleDropdown';
 export * from './DetailList';
 export * from './eventsModal';
 export * from './PreviewBadge';
+export * from './TechnologyPreview';
+export * from './DeveloperPreview';
 
 export * from './utils';
 

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/platformIntegration/ExternalPlatformDropdown.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/platformIntegration/ExternalPlatformDropdown.tsx
@@ -14,7 +14,6 @@ import { CaretDownIcon } from '@patternfly/react-icons';
 import { useField } from 'formik';
 import {
   CpuArchitecture,
-  DeveloperPreview,
   FeatureId,
   SupportedCpuArchitecture,
   getFieldId,
@@ -27,6 +26,7 @@ import {
   useNewFeatureSupportLevel,
 } from '../../../../common/components/newFeatureSupportLevels';
 import { architectureData } from '../CpuArchitectureDropdown';
+import { DeveloperPreview } from '../../../../common/components/ui/DeveloperPreview';
 
 const INPUT_NAME = 'platform';
 const fieldId = getFieldId(INPUT_NAME, 'input');


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-16041

Extracts the tech and dev preview components from PreviewBadge.tsx and declares them in their own modules