### PR TITLE
MGMT-16197: Change the way to download kubeconfig logs

### DIFF
--- a/libs/ui-lib/lib/common/components/clusterDetail/KubeconfigDownload.tsx
+++ b/libs/ui-lib/lib/common/components/clusterDetail/KubeconfigDownload.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { saveAs } from 'file-saver';
 import { Button, ButtonVariant } from '@patternfly/react-core';
 import { canDownloadKubeconfig } from '../hosts/utils';
 import { useAlerts } from '../AlertsContextProvider';
@@ -10,6 +9,7 @@ import ClustersAPI from '../../api/assisted-service/ClustersAPI';
 import { AxiosHeaderValue, AxiosHeaders, AxiosResponseHeaders } from 'axios';
 import { useTranslation } from '../../hooks/use-translation-wrapper';
 import { TFunction } from 'i18next';
+import { downloadFile } from '../../utils';
 
 type KubeconfigDownloadProps = {
   className?: string;
@@ -56,12 +56,12 @@ const KubeconfigDownload: React.FC<KubeconfigDownloadProps> = ({
             clusterId,
             fileName: 'kubeconfig',
           });
-          saveAs(data.url);
+          downloadFile(data.url);
         } else {
           const response = await ClustersAPI.downloadClusterCredentials(clusterId, 'kubeconfig');
           const fileName = getKubeconfigFileName(response.headers);
 
-          saveAs(response.data, fileName);
+          downloadFile('', response.data, fileName);
         }
       } catch (e) {
         handleApiError(e, (e) => {

--- a/libs/ui-lib/lib/common/utils.ts
+++ b/libs/ui-lib/lib/common/utils.ts
@@ -87,3 +87,21 @@ export const stringToJSON = <T>(jsonString: string | undefined): T | undefined =
 
   return jsObject;
 };
+
+export const downloadFile = (fileUrl?: string, dataBlob?: Blob, fileName?: string) => {
+  const link = document.createElement('a');
+  if (fileUrl && fileUrl !== '') {
+    link.setAttribute('href', fileUrl);
+  }
+  if (dataBlob) {
+    const file = new Blob([dataBlob], { type: 'text' });
+    link.setAttribute('href', URL.createObjectURL(file));
+  }
+  if (fileName) {
+    link.setAttribute('download', fileName);
+  }
+  link.style.visibility = 'hidden';
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+};

--- a/libs/ui-lib/lib/ocm/components/clusterDetail/utils.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterDetail/utils.tsx
@@ -3,7 +3,7 @@ import { isInOcm, handleApiError, getApiErrorMessage } from '../../../common/api
 import { AlertsContextType, hostStatusOrder } from '../../../common';
 import { ClustersAPI } from '../../services/apis';
 import { ClustersService } from '../../services';
-import { stringToJSON } from '../../../common/utils';
+import { downloadFile, stringToJSON } from '../../../common/utils';
 import {
   Cluster,
   Host,
@@ -23,10 +23,10 @@ export const downloadClusterInstallationLogs = async (
         hostId: undefined,
         logsType: 'all',
       });
-      download(data.url);
+      downloadFile(data.url);
     } else {
       const { data, fileName } = await ClustersService.downloadLogs(clusterId);
-      download('', data, fileName);
+      downloadFile('', data, fileName);
     }
   } catch (e) {
     handleApiError(e, (e) => {
@@ -96,22 +96,4 @@ export const getMostSevereHostStatus = (hosts: Host[]) => {
     }
   }
   return status;
-};
-
-const download = (fileUrl?: string, dataBlob?: Blob, fileName?: string) => {
-  const link = document.createElement('a');
-  if (fileUrl && fileUrl !== '') {
-    link.setAttribute('href', fileUrl);
-  }
-  if (dataBlob) {
-    const file = new Blob([dataBlob], { type: 'text' });
-    link.setAttribute('href', URL.createObjectURL(file));
-  }
-  if (fileName) {
-    link.setAttribute('download', fileName);
-  }
-  link.style.visibility = 'hidden';
-  document.body.appendChild(link);
-  link.click();
-  document.body.removeChild(link);
 };


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-16197

Changes the way that UI is downloading kubeconfig logs (with file-saver library) because some files don't work in some browsers. The problem is that file-saver try to download logs open a popup and some browsers have popup blockers and then don't work. (Related to https://github.com/openshift-assisted/assisted-installer-ui/pull/2431)