### PR TITLE
MGMT-17107: Update operators checkbox when cluster ready exits from cluster window when we are in 'Overview' tab inside OCM

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusterWizard/Operators.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/Operators.tsx
@@ -53,7 +53,9 @@ const OperatorsForm = ({ cluster }: { cluster: Cluster }) => {
     !canNextOperators({ cluster });
 
   const handleNext = () => {
-    history.replace(pathname, undefined);
+    if (window.location.pathname.indexOf('assisted-installer') > -1) {
+      history.replace(pathname, undefined);
+    }
     clusterWizardContext.moveNext();
   };
 


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-17107

Replace history/location state when moving from the Operators step only when we are in Assisted Installer pages and not inside 'Overview' tab in OCM view.

How it works before change:
https://issues.redhat.com/secure/attachment/13147053/Screencast%20from%202024-03-03%2015-47-09.webm

And after changes:

https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/418b5af8-2bf2-4d27-ad4c-bb65ad89bb82



