### PR TITLE
MGMT-16463: Enable LVMS for OCP version 4.15 or above

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/LvmCheckbox.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/LvmCheckbox.tsx
@@ -16,7 +16,10 @@ import {
 import LvmHostRequirements from './LvmHostRequirements';
 import { OcmCheckboxField } from '../../ui/OcmFormFields';
 import { useTranslation } from '../../../../common/hooks/use-translation-wrapper';
-import { getLvmIncompatibleWithCnvReason } from '../../featureSupportLevels/featureStateUtils';
+import {
+  getLvmIncompatibleWithCnvReason,
+  getLvmsIncompatibleWithOdfReason,
+} from '../../featureSupportLevels/featureStateUtils';
 import { useNewFeatureSupportLevel } from '../../../../common/components/newFeatureSupportLevels';
 import NewFeatureSupportLevelBadge from '../../../../common/components/newFeatureSupportLevels/NewFeatureSupportLevelBadge';
 import { SupportLevel } from '@openshift-assisted/types/assisted-installer-service';
@@ -79,6 +82,9 @@ const LvmCheckbox = ({ clusterId }: ClusterOperatorProps) => {
     let reason = featureSupportLevel.getFeatureDisabledReason('LVM');
     if (!reason) {
       reason = getLvmIncompatibleWithCnvReason(values, operatorInfo.lvmSupport);
+      if (!reason) {
+        reason = getLvmsIncompatibleWithOdfReason(values);
+      }
     }
     setDisabledReason(reason);
   }, [values, featureSupportLevel, operatorInfo.lvmSupport]);

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/OdfCheckbox.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/OdfCheckbox.tsx
@@ -1,9 +1,17 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { FormGroup, Tooltip } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons/dist/js/icons/external-link-alt-icon';
-import { getFieldId, PopoverIcon, ODF_REQUIREMENTS_LINK, ODF_LINK } from '../../../../common';
+import {
+  getFieldId,
+  PopoverIcon,
+  ODF_REQUIREMENTS_LINK,
+  ODF_LINK,
+  OperatorsValues,
+} from '../../../../common';
 import { OcmCheckboxField } from '../../ui/OcmFormFields';
 import { useNewFeatureSupportLevel } from '../../../../common/components/newFeatureSupportLevels';
+import { useFormikContext } from 'formik';
+import { getOdfIncompatibleWithLvmsReason } from '../../featureSupportLevels/featureStateUtils';
 
 const ODF_FIELD_NAME = 'useOpenShiftDataFoundation';
 
@@ -37,8 +45,18 @@ const OdfHelperText = () => {
 
 const OdfCheckbox = () => {
   const featureSupportLevelContext = useNewFeatureSupportLevel();
+  const { values } = useFormikContext<OperatorsValues>();
   const fieldId = getFieldId(ODF_FIELD_NAME, 'input');
-  const disabledReason = featureSupportLevelContext.getFeatureDisabledReason('ODF');
+  const [disabledReason, setDisabledReason] = useState<string | undefined>();
+
+  React.useEffect(() => {
+    let disabledReason = featureSupportLevelContext.getFeatureDisabledReason('ODF');
+    if (!disabledReason) {
+      disabledReason = getOdfIncompatibleWithLvmsReason(values);
+    }
+    setDisabledReason(disabledReason);
+  }, [values, featureSupportLevelContext]);
+
   return (
     <FormGroup isInline fieldId={fieldId}>
       <OcmCheckboxField

--- a/libs/ui-lib/lib/ocm/components/clusterWizard/OperatorsStep.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/OperatorsStep.tsx
@@ -11,7 +11,10 @@ import { isOCPVersionEqualsOrMajor } from '../utils';
 
 export const OperatorsStep = (props: ClusterOperatorProps) => {
   const isSNO = useSelector(selectIsCurrentClusterSNO);
-  const isLVMSMultiNodeEnabled = isOCPVersionEqualsOrMajor(props.openshiftVersion || '', '4.15');
+  const isVersionEqualsOrMajorThan4_15 = isOCPVersionEqualsOrMajor(
+    props.openshiftVersion || '',
+    '4.15',
+  );
   return (
     <Stack hasGutter data-testid={'operators-form'}>
       <StackItem>
@@ -23,9 +26,18 @@ export const OperatorsStep = (props: ClusterOperatorProps) => {
       <StackItem>
         <MceCheckbox />
       </StackItem>
-      <StackItem>
-        {isSNO || isLVMSMultiNodeEnabled ? <LvmCheckbox {...props} /> : <OdfCheckbox />}
-      </StackItem>
+      {isVersionEqualsOrMajorThan4_15 ? (
+        <>
+          <StackItem>
+            <LvmCheckbox {...props} />
+          </StackItem>
+          <StackItem>
+            <OdfCheckbox />
+          </StackItem>
+        </>
+      ) : (
+        <StackItem>{isSNO ? <LvmCheckbox {...props} /> : <OdfCheckbox />}</StackItem>
+      )}
     </Stack>
   );
 };

--- a/libs/ui-lib/lib/ocm/components/clusterWizard/OperatorsStep.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/OperatorsStep.tsx
@@ -7,10 +7,11 @@ import OdfCheckbox from '../clusterConfiguration/operators/OdfCheckbox';
 import LvmCheckbox from '../clusterConfiguration/operators/LvmCheckbox';
 import MceCheckbox from '../clusterConfiguration/operators/MceCheckbox';
 import { selectIsCurrentClusterSNO } from '../../store/slices/current-cluster/selectors';
+import { isOCPVersionEqualsOrMajor } from '../utils';
 
 export const OperatorsStep = (props: ClusterOperatorProps) => {
   const isSNO = useSelector(selectIsCurrentClusterSNO);
-
+  const isLVMSMultiNodeEnabled = isOCPVersionEqualsOrMajor(props.openshiftVersion || '', '4.15');
   return (
     <Stack hasGutter data-testid={'operators-form'}>
       <StackItem>
@@ -22,7 +23,9 @@ export const OperatorsStep = (props: ClusterOperatorProps) => {
       <StackItem>
         <MceCheckbox />
       </StackItem>
-      <StackItem>{isSNO ? <LvmCheckbox {...props} /> : <OdfCheckbox />}</StackItem>
+      <StackItem>
+        {isSNO || isLVMSMultiNodeEnabled ? <LvmCheckbox {...props} /> : <OdfCheckbox />}
+      </StackItem>
     </Stack>
   );
 };

--- a/libs/ui-lib/lib/ocm/components/featureSupportLevels/featureStateUtils.ts
+++ b/libs/ui-lib/lib/ocm/components/featureSupportLevels/featureStateUtils.ts
@@ -218,3 +218,19 @@ export const isFeatureSupportedAndAvailable = (supportLevel: SupportLevel | unde
 
 export const hostsNetworkConfigurationDisabledReason =
   "DHCP only is the supported hosts' network configuration when external partner integrations is selected";
+
+export const getOdfIncompatibleWithLvmsReason = (operatorValues: OperatorsValues) => {
+  const mustDisableOdf = operatorValues.useOdfLogicalVolumeManager;
+  // In versions >= 4.15, it's not possible to select ODF + LVMS
+  return mustDisableOdf
+    ? `Currently, you can not install ${ODF_OPERATOR_LABEL} operator at the same time as ${LVMS_OPERATOR_LABEL} operator.`
+    : undefined;
+};
+
+export const getLvmsIncompatibleWithOdfReason = (operatorValues: OperatorsValues) => {
+  const mustDisableLvms = operatorValues.useOpenShiftDataFoundation;
+  // In versions >= 4.15, it's not possible to select ODF + LVMS
+  return mustDisableLvms
+    ? `Currently, you can not install ${LVMS_OPERATOR_LABEL} operator at the same time as ${ODF_OPERATOR_LABEL} operator.`
+    : undefined;
+};

--- a/libs/ui-lib/lib/ocm/components/utils.ts
+++ b/libs/ui-lib/lib/ocm/components/utils.ts
@@ -5,3 +5,15 @@ export const isOciPlatformType = (cluster: Cluster): boolean => {
     cluster.platform?.type === 'external' && cluster.platform?.external?.platformName === 'oci'
   );
 };
+
+export const getMajorMinorVersion = (version = '') => {
+  const match = /[0-9].[0-9][0-9]?/g.exec(version);
+  return match?.[0] || '';
+};
+
+export const isOCPVersionEqualsOrMajor = (
+  openshiftVersion: string,
+  ocpVersionToCompare: string,
+): boolean => {
+  return parseFloat(getMajorMinorVersion(openshiftVersion)) >= parseFloat(ocpVersionToCompare);
+};


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-16463

Enable multi-node LVMS OCP 4.15. 
The idea is to display in Operator page both ODF and LVM but the user can't choose both - if he chooses ODF - LVM should be disabled and viceversa.


https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/245b00c0-d074-480a-bd2c-e72ebac9f7c7




