### PR TITLE
MGMT-17012: Solving styling issues in Networking Page

### DIFF
--- a/libs/ui-lib/lib/common/components/clusterWizard/networkingSteps/ManagedNetworkingControlGroup.tsx
+++ b/libs/ui-lib/lib/common/components/clusterWizard/networkingSteps/ManagedNetworkingControlGroup.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { FormGroup, TooltipProps } from '@patternfly/react-core';
+import { FormGroup, Split, SplitItem, TooltipProps } from '@patternfly/react-core';
 import { PopoverIcon, getFieldId } from '../../ui';
 import RadioFieldWithTooltip from '../../ui/formik/RadioFieldWithTooltip';
 import { useTranslation } from '../../../hooks/use-translation-wrapper';
@@ -35,29 +35,37 @@ export const ManagedNetworkingControlGroup = ({
       fieldId={getFieldId(GROUP_NAME, 'radio')}
       isInline
     >
-      <RadioFieldWithTooltip
-        tooltipProps={tooltipPropsCmn}
-        name={GROUP_NAME}
-        isDisabled={disabled}
-        value={'clusterManaged'}
-        label={t('ai:Cluster-Managed Networking')}
-      />
-      <RadioFieldWithTooltip
-        tooltipProps={tooltipPropsUmn}
-        name={GROUP_NAME}
-        isDisabled={disabled}
-        value={'userManaged'}
-        label={
-          <>
-            <span>{t('ai:User-Managed Networking')}</span>{' '}
-            <PopoverIcon
-              bodyContent={t(
-                "ai:With User-Managed Networking, you'll need to provide and configure a load balancer for the API and ingress endpoints.",
-              )}
-            />
-          </>
-        }
-      />
+      <Split>
+        <SplitItem>
+          <RadioFieldWithTooltip
+            tooltipProps={tooltipPropsCmn}
+            name={GROUP_NAME}
+            isDisabled={disabled}
+            value={'clusterManaged'}
+            label={t('ai:Cluster-Managed Networking')}
+          />
+        </SplitItem>
+      </Split>
+      <Split>
+        <SplitItem>
+          <RadioFieldWithTooltip
+            tooltipProps={tooltipPropsUmn}
+            name={GROUP_NAME}
+            isDisabled={disabled}
+            value={'userManaged'}
+            label={
+              <>
+                <span>{t('ai:User-Managed Networking')}</span>{' '}
+                <PopoverIcon
+                  bodyContent={t(
+                    "ai:With User-Managed Networking, you'll need to provide and configure a load balancer for the API and ingress endpoints.",
+                  )}
+                />
+              </>
+            }
+          />
+        </SplitItem>
+      </Split>
     </FormGroup>
   );
 };

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfiguration.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfiguration.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useFormikContext } from 'formik';
 import { useSelector } from 'react-redux';
-import { Grid, Tooltip } from '@patternfly/react-core';
+import { Stack, StackItem, Tooltip } from '@patternfly/react-core';
 import { VirtualIPControlGroup, VirtualIPControlGroupProps } from './VirtualIPControlGroup';
 import {
   canBeDualStack,
@@ -241,71 +241,87 @@ const NetworkConfiguration = ({
   }, [featureSupportLevelContext]);
 
   return (
-    <Grid hasGutter>
-      <ManagedNetworkingControlGroup
-        disabled={isViewerMode || managedNetworkingState.isDisabled}
-        tooltipCmnDisabled={managedNetworkingState.clusterManagedDisabledReason}
-        tooltipUmnDisabled={managedNetworkingState.userManagedDisabledReason}
-      />
+    <Stack hasGutter>
+      <StackItem>
+        <ManagedNetworkingControlGroup
+          disabled={isViewerMode || managedNetworkingState.isDisabled}
+          tooltipCmnDisabled={managedNetworkingState.clusterManagedDisabledReason}
+          tooltipUmnDisabled={managedNetworkingState.userManagedDisabledReason}
+        />
+      </StackItem>
 
       {isUserManagedNetworking && (
-        <UserManagedNetworkingTextContent
-          shouldDisplayLoadBalancersBullet={!isSNOCluster}
-          docVersion={cluster.openshiftVersion}
-        />
+        <StackItem>
+          <UserManagedNetworkingTextContent
+            shouldDisplayLoadBalancersBullet={!isSNOCluster}
+            docVersion={cluster.openshiftVersion}
+          />
+        </StackItem>
       )}
 
       {(isSNOCluster || !isUserManagedNetworking) && (
-        <StackTypeControlGroup
-          clusterId={cluster.id}
-          isDualStackSelectable={isDualStackSelectable}
-          hostSubnets={hostSubnets}
-        />
+        <StackItem>
+          <StackTypeControlGroup
+            clusterId={cluster.id}
+            isDualStackSelectable={isDualStackSelectable}
+            hostSubnets={hostSubnets}
+          />
+        </StackItem>
       )}
       {isSDNSupported && (
-        <NetworkTypeControlGroup isDisabled={isViewerMode} isSDNSelectable={isSDNSelectable} />
+        <StackItem>
+          <NetworkTypeControlGroup isDisabled={isViewerMode} isSDNSelectable={isSDNSelectable} />
+        </StackItem>
       )}
 
       {!(isUserManagedNetworking && !isSNOCluster) && (
-        <AvailableSubnetsControl
-          clusterId={cluster.id}
-          hostSubnets={hostSubnets}
-          isRequired={!isUserManagedNetworking}
-          isDisabled={
-            (cluster.vipDhcpAllocation &&
-              selectApiVip(cluster) === '' &&
-              selectIngressVip(cluster) === '') ||
-            hostSubnets.length === 0 ||
-            false
-          }
-        />
+        <StackItem>
+          <AvailableSubnetsControl
+            clusterId={cluster.id}
+            hostSubnets={hostSubnets}
+            isRequired={!isUserManagedNetworking}
+            isDisabled={
+              (cluster.vipDhcpAllocation &&
+                selectApiVip(cluster) === '' &&
+                selectIngressVip(cluster) === '') ||
+              hostSubnets.length === 0 ||
+              false
+            }
+          />
+        </StackItem>
       )}
 
       {!isUserManagedNetworking && (
-        <VirtualIPControlGroup
-          cluster={cluster}
-          isVipDhcpAllocationDisabled={isVipDhcpAllocationDisabled || !isSDNSupported}
-          supportLevel={featureSupportLevelContext.getFeatureSupportLevel('VIP_AUTO_ALLOC')}
-        />
+        <StackItem>
+          <VirtualIPControlGroup
+            cluster={cluster}
+            isVipDhcpAllocationDisabled={isVipDhcpAllocationDisabled || !isSDNSupported}
+            supportLevel={featureSupportLevelContext.getFeatureSupportLevel('VIP_AUTO_ALLOC')}
+          />
+        </StackItem>
       )}
-
-      <Tooltip
-        content={'Advanced networking properties must be configured in dual-stack'}
-        hidden={!isDualStack}
-        position={'top-start'}
-      >
-        <OcmCheckbox
-          id="useAdvancedNetworking"
-          label="Use advanced networking"
-          description="Configure advanced networking properties (e.g. CIDR ranges)."
-          isChecked={isAdvanced}
-          onChange={(_event, value) => toggleAdvConfiguration(value)}
-          isDisabled={isDualStack}
-        />
-      </Tooltip>
-
-      {isAdvanced && <AdvancedNetworkFields />}
-    </Grid>
+      <StackItem>
+        <Tooltip
+          content={'Advanced networking properties must be configured in dual-stack'}
+          hidden={!isDualStack}
+          position={'top-start'}
+        >
+          <OcmCheckbox
+            id="useAdvancedNetworking"
+            label="Use advanced networking"
+            description="Configure advanced networking properties (e.g. CIDR ranges)."
+            isChecked={isAdvanced}
+            onChange={(_event, value) => toggleAdvConfiguration(value)}
+            isDisabled={isDualStack}
+          />
+        </Tooltip>
+      </StackItem>
+      {isAdvanced && (
+        <StackItem>
+          <AdvancedNetworkFields />
+        </StackItem>
+      )}
+    </Stack>
   );
 };
 


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-17012

In networking page - use advanced networking conf text should be adjust to view:
![Captura desde 2024-02-26 15-36-07](https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/20377a7b-9cd6-45df-87bd-3b6fa84c9ef7)
