### PR TITLE
MGMT-15125: Remove singular VIPs, continue to use the plural ones

### DIFF
--- a/libs/ui-lib-tests/cypress/fixtures/create-mn/requests.ts
+++ b/libs/ui-lib-tests/cypress/fixtures/create-mn/requests.ts
@@ -2,9 +2,7 @@ import { fakeClusterId } from '../cluster/base-cluster';
 
 const UMNetworkingRequest = {
   api_vips: [],
-  api_vip: '',
   ingress_vips: [],
-  ingress_vip: '',
   cluster_networks: [
     {
       cidr: '10.128.0.0/14',
@@ -26,9 +24,7 @@ const UMNetworkingRequest = {
 
 const NetworkingRequest = {
   api_vips: [{ ip: '192.168.122.10', cluster_id: fakeClusterId }],
-  api_vip: '192.168.122.10',
   ingress_vips: [{ ip: '192.168.122.110', cluster_id: fakeClusterId }],
-  ingress_vip: '192.168.122.110',
   cluster_networks: [
     {
       cidr: '10.128.0.0/14',

--- a/libs/ui-lib-tests/cypress/fixtures/create-sno/5-cluster-ready.ts
+++ b/libs/ui-lib-tests/cypress/fixtures/create-sno/5-cluster-ready.ts
@@ -15,9 +15,7 @@ const clusterReadyBuilder = (baseCluster) => {
         cluster_id: fakeClusterId,
       },
     ],
-    api_vip: '192.168.122.10',
     api_vips: [{ ip: '192.168.122.10', cluster_id: fakeClusterId }],
-    ingress_vip: '192.168.122.110',
     ingress_vips: [{ ip: '192.168.122.110', cluster_id: fakeClusterId }],
     validations_info: JSON.stringify(clusterReadyValidations.clusterValidationsInfo),
   };

--- a/libs/ui-lib-tests/cypress/fixtures/day2-flow/day1-ai-cluster.ts
+++ b/libs/ui-lib-tests/cypress/fixtures/day2-flow/day1-ai-cluster.ts
@@ -7,7 +7,6 @@ const aiCluster = {
   openshift_cluster_id: aiClusterId,
   additional_ntp_source: 'clock.redhat.com',
   ams_subscription_id: day2FlowIds.day1.ocmSubscriptionId,
-  api_vip: '192.168.127.100',
   api_vips: [
     {
       cluster_id: aiClusterId,
@@ -244,7 +243,6 @@ const aiCluster = {
   hyperthreading: 'all',
   ignition_endpoint: {},
   image_info: { created_at: '0001-01-01T00:00:00Z', expires_at: '0001-01-01T00:00:00.000Z' },
-  ingress_vip: '192.168.127.101',
   ingress_vips: [
     {
       cluster_id: aiClusterId,

--- a/libs/ui-lib-tests/cypress/fixtures/dualstack/1-network-ready.ts
+++ b/libs/ui-lib-tests/cypress/fixtures/dualstack/1-network-ready.ts
@@ -46,9 +46,7 @@ const featureUsageDualstack = {
 
 const dualstackClusterBase = {
   ...baseCluster('ai-e2e-dualstack'),
-  apiVip: '192.168.122.10',
   apiVips: [{ ip: '192.168.122.10', clusterId: fakeClusterId }],
-  ingressVip: '192.168.122.110',
   ingressVips: [{ ip: '192.168.122.110', clusterId: fakeClusterId }],
   cluster_networks: [
     {
@@ -100,9 +98,7 @@ const addNetworkItem = (networkItems, data) => {
 
 const withDualStackNetworks = (singleStackCluster) => ({
   ...singleStackCluster,
-  apiVip: '192.168.122.10',
   apiVips: [{ ip: '192.168.122.10', clusterId: fakeClusterId }],
-  ingressVip: '192.168.122.110',
   ingressVips: [{ ip: '192.168.122.110', clusterId: fakeClusterId }],
   cluster_networks: addNetworkItem(singleStackCluster.cluster_networks, {
     cidr: 'fd01::/48',

--- a/libs/ui-lib-tests/cypress/fixtures/dualstack/requests.ts
+++ b/libs/ui-lib-tests/cypress/fixtures/dualstack/requests.ts
@@ -6,8 +6,6 @@ export const ipv4NetworkingRequest = {
   ssh_public_key: '',
   vip_dhcp_allocation: false,
   api_vips: [{ ip: '192.168.122.10', cluster_id: fakeClusterId }],
-  api_vip: '192.168.122.10',
-  ingress_vip: '192.168.122.110',
   ingress_vips: [{ ip: '192.168.122.110', cluster_id: fakeClusterId }],
   network_type: 'OVNKubernetes',
   machine_networks: [],
@@ -63,7 +61,5 @@ export const dualStackNetworkingRequest = {
   ],
   user_managed_networking: false,
   api_vips: [{ ip: '192.168.122.10', cluster_id: fakeClusterId }],
-  api_vip: '192.168.122.10',
   ingress_vips: [{ ip: '192.168.122.110', cluster_id: fakeClusterId }],
-  ingress_vip: '192.168.122.110',
 };

--- a/libs/ui-lib-tests/cypress/fixtures/storage/storage-cluster.ts
+++ b/libs/ui-lib-tests/cypress/fixtures/storage/storage-cluster.ts
@@ -161,8 +161,8 @@ const storageCluster = {
   user_name: 'admin',
   validations_info: JSON.stringify(clusterValidation),
   vip_dhcp_allocation: false,
-  api_vip: '192.168.122.10',
-  ingress_vip: '192.168.122.110',
+  apiVips: [{ ip: '192.168.122.10', clusterId: fakeClusterId }],
+  ingressVips: [{ ip: '192.168.122.110', clusterId: fakeClusterId }],
 };
 
 export default storageCluster;

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfigurationForm.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfigurationForm.tsx
@@ -14,8 +14,6 @@ import {
   LoadingState,
   NetworkConfigurationValues,
   SecurityFields,
-  selectApiVip,
-  selectIngressVip,
   useAlerts,
   useFormikAutoSave,
 } from '../../../../common';
@@ -201,9 +199,7 @@ const NetworkConfigurationPage = ({ cluster }: { cluster: Cluster }) => {
 
       const params: V2ClusterUpdateParams = {
         apiVips: values.apiVips,
-        apiVip: selectApiVip(values),
         ingressVips: values.ingressVips,
-        ingressVip: selectIngressVip(values),
         sshPublicKey: values.sshPublicKey,
         vipDhcpAllocation: values.vipDhcpAllocation,
         networkType: values.networkType,
@@ -215,9 +211,7 @@ const NetworkConfigurationPage = ({ cluster }: { cluster: Cluster }) => {
 
       if (params.userManagedNetworking) {
         params.apiVips = [];
-        params.apiVip = '';
         params.ingressVips = [];
-        params.ingressVip = '';
         if (isMultiNodeCluster) {
           delete params.machineNetworks;
         }
@@ -225,9 +219,7 @@ const NetworkConfigurationPage = ({ cluster }: { cluster: Cluster }) => {
         // cluster-managed can't be chosen in SNO, so this must be a multi-node cluster
         if (values.vipDhcpAllocation) {
           delete params.apiVips;
-          delete params.apiVip;
           delete params.ingressVips;
-          delete params.ingressVip;
         } else if (values.stackType === IPV4_STACK) {
           // The API will rebuild the default machineNetwork
           params.machineNetworks = [];

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/review/ReviewNetworkingTable.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/review/ReviewNetworkingTable.tsx
@@ -59,7 +59,8 @@ export const ReviewNetworkingTable = ({ cluster }: { cluster: Cluster }) => {
         ],
       });
 
-    cluster.apiVip &&
+    cluster.apiVips &&
+      cluster.apiVips.length > 0 &&
       networkRows.push({
         rowId: 'api-ip',
         cells: [
@@ -71,7 +72,8 @@ export const ReviewNetworkingTable = ({ cluster }: { cluster: Cluster }) => {
         ],
       });
 
-    cluster.ingressVip &&
+    cluster.ingressVips &&
+      cluster.ingressVips.length &&
       networkRows.push({
         rowId: 'ingress-ip',
         cells: [


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-15125

UI to remove the Singular VIPs completely from the codebase and keep using plural VIPs.
