### PR TITLE
MGMT-15125: Remove singular VIPs, continue to use the plural ones - followup

### DIFF
--- a/libs/ui-lib/lib/cim/components/ClusterDeployment/networkConfigurationValidation.ts
+++ b/libs/ui-lib/lib/cim/components/ClusterDeployment/networkConfigurationValidation.ts
@@ -58,8 +58,8 @@ export const getNetworkInitialValues = (
       selectClusterNetworkHostPrefix(cluster) || defaultNetworkSettings.clusterNetworkHostPrefix,
     serviceNetworkCidr:
       selectServiceNetworkCIDR(cluster) || defaultNetworkSettings.serviceNetworkCidr,
-    apiVip: cluster.apiVip || '',
-    ingressVip: cluster.ingressVip || '',
+    apiVips: cluster.apiVips,
+    ingressVips: cluster.ingressVips,
     sshPublicKey: cluster.sshPublicKey || '',
     hostSubnet: getInitHostSubnet(cluster, managedNetworkingType) || NO_SUBNET_SET,
     vipDhcpAllocation: cluster.vipDhcpAllocation,

--- a/libs/ui-lib/lib/cim/components/helpers/toAssisted.ts
+++ b/libs/ui-lib/lib/cim/components/helpers/toAssisted.ts
@@ -135,8 +135,14 @@ export const getAICluster = ({
     name: clusterDeployment.spec?.clusterName,
     baseDnsDomain: clusterDeployment.spec?.baseDomain,
     openshiftVersion: installVersion,
-    apiVip: agentClusterInstall?.status?.apiVIP || agentClusterInstall?.spec?.apiVIP,
-    ingressVip: agentClusterInstall?.status?.ingressVIP || agentClusterInstall?.spec?.apiVIP,
+    apiVips: [
+      {
+        ip: agentClusterInstall?.status?.apiVIP || agentClusterInstall?.spec?.apiVIP,
+      },
+    ],
+    ingressVips: [
+      { ip: agentClusterInstall?.status?.ingressVIP || agentClusterInstall?.spec?.apiVIP },
+    ],
     highAvailabilityMode:
       agentClusterInstall?.spec?.provisionRequirements?.controlPlaneAgents === 1 ? 'None' : 'Full',
     status,

--- a/libs/ui-lib/lib/common/components/clusterWizard/networkingSteps/VirtualIPControlGroup.tsx
+++ b/libs/ui-lib/lib/common/components/clusterWizard/networkingSteps/VirtualIPControlGroup.tsx
@@ -9,10 +9,10 @@ import { FeatureSupportLevelBadge } from '../../featureSupportLevels';
 import { useTranslation } from '../../../hooks/use-translation-wrapper';
 import { TFunction } from 'i18next';
 import { getVipValidationsById } from '../../clusterConfiguration';
-import { selectApiVip } from '../../../selectors';
+import { selectApiVip, selectIngressVip } from '../../../selectors';
 
 interface VipStaticValueProps {
-  vipName: 'apiVip' | 'ingressVip';
+  vipName: 'apiVips' | 'ingressVips';
   cluster: Cluster;
   validationErrorMessage?: string;
 }
@@ -124,12 +124,12 @@ export const VirtualIPControlGroup = ({
             label={t('ai:API IP')}
             name="apiVip"
             helperText={apiVipHelperText}
-            value={cluster.apiVip || ''}
+            value={selectApiVip(cluster)}
             isValid={!apiVipFailedValidationMessage}
             isRequired
           >
             <VipStaticValue
-              vipName="apiVip"
+              vipName="apiVips"
               cluster={cluster}
               validationErrorMessage={apiVipFailedValidationMessage}
             />
@@ -138,12 +138,12 @@ export const VirtualIPControlGroup = ({
             label={t('ai:Ingress IP')}
             name="ingressVip"
             helperText={ingressVipHelperText}
-            value={cluster.ingressVip || ''}
+            value={selectIngressVip(cluster)}
             isValid={!ingressVipFailedValidationMessage}
             isRequired
           >
             <VipStaticValue
-              vipName="ingressVip"
+              vipName="ingressVips"
               cluster={cluster}
               validationErrorMessage={ingressVipFailedValidationMessage}
             />

--- a/libs/ui-lib/lib/common/types/clusters.ts
+++ b/libs/ui-lib/lib/common/types/clusters.ts
@@ -37,9 +37,7 @@ export type NetworkConfigurationValues = Pick<
   | 'clusterNetworkHostPrefix'
   | 'serviceNetworkCidr'
   | 'apiVips'
-  | 'apiVip'
   | 'ingressVips'
-  | 'ingressVip'
   | 'sshPublicKey'
   | 'vipDhcpAllocation'
   | 'networkType'
@@ -50,6 +48,8 @@ export type NetworkConfigurationValues = Pick<
   hostSubnet?: string;
   managedNetworkingType: 'userManaged' | 'clusterManaged';
   stackType?: 'singleStack' | 'dualStack';
+  apiVip?: string;
+  ingressVip?: string;
 };
 export type HostDiscoveryValues = V2ClusterUpdateParams & {
   usePlatformIntegration: boolean;


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-15125

We need to update our assisted-installer-service.d.ts with new changes of swagger.yaml from assisted-service to remove deprecated  api_vip and ingress_vip fields. (https://github.com/openshift/assisted-service/pull/5734)