### PR TITLE
MGMT-16776: DHCP checkbox should be removed as there is no sdn/ovn selection in OCP version 4.15 - 2.30

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfiguration.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfiguration.tsx
@@ -284,7 +284,7 @@ const NetworkConfiguration = ({
       {!isUserManagedNetworking && (
         <VirtualIPControlGroup
           cluster={cluster}
-          isVipDhcpAllocationDisabled={isVipDhcpAllocationDisabled}
+          isVipDhcpAllocationDisabled={isVipDhcpAllocationDisabled || !isSDNSupported}
           supportLevel={featureSupportLevelContext.getFeatureSupportLevel('VIP_AUTO_ALLOC')}
         />
       )}


### PR DESCRIPTION
backport of #2491 