### PR TITLE
MGMT-16392: NTP text box allows to add empty string and browser freeze

### DIFF
--- a/libs/ui-lib/lib/common/components/ui/formik/AdditionalNTPSourcesField.tsx
+++ b/libs/ui-lib/lib/common/components/ui/formik/AdditionalNTPSourcesField.tsx
@@ -20,7 +20,7 @@ const AdditionalNTPSourcesField: React.FC<AdditionalNTPSourcesFieldProps> = ({
 }) => {
   const [field, , { setValue, setTouched }] = useField<string>(name);
   const formatAdditionalNtpSources = () => {
-    if (field.value) {
+    if (field.value && field.value !== '') {
       setValue(trimCommaSeparatedList(field.value));
       setTouched(true);
     }

--- a/libs/ui-lib/lib/common/components/ui/formik/validationSchemas.ts
+++ b/libs/ui-lib/lib/common/components/ui/formik/validationSchemas.ts
@@ -608,7 +608,7 @@ export const ntpSourceValidationSchema = Yup.string()
     'ntp-source-validation',
     'Provide a comma separated list of valid DNS names or IP addresses.',
     (value: string) => {
-      if (!value) {
+      if (!value || value === '') {
         return true;
       }
       return trimCommaSeparatedList(value)
@@ -620,6 +620,9 @@ export const ntpSourceValidationSchema = Yup.string()
     'ntp-source-validation-unique',
     'DNS names and IP addresses must be unique.',
     (value: string) => {
+      if (!value || value === '') {
+        return true;
+      }
       const arr = trimCommaSeparatedList(value).split(',');
       return arr.length === new Set(arr).size;
     },


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-16392

In the NTP dialog when we add an empty string we need to avoid browser freeze.

![Captura desde 2023-12-13 09-18-10](https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/0e7dd8f8-8fc7-412a-8614-f7e669bd8b22)
