### PR TITLE
PreviewBadge: Disable focustrap

### DIFF
--- a/libs/ui-lib/lib/common/components/ui/PreviewBadge.tsx
+++ b/libs/ui-lib/lib/common/components/ui/PreviewBadge.tsx
@@ -49,7 +49,7 @@ export const PreviewBadge: React.FC<PreviewBadgeProps> = ({
   );
   return (
     <span onClick={(e) => e.preventDefault()}>
-      <Popover bodyContent={bodyContent} position="top">
+      <Popover bodyContent={bodyContent} position="top" withFocusTrap={false}>
         <Label
           style={{ cursor: 'pointer' }}
           color="orange"


### PR DESCRIPTION
Addresses https://issues.redhat.com/browse/OCMUI-1240

Visible in Chrome when clicking on the label

![previewbadge_errors](https://github.com/openshift-assisted/assisted-installer-ui/assets/869106/6c970600-59e8-4837-b8ab-d99f5bea54c0)
