### PR TITLE
MGMT-16197: Change the way to download kubeconfig logs - followup

### DIFF
--- a/libs/ui-lib/lib/common/utils.ts
+++ b/libs/ui-lib/lib/common/utils.ts
@@ -94,7 +94,7 @@ export const downloadFile = (fileUrl?: string, dataBlob?: Blob, fileName?: strin
     link.setAttribute('href', fileUrl);
   }
   if (dataBlob) {
-    const file = new Blob([dataBlob], { type: 'text' });
+    const file = new Blob([dataBlob], { type: 'octet/stream' });
     link.setAttribute('href', URL.createObjectURL(file));
   }
   if (fileName) {


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-16197
Solves issue https://issues.redhat.com/browse/MGMT-16430
With last changes to download kubeconfig files, the browser was adding 'txt' extension to the downloaded file.
We need to change the type when we create the blob data to download.