### PR TITLE
MGMT-16710: Operators page - LVMS and ODF are disabled once you turn on CNV+LVMS  - 2.30

### DIFF
--- a/libs/ui-lib/lib/ocm/components/featureSupportLevels/featureStateUtils.ts
+++ b/libs/ui-lib/lib/ocm/components/featureSupportLevels/featureStateUtils.ts
@@ -40,11 +40,6 @@ export const getLvmIncompatibleWithCnvReason = (
   lvmSupport: SupportLevel | undefined,
 ) => {
   const hasSelectedCnv = operatorValues.useContainerNativeVirtualization;
-  const hasSelectedLVMS = operatorValues.useOdfLogicalVolumeManager;
-  // In versions which support for LVMS (4.12+), LVMS needs to be installed together with CNV
-  if (hasSelectedCnv && hasSelectedLVMS) {
-    return `${LVMS_OPERATOR_LABEL} must be installed when ${CNV_OPERATOR_LABEL} operator is also installed`;
-  }
   // In versions with none or limited support for LVM (< 4.12), it's not possible to select CNV + LVM
   if (hasSelectedCnv && lvmSupport !== 'supported') {
     return `Currently, you can not install ${LVM_OPERATOR_LABEL} operator at the same time as ${CNV_OPERATOR_LABEL} operator.`;

--- a/libs/ui-lib/lib/ocm/components/featureSupportLevels/featureStateUtils.ts
+++ b/libs/ui-lib/lib/ocm/components/featureSupportLevels/featureStateUtils.ts
@@ -31,7 +31,7 @@ export const getCnvIncompatibleWithLvmReason = (
     lvmSupport !== 'supported';
   // In versions with none or limited support for LVM (< 4.12), it's not possible to select CNV + LVM
   return mustDisableCnv
-    ? `Currently, you can not install ${CNV_OPERATOR_LABEL} operator at the same time as ${LVM_OPERATOR_LABEL} operator.`
+    ? `Currently, you cannot install ${CNV_OPERATOR_LABEL} operator at the same time as ${LVM_OPERATOR_LABEL} operator.`
     : undefined;
 };
 
@@ -42,7 +42,7 @@ export const getLvmIncompatibleWithCnvReason = (
   const hasSelectedCnv = operatorValues.useContainerNativeVirtualization;
   // In versions with none or limited support for LVM (< 4.12), it's not possible to select CNV + LVM
   if (hasSelectedCnv && lvmSupport !== 'supported') {
-    return `Currently, you can not install ${LVM_OPERATOR_LABEL} operator at the same time as ${CNV_OPERATOR_LABEL} operator.`;
+    return `Currently, you cannot install ${LVM_OPERATOR_LABEL} operator at the same time as ${CNV_OPERATOR_LABEL} operator.`;
   }
   return undefined;
 };
@@ -218,7 +218,7 @@ export const getOdfIncompatibleWithLvmsReason = (operatorValues: OperatorsValues
   const mustDisableOdf = operatorValues.useOdfLogicalVolumeManager;
   // In versions >= 4.15, it's not possible to select ODF + LVMS
   return mustDisableOdf
-    ? `Currently, you can not install ${ODF_OPERATOR_LABEL} operator at the same time as ${LVMS_OPERATOR_LABEL} operator.`
+    ? `Currently, you cannot install ${ODF_OPERATOR_LABEL} operator at the same time as ${LVMS_OPERATOR_LABEL} operator.`
     : undefined;
 };
 
@@ -226,6 +226,6 @@ export const getLvmsIncompatibleWithOdfReason = (operatorValues: OperatorsValues
   const mustDisableLvms = operatorValues.useOpenShiftDataFoundation;
   // In versions >= 4.15, it's not possible to select ODF + LVMS
   return mustDisableLvms
-    ? `Currently, you can not install ${LVMS_OPERATOR_LABEL} operator at the same time as ${ODF_OPERATOR_LABEL} operator.`
+    ? `Currently, you cannot install ${LVMS_OPERATOR_LABEL} operator at the same time as ${ODF_OPERATOR_LABEL} operator.`
     : undefined;
 };


### PR DESCRIPTION
backport of #2490 