### PR TITLE
MGMT-17236: Add aria label property to close button in host status popover  to help cypress tests

### DIFF
--- a/libs/ui-lib/lib/common/components/hosts/HostStatus.tsx
+++ b/libs/ui-lib/lib/common/components/hosts/HostStatus.tsx
@@ -202,6 +202,7 @@ const WithHostStatusPopover: React.FC<WithHostStatusPopoverProps> = (props) => (
     maxWidth="50rem"
     hideOnOutsideClick={props.hideOnOutsideClick}
     zIndex={props.zIndex || 300}
+    closeBtnAriaLabel={`close-popover-${props.host.requestedHostname ?? ''}`}
   >
     <Button variant={'link'} isInline size="sm">
       {props.children}


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-17236

Add "aria-label" property to close button in host status popover to help cypress tests:

![image](https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/ed3027ed-3607-44ec-b612-5d8bb35e8b89)
