### PR TITLE
MGMT-16354: Problem adding hosts when platform type is not none,baremetal,nutanix,vsphere,oci

### DIFF
--- a/libs/ui-lib/lib/ocm/services/Day2ClusterService.ts
+++ b/libs/ui-lib/lib/ocm/services/Day2ClusterService.ts
@@ -1,6 +1,12 @@
 import { InfraEnvsService } from '.';
 import { ClustersAPI } from './apis';
-import { CpuArchitecture, SupportedCpuArchitecture } from '../../common';
+import {
+  CpuArchitecture,
+  NonPlatformIntegrations,
+  SupportedCpuArchitecture,
+  SupportedPlatformIntegrations,
+  SupportedPlatformType,
+} from '../../common';
 import { OcmClusterType } from '../components/AddHosts/types';
 import { mapOcmArchToCpuArchitecture } from './CpuArchitectureService';
 import {
@@ -35,7 +41,13 @@ export const getApiVipDnsName = (ocmCluster: OcmClusterType) => {
 };
 
 export const mapCloudProviderToPlatformType = (cloudProviderId?: string) => {
-  const platformType = cloudProviderId === 'external' ? 'oci' : cloudProviderId;
+  let platformType = cloudProviderId === 'external' ? 'oci' : cloudProviderId;
+  if (
+    !SupportedPlatformIntegrations.includes(platformType as SupportedPlatformType) &&
+    !NonPlatformIntegrations.includes(platformType as SupportedPlatformType)
+  ) {
+    platformType = 'baremetal';
+  }
   const platform: Platform = {
     type: (platformType as PlatformType) || 'baremetal',
   };


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-16354

Trying to add hosts in day2 throws an error when external_id of cluster is not none,baremetal,vsphere,nutanix or external.