### PR TITLE
MGMT-15805: OpenshiftSDN is the default SDN selected when installing a new cluster

### DIFF
--- a/libs/ui-lib/lib/cim/components/ClusterDeployment/NetworkConfiguration.tsx
+++ b/libs/ui-lib/lib/cim/components/ClusterDeployment/NetworkConfiguration.tsx
@@ -13,7 +13,6 @@ import {
 } from '../../../common/components/clusterWizard/networkingSteps';
 import {
   canSelectNetworkTypeSDN,
-  getDefaultNetworkType,
   isAdvNetworkConf,
   isSNO,
   isSubnetInIPv6,
@@ -86,8 +85,6 @@ const NetworkConfiguration = ({
 
   useEffect(() => {
     if (!cluster.networkType) {
-      setFieldValue('networkType', getDefaultNetworkType(!isMultiNodeCluster, isIPv6));
-    } else if (!isSDNSelectable) {
       setFieldValue('networkType', NETWORK_TYPE_OVN);
     }
     // Skipping "cluster.networkType" as it's ultimately the value we are setting in the form

--- a/libs/ui-lib/lib/cim/components/ClusterDeployment/networkConfigurationValidation.ts
+++ b/libs/ui-lib/lib/cim/components/ClusterDeployment/networkConfigurationValidation.ts
@@ -15,8 +15,6 @@ import {
 import {
   getSubnetFromMachineNetworkCidr,
   getHostSubnets,
-  isSubnetInIPv6,
-  getDefaultNetworkType,
 } from '../../../common/components/clusterConfiguration/utils';
 import {
   isSNO,
@@ -25,7 +23,7 @@ import {
   selectMachineNetworkCIDR,
   selectServiceNetworkCIDR,
 } from '../../../common/selectors/clusterSelectors';
-import { NO_SUBNET_SET } from '../../../common/config';
+import { NETWORK_TYPE_OVN, NO_SUBNET_SET } from '../../../common/config';
 
 const getInitHostSubnet = (
   cluster: Cluster,
@@ -48,8 +46,6 @@ export const getNetworkInitialValues = (
   defaultNetworkSettings: ClusterDefaultConfig,
 ): NetworkConfigurationValues => {
   const managedNetworkingType = cluster.userManagedNetworking ? 'userManaged' : 'clusterManaged';
-  const isIPv6 = isSubnetInIPv6(cluster);
-  const isSNOCluster = isSNO(cluster);
 
   return {
     clusterNetworkCidr:
@@ -64,7 +60,7 @@ export const getNetworkInitialValues = (
     hostSubnet: getInitHostSubnet(cluster, managedNetworkingType) || NO_SUBNET_SET,
     vipDhcpAllocation: cluster.vipDhcpAllocation,
     managedNetworkingType,
-    networkType: cluster.networkType || getDefaultNetworkType(isSNOCluster, isIPv6),
+    networkType: cluster.networkType || NETWORK_TYPE_OVN,
   };
 };
 

--- a/libs/ui-lib/lib/common/components/clusterConfiguration/utils.ts
+++ b/libs/ui-lib/lib/common/components/clusterConfiguration/utils.ts
@@ -9,7 +9,7 @@ import {
   MachineNetwork,
   ServiceNetwork,
 } from '@openshift-assisted/types/assisted-installer-service';
-import { NETWORK_TYPE_OVN, NETWORK_TYPE_SDN, NO_SUBNET_SET } from '../../config';
+import { NO_SUBNET_SET } from '../../config';
 import {
   selectClusterNetworkCIDR,
   selectClusterNetworkHostPrefix,
@@ -171,10 +171,6 @@ export const isAdvNetworkConf = (cluster: Cluster, defaultNetworkSettings: Clust
 
 export const canSelectNetworkTypeSDN = (isSNO: boolean, isIPv6 = false) => {
   return !(isSNO || isIPv6);
-};
-
-export const getDefaultNetworkType = (isSNO: boolean, isIPv6 = false) => {
-  return isSNO || isIPv6 ? NETWORK_TYPE_OVN : NETWORK_TYPE_SDN;
 };
 
 export const canBeDualStack = (subnets: HostSubnets) =>

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/networkConfiguration/networkConfigurationValidation.ts
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/networkConfiguration/networkConfigurationValidation.ts
@@ -2,7 +2,6 @@ import * as Yup from 'yup';
 import {
   clusterNetworksValidationSchema,
   dualStackValidationSchema,
-  getDefaultNetworkType,
   HostSubnets,
   isDualStack,
   isSNO,
@@ -14,6 +13,7 @@ import {
   IPV4_STACK,
   DUAL_STACK,
   vipArrayValidationSchema,
+  NETWORK_TYPE_OVN,
 } from '../../../../common';
 import {
   ApiVip,
@@ -46,7 +46,7 @@ export const getNetworkInitialValues = (
       isSNOCluster
         ? 'userManaged'
         : 'clusterManaged',
-    networkType: cluster.networkType || getDefaultNetworkType(isSNOCluster, isDualStackType),
+    networkType: cluster.networkType || NETWORK_TYPE_OVN,
     machineNetworks: cluster.machineNetworks || [],
     stackType: isDualStackType ? DUAL_STACK : IPV4_STACK,
     clusterNetworks:


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-15805

To my knowledge, SDN should not be used as the default networking type anymore. I've removed all of the related code.