### PR TITLE
MGMT-16027: Base domain helper info should be updated

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/OcmBaseDomainField.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/OcmBaseDomainField.tsx
@@ -22,11 +22,11 @@ export const BaseDnsHelperText = ({
   baseDnsDomain?: string;
 }) => (
   <HelperText fieldId={fieldId}>
-    Enter the name of your local host [localhost] or [localhost.com]. This cannot be changed after
-    creation. All DNS records must include the cluster name and be subdomains of the base you enter.
-    The full cluster address will be: <br />
+    Enter the name of your domain [domainname] or [domainname.com]. This cannot be changed after
+    cluster installed. All DNS records must include the cluster name and be subdomains of the base
+    you enter. The full cluster address will be: <br />
     <strong>
-      {name || '[Cluster Name]'}.{baseDnsDomain || '[localhost.com]'}
+      {name || '[Cluster Name]'}.{baseDnsDomain || '[domainname.com]'}
     </strong>
   </HelperText>
 );


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-16027

New info text for base domain field:
![Captura desde 2023-11-16 13-41-43](https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/e695dbc9-dbfc-434a-918a-b2113948623e)
