### PR TITLE
MGMT-16069: OCI is enabled if SNO + OCP version < 4.14 - should be blocked

### DIFF
--- a/libs/ui-lib-tests/cypress/integration/use-cases/create-cluster/with-external-partner-integrations.cy.ts
+++ b/libs/ui-lib-tests/cypress/integration/use-cases/create-cluster/with-external-partner-integrations.cy.ts
@@ -99,6 +99,7 @@ describe('Create a new cluster with external partner integrations', () => {
     });
 
     it('Validate that Nutanix option is disabled when we choose SNO option', () => {
+      ClusterDetailsForm.openshiftVersionField.selectVersion('4.14');
       ClusterDetailsForm.snoField.findCheckbox().click();
       ClusterDetailsForm.externalPartnerIntegrationsField
         .findDropdownItem('Nutanix')

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/platformIntegration/ExternalPlatformDropdown.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/platformIntegration/ExternalPlatformDropdown.tsx
@@ -52,19 +52,19 @@ const getDisabledReasonForExternalPlatform = (
   featureSupportLevelData?: NewFeatureSupportLevelMap | null,
   cpuArchitecture?: SupportedCpuArchitecture,
 ): string | undefined => {
-  if (!isSNO) {
+  if (isSNO && (platform === 'nutanix' || platform === 'vsphere')) {
+    return `${ExternalPlatformLabels[platform]} integration is not supported for Single-Node OpenShift.`;
+  } else if (
+    isSNO &&
+    (cpuArchitecture === CpuArchitecture.ppc64le || cpuArchitecture === CpuArchitecture.s390x)
+  ) {
+    return `Plaform integration is not supported for Single-Node OpenShift with the selected CPU architecture.`;
+  } else {
     return newFeatureSupportLevelContext.getFeatureDisabledReason(
       ExternalPlaformIds[platform] as FeatureId,
       featureSupportLevelData ?? undefined,
       cpuArchitecture,
     );
-  } else if (platform === 'nutanix' || platform === 'vsphere') {
-    return `${ExternalPlatformLabels[platform]} integration is not supported for Single-Node OpenShift.`;
-  } else if (
-    cpuArchitecture === CpuArchitecture.ppc64le ||
-    cpuArchitecture === CpuArchitecture.s390x
-  ) {
-    return `Plaform integration is not supported for Single-Node OpenShift with the selected CPU architecture.`;
   }
 };
 


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-16069

Before changes:
![Captura desde 2023-10-30 14-13-33](https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/74f44f3a-8334-4c11-bc48-05d9c1c9e635)

After changes:
![image](https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/7c04c9ec-91b0-4e72-8ce0-a4e200ee14b5)
