### PR TITLE
MGMT-16923: Change regexp to validate SSH keys

### DIFF
--- a/libs/ui-lib/lib/common/components/ui/formik/validationSchemas.ts
+++ b/libs/ui-lib/lib/common/components/ui/formik/validationSchemas.ts
@@ -36,7 +36,7 @@ const NAME_CHARS_REGEX = /^[a-z0-9-.]*$/;
 const CLUSTER_NAME_START_END_REGEX = /^[a-z0-9](.*[a-z0-9])?$/;
 const CLUSTER_NAME_VALID_CHARS_REGEX = /^[a-z0-9-]*$/;
 const SSH_PUBLIC_KEY_REGEX =
-  /^(ssh-rsa|ssh-ed25519|ecdsa-[-a-z0-9]*) AAAA[0-9A-Za-z+/]+[=]{0,3}( .+)?$/;
+  /^(ssh-rsa AAAAB3NzaC1yc2|ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNT|ecdsa-sha2-nistp384 AAAAE2VjZHNhLXNoYTItbmlzdHAzODQAAAAIbmlzdHAzOD|ecdsa-sha2-nistp521 AAAAE2VjZHNhLXNoYTItbmlzdHA1MjEAAAAIbmlzdHA1Mj|ssh-ed25519 AAAAC3NzaC1lZDI1NTE5|ssh-dss AAAAB3NzaC1kc3)[0-9A-Za-z+/]+[=]{0,3}( .*)?$/;
 const DNS_NAME_REGEX = /^([a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,}$/;
 
 const PROXY_DNS_REGEX =
@@ -117,7 +117,7 @@ export const sshPublicKeyValidationSchema = Yup.string().test(
 export const sshPublicKeyListValidationSchema = Yup.string()
   .test(
     'ssh-public-keys',
-    'SSH public keys separated by newlines must consist of "[TYPE] key [[EMAIL]]", supported types are: ssh-rsa, ssh-ed25519, ecdsa-[VARIANT].',
+    'SSH public key must consist of "[TYPE] key [[EMAIL]]", supported types are: ssh-rsa, ssh-ed25519, ecdsa-[VARIANT].',
     (value: string) => {
       if (!value) {
         return true;


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-16923

Replace existing regex with the same regex from assisted-service.

Before changes, the ssh key 'ssh-rsa AAAAAA' was not validated well in UI:
![image](https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/c4f473be-c4fc-4c4a-8a4e-c4ad52cd48b7)


After changes, the ssh key 'ssh-rsa AAAAAA' is not validated well in UI:
![image](https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/801e5472-1dbb-481c-9c3f-5f1d3fe7b9c3)
