### PR TITLE
MGMT-16278: Platform integration dropdown remains disabled when CPU architecture dropdown is changed automatically to x86_64

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/CpuArchitectureDropdown.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/CpuArchitectureDropdown.tsx
@@ -173,6 +173,7 @@ const CpuArchitectureDropdown = ({
       !isSelectedCpuArchitectureSupported &&
       selectedCpuArchitecture !== getDefaultCpuArchitecture()
     ) {
+      setValue(getDefaultCpuArchitecture());
       setCurrentCpuArch(architectureData[getDefaultCpuArchitecture()].label);
       setOpen(false);
     }


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-16278

Now when we updating CpuArchitectureDropdown with default CPU architecture when selected CPU architecture is not supported the ExternalPlatformDropdown is correctly updated.


https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/457c392d-3e43-462d-b15a-3db2ab77a59d

