### PR TITLE
MGMT-15919: If day1 cluster is ARM cpu arch, then only ARM nodes can be added in Day2 - followup

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/CpuArchitectureDropdown.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/CpuArchitectureDropdown.tsx
@@ -60,13 +60,17 @@ export const architectureData: Record<SupportedCpuArchitecture, CpuArchitectureI
 const INPUT_NAME = 'cpuArchitecture';
 const fieldId = getFieldId(INPUT_NAME, 'input');
 
-const isCpuArchitectureSupported = (
+const isCurrentDefaultCpuArchitecture = (
   cpuArchitectures: SupportedCpuArchitecture[],
   cpuArchitecture: SupportedCpuArchitecture,
-  isArmDay1CpuArch: boolean,
+  day1CpuArchitecture?: SupportedCpuArchitecture,
 ): boolean => {
   const cpuArchFound = cpuArchitectures.find((cpuArch) => cpuArch === cpuArchitecture);
-  return cpuArchFound !== undefined && !isArmDay1CpuArch;
+  return (
+    cpuArchFound === undefined &&
+    cpuArchitecture !== getDefaultCpuArchitecture() &&
+    day1CpuArchitecture !== CpuArchitecture.ARM
+  );
 };
 
 type CpuArchitectureDropdownProps = {
@@ -164,15 +168,12 @@ const CpuArchitectureDropdown = ({
   );
 
   React.useEffect(() => {
-    const isSelectedCpuArchitectureSupported = isCpuArchitectureSupported(
+    const isCurrentDefaultCpuArchitectureSelected = isCurrentDefaultCpuArchitecture(
       cpuArchitectures,
       selectedCpuArchitecture,
-      day1CpuArchitecture === CpuArchitecture.ARM,
+      day1CpuArchitecture,
     );
-    if (
-      !isSelectedCpuArchitectureSupported &&
-      selectedCpuArchitecture !== getDefaultCpuArchitecture()
-    ) {
+    if (isCurrentDefaultCpuArchitectureSelected) {
       setCurrentCpuArch(architectureData[getDefaultCpuArchitecture()].label);
       setOpen(false);
     }


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-15919

If day1 cluster is ARM cpu arch, then only ARM nodes can be added in Day2:
![image](https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/54e51d2d-0145-4478-bcaf-43a845d64adc)

Other options in dropdown are disabled:
![image](https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/0b33929d-046e-43c7-9b11-3e19fc268e28)
