### PR TITLE
MGMT-16480: Remove what's new link outside OCM because does not work

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusters/AssistedInstallerHeader.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusters/AssistedInstallerHeader.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { TextContent, Text, Split, SplitItem } from '@patternfly/react-core';
-import { ASSISTED_INSTALLER_DOCUMENTATION_LINK, ExternalLink } from '../../../common';
+import { ASSISTED_INSTALLER_DOCUMENTATION_LINK, ExternalLink, isInOcm } from '../../../common';
 
 export const AssistedInstallerHeader = () => {
   return (
@@ -14,11 +14,13 @@ export const AssistedInstallerHeader = () => {
             Assisted Installer documentation
           </ExternalLink>
         </SplitItem>
-        <SplitItem>
-          <Text component="a" data-testid="whats-new-link">
-            What's new in Assisted Installer?
-          </Text>
-        </SplitItem>
+        {isInOcm && (
+          <SplitItem>
+            <Text component="a" data-testid="whats-new-link">
+              What's new in Assisted Installer?
+            </Text>
+          </SplitItem>
+        )}
       </Split>
     </TextContent>
   );


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-16480
What's new link is not working in OnPrem AI. We should remove it when we are outside OCM to avoid problems.

![Captura desde 2024-01-04 07-58-55](https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/93b8967e-2d91-4c59-b1cc-8fcfbd3543ff)
