### PR TITLE
MGMT-16481: Add developer preview badge in external platform integration dropdown when platform is dev-preview

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/platformIntegration/ExternalPlatformDropdown.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/platformIntegration/ExternalPlatformDropdown.tsx
@@ -104,6 +104,18 @@ export const areAllExternalPlatformIntegrationDisabled = (
     .every((info) => info.disabledReason !== undefined);
 };
 
+const isPlatformDevPreview = (
+  platform: PlatformType,
+  newFeatureSupportLevelContext: NewFeatureSupportLevelData,
+  featureSupportLevelData?: NewFeatureSupportLevelMap | null,
+): boolean => {
+  const supportLevel = newFeatureSupportLevelContext.getFeatureSupportLevel(
+    ExternalPlaformIds[platform] as FeatureId,
+    featureSupportLevelData ?? undefined,
+  );
+  return platform === 'external' || supportLevel === 'dev-preview';
+};
+
 export const ExternalPlatformDropdown = ({
   showOciOption,
   onChange,
@@ -164,6 +176,7 @@ export const ExternalPlatformDropdown = ({
     const { label, href, disabledReason } = externalPlatformTypes[
       platform as PlatformType
     ] as ExternalPlatformInfo;
+
     return (
       <DropdownItem key={platform} id={platform} isAriaDisabled={disabledReason !== undefined}>
         <Split>
@@ -171,7 +184,11 @@ export const ExternalPlatformDropdown = ({
             <Tooltip hidden={!disabledReason} content={disabledReason} position="top">
               <div>
                 {label}
-                {platform === 'external' && <DeveloperPreview testId={'oci-support-level`'} />}
+                {isPlatformDevPreview(
+                  platform as PlatformType,
+                  newFeatureSupportLevelContext,
+                  featureSupportLevelData,
+                ) && <DeveloperPreview testId={'platform-support-level'} />}
               </div>
             </Tooltip>
           </SplitItem>

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/platformIntegration/ExternalPlatformDropdown.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/platformIntegration/ExternalPlatformDropdown.tsx
@@ -188,7 +188,11 @@ export const ExternalPlatformDropdown = ({
                   platform as PlatformType,
                   newFeatureSupportLevelContext,
                   featureSupportLevelData,
-                ) && <DeveloperPreview testId={'platform-support-level'} />}
+                ) && (
+                  <span onClick={(event) => event.stopPropagation()}>
+                    <DeveloperPreview testId={'platform-support-level'} />
+                  </span>
+                )}
               </div>
             </Tooltip>
           </SplitItem>


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-16481
OCP 4.11 + nutanix integration should have dev-preview badge in UI.  We need to take into consideration the dev-preview from BE response in the external platform integration drodpdown.

![image](https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/e0c8a080-b659-477f-bf71-e41eedc134a6)
