### PR TITLE
MGMT-16475: Change reason for platform dropdown to be disabled

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/platformIntegration/ExternalPlatformDropdown.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/platformIntegration/ExternalPlatformDropdown.tsx
@@ -104,6 +104,14 @@ export const areAllExternalPlatformIntegrationDisabled = (
     .every((info) => info.disabledReason !== undefined);
 };
 
+const getReasonForDropdownDisabled = (isSNO: boolean, labelCpuArch: string): string => {
+  if (!isSNO) {
+    return `Platform integration is not supported when ${labelCpuArch} is selected`;
+  } else {
+    return `Platform integration is not supported for SNO clusters`;
+  }
+};
+
 export const ExternalPlatformDropdown = ({
   showOciOption,
   onChange,
@@ -117,9 +125,10 @@ export const ExternalPlatformDropdown = ({
     Partial<{ [key in PlatformType]: ExternalPlatformInfo }>
   >({});
 
-  const tooltipDropdownDisabled = `Platform integration is not supported when ${
-    cpuArchitecture ? architectureData[cpuArchitecture].label : ''
-  } is selected`;
+  const tooltipDropdownDisabled = getReasonForDropdownDisabled(
+    isSNO,
+    cpuArchitecture ? architectureData[cpuArchitecture].label : '',
+  );
 
   const handleClick = (event: MouseEvent<HTMLButtonElement>, href: string) => {
     event.stopPropagation(); // Stop event propagation here


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-16475

In case of x86 and SNO - UI shows integration box disabled because of "Platform integration is not supported when x86 is selected" and needs to show "Platform integration is not supported for SNO clusters":

![Captura desde 2024-01-08 12-23-31](https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/1139e2df-0f76-4fe9-b06d-74c45ccefbbf)
