### PR TITLE
MGMT-17475: Updating CPU and platform dropdowns when OCP custom release is selected

### DIFF
--- a/libs/ui-lib/lib/common/components/ui/OpenShiftVersionDropdown.tsx
+++ b/libs/ui-lib/lib/common/components/ui/OpenShiftVersionDropdown.tsx
@@ -83,7 +83,9 @@ export const OpenShiftVersionDropdown = ({
 
   React.useEffect(() => {
     setCurrent(defaultLabel);
-  }, [defaultLabel]);
+    setValue(defaultValue);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [defaultLabel, defaultValue]);
 
   const parsedVersionsForItems = getParsedVersions(items);
   const dropdownItems = parsedVersionsForItems.parsedVersions.map(({ y, versions }) => {


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-17475 and https://issues.redhat.com/browse/MGMT-17474

When custom OCP version selected the platform and cpu dropdowns needs to be updated:

https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/617b5c44-5e00-4c95-8cee-5e5c0919c88f


