### PR TITLE
MGMT-16776: DHCP checkbox should be removed as there is no sdn/ovn selection in OCP version 4.15

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfiguration.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfiguration.tsx
@@ -284,7 +284,7 @@ const NetworkConfiguration = ({
       {!isUserManagedNetworking && (
         <VirtualIPControlGroup
           cluster={cluster}
-          isVipDhcpAllocationDisabled={isVipDhcpAllocationDisabled}
+          isVipDhcpAllocationDisabled={isVipDhcpAllocationDisabled || !isSDNSupported}
           supportLevel={featureSupportLevelContext.getFeatureSupportLevel('VIP_AUTO_ALLOC')}
         />
       )}


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-16776

DHCP checkbox should be removed as there is no sdn/ovn selectioRemove dhcp option in OCP version 4.15.

![Captura desde 2024-02-06 09-35-28](https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/b3fb87b9-ac8f-477d-b9de-6793baf4e839)
