### PR TITLE
MGMT-17155: Remove error helper duplicated in SecurityFields in Networking Page

### DIFF
--- a/libs/ui-lib/lib/common/components/clusterConfiguration/SecurityFields.tsx
+++ b/libs/ui-lib/lib/common/components/clusterConfiguration/SecurityFields.tsx
@@ -1,12 +1,6 @@
 import * as React from 'react';
 import { useFormikContext } from 'formik';
-import {
-  Checkbox,
-  FormGroup,
-  FormHelperText,
-  HelperText,
-  HelperTextItem,
-} from '@patternfly/react-core';
+import { Checkbox, FormGroup, HelperText, HelperTextItem } from '@patternfly/react-core';
 
 import { RenderIf } from '../ui/RenderIf';
 import { getFieldId, TextAreaField, trimSshPublicKey, ExternalLink } from '../ui';
@@ -46,10 +40,8 @@ const SecurityFields = ({
   //clusterSshKey updating causes the textarea to disappear when the user clears it to edit it
   const defaultShareSshKey = !!imageSshKey && (clusterSshKey === imageSshKey || !clusterSshKey);
   const [shareSshKey, setShareSshKey] = React.useState(defaultShareSshKey);
-  const { values, setFieldValue, errors, touched } =
+  const { values, setFieldValue } =
     useFormikContext<Pick<NetworkConfigurationValues, 'sshPublicKey'>>();
-
-  const errorMsg = errors.sshPublicKey;
 
   const handleSshKeyBlur = () => {
     if (values.sshPublicKey) {
@@ -90,15 +82,6 @@ const SecurityFields = ({
             isDisabled={isDisabled}
           />
         </RenderIf>
-        {errorMsg && (
-          <FormHelperText>
-            <HelperText>
-              <HelperTextItem variant={touched && errorMsg ? 'error' : 'default'}>
-                {errorMsg ? errorMsg : ''}
-              </HelperTextItem>
-            </HelperText>
-          </FormHelperText>
-        )}
       </FormGroup>
     </>
   );


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-17155

- Before changes,  SSH key field in networking page - Error helper is duplicated:

![image](https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/b3066847-f8f4-4d4d-93c6-93e845f35a98)


- After changes, error helper is shown only once:

![image](https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/2f5c2fb9-8790-4f9f-8f6d-e1f022661972)
