### PR TITLE
MGMT-16558: Failed messages not cleaned after download cluster installation logs - 2.30

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusterDetail/ClusterDetailsButtonGroup.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterDetail/ClusterDetailsButtonGroup.tsx
@@ -30,7 +30,7 @@ const ClusterDetailsButtonGroup: React.FC<ClusterDetailsButtonGroupProps> = ({
   credentialsError,
   showKubeConfig = true,
 }) => {
-  const { addAlert } = useAlerts();
+  const { addAlert, clearAlerts } = useAlerts();
   const { cancelInstallationDialog, resetClusterDialog } = useModalDialogsContext();
   const hasConsoleUrlAndNoError = credentials?.consoleUrl !== undefined && !credentialsError;
 
@@ -88,7 +88,7 @@ const ClusterDetailsButtonGroup: React.FC<ClusterDetailsButtonGroupProps> = ({
           data-testid="cluster-installation-logs-button"
           variant={ButtonVariant.link}
           onClick={() => {
-            void downloadClusterInstallationLogs(addAlert, cluster.id);
+            void downloadClusterInstallationLogs(addAlert, cluster.id, clearAlerts);
           }}
           isDisabled={!canDownloadClusterLogs(cluster)}
         >

--- a/libs/ui-lib/lib/ocm/components/clusterDetail/ClusterInstallationError.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterDetail/ClusterInstallationError.tsx
@@ -23,7 +23,7 @@ const ClusterInstallationError: React.FC<ClusterInstallationErrorProps> = ({
   cluster,
   title = 'Cluster installation failed',
 }) => {
-  const { addAlert } = useAlerts();
+  const { addAlert, clearAlerts } = useAlerts();
   const { resetClusterDialog } = useModalDialogsContext();
 
   return (
@@ -41,7 +41,7 @@ const ClusterInstallationError: React.FC<ClusterInstallationErrorProps> = ({
             </AlertActionLink>
             <AlertActionLink
               onClick={() => {
-                void downloadClusterInstallationLogs(addAlert, cluster.id);
+                void downloadClusterInstallationLogs(addAlert, cluster.id, clearAlerts);
               }}
               isDisabled={!canDownloadClusterLogs(cluster)}
               id={getID('button-download-installation-logs')}

--- a/libs/ui-lib/lib/ocm/components/clusterDetail/ProgressBarAlerts.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterDetail/ProgressBarAlerts.tsx
@@ -92,7 +92,7 @@ export const HostInstallationWarning = ({
   failedOperators = [],
   message,
 }: InstallationProgressWarningProps) => {
-  const { addAlert } = useAlerts();
+  const { addAlert, clearAlerts } = useAlerts();
   const { t } = useTranslation();
   const featureSupportLevel = useNewFeatureSupportLevel();
 
@@ -107,7 +107,7 @@ export const HostInstallationWarning = ({
             <AlertActionLink
               id="cluster-installation-logs-button"
               onClick={() => {
-                void downloadClusterInstallationLogs(addAlert, cluster.id);
+                void downloadClusterInstallationLogs(addAlert, cluster.id, clearAlerts);
               }}
               isDisabled={!canDownloadClusterLogs(cluster)}
             >
@@ -143,7 +143,7 @@ export const HostsInstallationFailed = ({
   totalHosts,
   isCriticalNumberOfWorkersFailed,
 }: InstallationProgressWarningProps) => {
-  const { addAlert } = useAlerts();
+  const { addAlert, clearAlerts } = useAlerts();
   const { resetClusterDialog } = useModalDialogsContext();
   const getID = (suffix: string) => `cluster-install-error-${suffix}`;
   let title, message;
@@ -185,7 +185,7 @@ export const HostsInstallationFailed = ({
             <AlertActionLink
               id="cluster-installation-logs-button"
               onClick={() => {
-                void downloadClusterInstallationLogs(addAlert, cluster.id);
+                void downloadClusterInstallationLogs(addAlert, cluster.id, clearAlerts);
               }}
               isDisabled={!canDownloadClusterLogs(cluster)}
             >

--- a/libs/ui-lib/lib/ocm/components/clusterDetail/utils.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterDetail/utils.tsx
@@ -14,7 +14,9 @@ import {
 export const downloadClusterInstallationLogs = async (
   addAlert: AlertsContextType['addAlert'],
   clusterId: string,
+  clearAlerts: AlertsContextType['clearAlerts'],
 ) => {
+  clearAlerts();
   try {
     if (isInOcm) {
       const { data } = await ClustersAPI.getPresignedForClusterFiles({


### PR DESCRIPTION
Backport of #2474 