### PR TITLE
MGMT-15919: If day1 cluster is ARM cpu arch, then only ARM nodes can be added in Day2

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/CpuArchitectureDropdown.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/CpuArchitectureDropdown.tsx
@@ -63,9 +63,10 @@ const fieldId = getFieldId(INPUT_NAME, 'input');
 const isCpuArchitectureSupported = (
   cpuArchitectures: SupportedCpuArchitecture[],
   cpuArchitecture: SupportedCpuArchitecture,
+  isArmDay1CpuArch: boolean,
 ): boolean => {
   const cpuArchFound = cpuArchitectures.find((cpuArch) => cpuArch === cpuArchitecture);
-  return cpuArchFound !== undefined;
+  return cpuArchFound !== undefined && !isArmDay1CpuArch;
 };
 
 type CpuArchitectureDropdownProps = {
@@ -166,6 +167,7 @@ const CpuArchitectureDropdown = ({
     const isSelectedCpuArchitectureSupported = isCpuArchitectureSupported(
       cpuArchitectures,
       selectedCpuArchitecture,
+      day1CpuArchitecture === CpuArchitecture.ARM,
     );
     if (
       !isSelectedCpuArchitectureSupported &&
@@ -178,7 +180,7 @@ const CpuArchitectureDropdown = ({
       prevVersionRef.current = openshiftVersion;
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [openshiftVersion, selectedCpuArchitecture]);
+  }, [cpuArchitectures, openshiftVersion, selectedCpuArchitecture]);
 
   const toggle = React.useMemo(
     () => (


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-15919

Before chages, when open the add hosts tab in arm cluster, default is still x86, although its disabled:
![image](https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/042f4e6d-88b7-4417-b81f-e9b83a61f0c5)


After changes, when open the add hosts tab in arm cluster, default is arm:
![image](https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/3a71e921-5655-49eb-b6be-3c612604a0d3)
