### PR TITLE
MGMT-15692: Use the new API to define oci platform  - followup

### DIFF
--- a/libs/types/assisted-installer-service.d.ts
+++ b/libs/types/assisted-installer-service.d.ts
@@ -2191,11 +2191,6 @@ export type OsImages = OsImage[];
 export interface Platform {
   type: PlatformType;
   external?: PlatformExternal;
-  /**
-   * Used by the service to indicate that the platform-specific components are not included in
-   * OpenShift and must be provided as manifests separately.
-   */
-  readonly isExternal?: boolean;
 }
 /**
  * Configuration used when installing with an external platform type.
@@ -2210,7 +2205,7 @@ export interface PlatformExternal {
    */
   cloudControllerManager?: '' | 'External';
 }
-export type PlatformType = 'baremetal' | 'nutanix' | 'vsphere' | 'none' | 'oci' | 'external';
+export type PlatformType = 'baremetal' | 'nutanix' | 'vsphere' | 'none' | 'external';
 export interface PreflightHardwareRequirements {
   /**
    * Preflight operators hardware requirements
@@ -2619,7 +2614,8 @@ export interface V2SupportLevelsArchitectures {
 export interface V2SupportLevelsFeatures {
   openshiftVersion: string;
   cpuArchitecture?: 'x86_64' | 'aarch64' | 'arm64' | 'ppc64le' | 's390x' | 'multi';
-  platformType?: 'baremetal' | 'none' | 'nutanix' | 'vsphere' | 'oci' | 'external';
+  platformType?: 'baremetal' | 'none' | 'nutanix' | 'vsphere' | 'external';
+  externalPlatformName?: string;
 }
 /**
  * Single VIP verification result.

--- a/libs/ui-lib-tests/cypress/fixtures/cluster/external-platform-types.ts
+++ b/libs/ui-lib-tests/cypress/fixtures/cluster/external-platform-types.ts
@@ -9,7 +9,7 @@ export const externalPlatformTypes = {
     href: 'https://access.redhat.com/solutions/6983944',
     tooltip: '',
   },
-  oci: {
+  external: {
     label: 'Oracle Cloud Infrastructure (Requires a custom manifest)',
     href: '',
     tooltip:

--- a/libs/ui-lib/lib/common/api/assisted-service/NewFeatureSupportLevelsAPI.ts
+++ b/libs/ui-lib/lib/common/api/assisted-service/NewFeatureSupportLevelsAPI.ts
@@ -17,6 +17,7 @@ const NewFeatureSupportLevelsAPI = {
           openshift_version: openshiftVersion,
           cpu_architecture: cpuArchitecture,
           platform_type: platformType,
+          ...(platformType === 'external' ? { external_platform_name: 'oci' } : {}),
         },
       },
     );

--- a/libs/ui-lib/lib/common/types/clusters.ts
+++ b/libs/ui-lib/lib/common/types/clusters.ts
@@ -65,9 +65,13 @@ export type OperatorsValues = V2ClusterUpdateParams & {
   useMultiClusterEngine: boolean;
 };
 
-export type SupportedPlatformType = Extract<PlatformType, 'vsphere' | 'nutanix' | 'oci'>;
+export type SupportedPlatformType = Extract<PlatformType, 'vsphere' | 'nutanix' | 'external'>;
 
-export const SupportedPlatformIntegrations: SupportedPlatformType[] = ['vsphere', 'nutanix', 'oci'];
+export const SupportedPlatformIntegrations: SupportedPlatformType[] = [
+  'vsphere',
+  'nutanix',
+  'external',
+];
 export const NonPlatformIntegrations: PlatformType[] = ['baremetal', 'none'];
 
 export type DiscoveryImageType = ImageType | 'discovery-image-ipxe';

--- a/libs/ui-lib/lib/ocm/components/AddHosts/day2Wizard/Day2ClusterDetails.tsx
+++ b/libs/ui-lib/lib/ocm/components/AddHosts/day2Wizard/Day2ClusterDetails.tsx
@@ -242,7 +242,10 @@ const Day2ClusterDetails = () => {
                 )}
                 <GridItem>
                   <Day2HostStaticIpConfigurations
-                    isDisabled={day2Cluster.platform?.type === 'oci'}
+                    isDisabled={
+                      day2Cluster.platform?.type === 'external' &&
+                      day2Cluster.platform?.external?.platformName === 'oci'
+                    }
                   />
                 </GridItem>
               </Grid>

--- a/libs/ui-lib/lib/ocm/components/AddHosts/day2Wizard/Day2ClusterDetails.tsx
+++ b/libs/ui-lib/lib/ocm/components/AddHosts/day2Wizard/Day2ClusterDetails.tsx
@@ -29,6 +29,7 @@ import {
   InfraEnv,
   InfraEnvCreateParams,
 } from '@openshift-assisted/types/assisted-installer-service';
+import { isOciPlatformType } from '../../utils';
 
 const getDay2ClusterDetailInitialValues = async (
   clusterId: Cluster['id'],
@@ -241,12 +242,7 @@ const Day2ClusterDetails = () => {
                   </GridItem>
                 )}
                 <GridItem>
-                  <Day2HostStaticIpConfigurations
-                    isDisabled={
-                      day2Cluster.platform?.type === 'external' &&
-                      day2Cluster.platform?.external?.platformName === 'oci'
-                    }
-                  />
+                  <Day2HostStaticIpConfigurations isDisabled={isOciPlatformType(day2Cluster)} />
                 </GridItem>
               </Grid>
             </Form>

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/DiscoveryImageForm.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/DiscoveryImageForm.tsx
@@ -114,7 +114,9 @@ const DiscoveryImageForm = ({
           ? mapClusterCpuArchToInfraEnvCpuArch(infraEnv.cpuArchitecture)
           : mapClusterCpuArchToInfraEnvCpuArch(cpuArchitecture)
       }
-      isOracleCloudInfrastructure={cluster.platform?.type === 'oci'}
+      isOracleCloudInfrastructure={
+        cluster.platform?.type === 'external' && cluster.platform?.external?.platformName === 'oci'
+      }
     />
   );
 };

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/DiscoveryImageForm.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/DiscoveryImageForm.tsx
@@ -18,6 +18,7 @@ import {
 import { mapClusterCpuArchToInfraEnvCpuArch } from '../../services/CpuArchitectureService';
 import { usePullSecret } from '../../hooks';
 import { Cluster } from '@openshift-assisted/types/assisted-installer-service';
+import { isOciPlatformType } from '../utils';
 
 type DiscoveryImageFormProps = {
   cluster: Cluster;
@@ -114,9 +115,7 @@ const DiscoveryImageForm = ({
           ? mapClusterCpuArchToInfraEnvCpuArch(infraEnv.cpuArchitecture)
           : mapClusterCpuArchToInfraEnvCpuArch(cpuArchitecture)
       }
-      isOracleCloudInfrastructure={
-        cluster.platform?.type === 'external' && cluster.platform?.external?.platformName === 'oci'
-      }
+      isOracleCloudInfrastructure={isOciPlatformType(cluster)}
     />
   );
 };

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/OcmClusterDetailsFormFields.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/OcmClusterDetailsFormFields.tsx
@@ -92,7 +92,7 @@ export const OcmClusterDetailsFormFields = ({
 
   const handleExternalPartnerIntegrationsChange = React.useCallback(
     (selectedPlatform: PlatformType) => {
-      const isOracleSelected = selectedPlatform === 'oci';
+      const isOracleSelected = selectedPlatform === 'external';
       if (isOracleSelected) {
         setFieldValue('addCustomManifest', isOracleSelected, false);
         clusterWizardContext.setCustomManifestsStep(isOracleSelected);
@@ -178,14 +178,14 @@ export const OcmClusterDetailsFormFields = ({
         />
       )}
 
-      <CustomManifestCheckbox clusterId={clusterId || ''} isDisabled={platform === 'oci'} />
+      <CustomManifestCheckbox clusterId={clusterId || ''} isDisabled={platform === 'external'} />
 
       {
         // Reason: In the single-cluster flow, the Host discovery phase is replaced by a single one-fits-all ISO download
         !isSingleClusterFeatureEnabled && (
           <HostsNetworkConfigurationControlGroup
             clusterExists={clusterExists}
-            isDisabled={platform === 'oci'}
+            isDisabled={platform === 'external'}
           />
         )
       }

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfiguration.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfiguration.tsx
@@ -227,12 +227,12 @@ const NetworkConfiguration = ({
     () =>
       getManagedNetworkingState(
         isDualStack,
-        cluster.platform?.type === 'oci',
+        cluster.platform?.type === 'external' && cluster.platform.external?.platformName === 'oci',
         featureSupportLevelContext,
         cluster.platform?.type,
         featureSupportLevelData,
       ),
-    [isDualStack, cluster.platform?.type, featureSupportLevelContext, featureSupportLevelData],
+    [isDualStack, cluster.platform, featureSupportLevelContext, featureSupportLevelData],
   );
 
   return (

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfiguration.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfiguration.tsx
@@ -37,6 +37,7 @@ import {
   PlatformType,
 } from '@openshift-assisted/types/assisted-installer-service';
 import useSupportLevelsAPI from '../../../hooks/useSupportLevelsAPI';
+import { isOciPlatformType } from '../../utils';
 
 export type NetworkConfigurationProps = VirtualIPControlGroupProps & {
   hostSubnets: HostSubnets;
@@ -227,12 +228,12 @@ const NetworkConfiguration = ({
     () =>
       getManagedNetworkingState(
         isDualStack,
-        cluster.platform?.type === 'external' && cluster.platform.external?.platformName === 'oci',
+        isOciPlatformType(cluster),
         featureSupportLevelContext,
         cluster.platform?.type,
         featureSupportLevelData,
       ),
-    [isDualStack, cluster.platform, featureSupportLevelContext, featureSupportLevelData],
+    [isDualStack, cluster, featureSupportLevelContext, featureSupportLevelData],
   );
 
   return (

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/platformIntegration/ExternalPlatformDropdown.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/platformIntegration/ExternalPlatformDropdown.tsx
@@ -75,7 +75,7 @@ const getExternalPlatformTypes = (
   featureSupportLevelData?: NewFeatureSupportLevelMap | null,
   cpuArchitecture?: SupportedCpuArchitecture,
 ): Partial<{ [key in PlatformType]: ExternalPlatformInfo }> => {
-  const platforms = ['none', 'nutanix', showOciOption && 'oci', 'vsphere'] as PlatformType[];
+  const platforms = ['none', 'nutanix', showOciOption && 'external', 'vsphere'] as PlatformType[];
 
   return platforms.filter(Boolean).reduce(
     (a, platform) => ({
@@ -171,7 +171,7 @@ export const ExternalPlatformDropdown = ({
             <Tooltip hidden={!disabledReason} content={disabledReason} position="top">
               <div>
                 {label}
-                {platform === 'oci' && <DeveloperPreview testId={'oci-support-level`'} />}
+                {platform === 'external' && <DeveloperPreview testId={'oci-support-level`'} />}
               </div>
             </Tooltip>
           </SplitItem>

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/platformIntegration/constants.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/platformIntegration/constants.tsx
@@ -5,9 +5,8 @@ export const ExternalPlatformLabels: { [key in PlatformType]: string } = {
   baremetal: 'No platform integration',
   none: 'No platform integration',
   nutanix: 'Nutanix',
-  oci: 'Oracle Cloud Infrastructure (Requires a custom manifest)',
+  external: 'Oracle Cloud Infrastructure (Requires a custom manifest)',
   vsphere: 'vSphere',
-  external: '',
 };
 
 export const ExternalPlatformLinks: Partial<{ [key in PlatformType]: string }> = {
@@ -19,7 +18,6 @@ export const ExternalPlaformIds: { [key in PlatformType]: string } = {
   baremetal: '',
   none: '',
   nutanix: 'NUTANIX_INTEGRATION',
-  oci: 'EXTERNAL_PLATFORM_OCI',
+  external: 'EXTERNAL_PLATFORM_OCI',
   vsphere: 'VSPHERE_INTEGRATION',
-  external: '',
 };

--- a/libs/ui-lib/lib/ocm/components/utils.ts
+++ b/libs/ui-lib/lib/ocm/components/utils.ts
@@ -1,0 +1,7 @@
+import { Cluster } from '@openshift-assisted/types/./assisted-installer-service';
+
+export const isOciPlatformType = (cluster: Cluster): boolean => {
+  return (
+    cluster.platform?.type === 'external' && cluster.platform?.external?.platformName === 'oci'
+  );
+};

--- a/libs/ui-lib/lib/ocm/services/ClusterDetailsService.ts
+++ b/libs/ui-lib/lib/ocm/services/ClusterDetailsService.ts
@@ -44,6 +44,14 @@ const ClusterDetailsService = {
       diskEncryption: DiskEncryptionService.getDiskEncryptionParams(values),
       platform: {
         type: values.platform,
+        ...(values.platform === 'external'
+          ? {
+              external: {
+                platformName: 'oci',
+                cloudControllerManager: 'External',
+              },
+            }
+          : {}),
       },
     };
 
@@ -76,9 +84,13 @@ const ClusterDetailsService = {
     }
 
     if (platform) {
-      params.platform = {
-        type: platform,
-      };
+      params.platform =
+        platform === 'external'
+          ? {
+              type: platform,
+              external: { platformName: 'oci', cloudControllerManager: 'External' },
+            }
+          : { type: platform };
     }
 
     return params;

--- a/libs/ui-lib/lib/ocm/services/ClustersService.ts
+++ b/libs/ui-lib/lib/ocm/services/ClustersService.ts
@@ -33,7 +33,7 @@ const ClustersService = {
       staticNetworkConfig: params.staticNetworkConfig,
     };
 
-    if (params.platform?.type === 'oci') {
+    if (params.platform?.type === 'external' && params.platform.external?.platformName === 'oci') {
       infraEnvCreateParams.imageType = 'minimal-iso';
     }
 

--- a/libs/ui-lib/lib/ocm/services/Day2ClusterService.ts
+++ b/libs/ui-lib/lib/ocm/services/Day2ClusterService.ts
@@ -41,7 +41,7 @@ export const getApiVipDnsName = (ocmCluster: OcmClusterType) => {
 };
 
 export const mapCloudProviderToPlatformType = (cloudProviderId?: string) => {
-  let platformType = cloudProviderId === 'external' ? 'oci' : cloudProviderId;
+  let platformType = cloudProviderId === 'external' ? 'external' : cloudProviderId;
   if (
     !SupportedPlatformIntegrations.includes(platformType as SupportedPlatformType) &&
     !NonPlatformIntegrations.includes(platformType as SupportedPlatformType)
@@ -51,6 +51,12 @@ export const mapCloudProviderToPlatformType = (cloudProviderId?: string) => {
   const platform: Platform = {
     type: (platformType as PlatformType) || 'baremetal',
   };
+  if (platformType === 'external') {
+    platform.external = {
+      platformName: 'oci',
+      cloudControllerManager: 'External',
+    };
+  }
   return platform;
 };
 

--- a/libs/ui-lib/lib/ocm/services/Day2ClusterService.ts
+++ b/libs/ui-lib/lib/ocm/services/Day2ClusterService.ts
@@ -41,7 +41,7 @@ export const getApiVipDnsName = (ocmCluster: OcmClusterType) => {
 };
 
 export const mapCloudProviderToPlatformType = (cloudProviderId?: string) => {
-  let platformType = cloudProviderId === 'external' ? 'external' : cloudProviderId;
+  let platformType = cloudProviderId;
   if (
     !SupportedPlatformIntegrations.includes(platformType as SupportedPlatformType) &&
     !NonPlatformIntegrations.includes(platformType as SupportedPlatformType)


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-15692

To use OCI platform 
Instead of

```
platform: {
  type: oci
}
```

we have to use:

```
platform: {
  type: external
  external: {
    platformName: oci,
    CloudControlerManager: External
  }
}
```