### PR TITLE
MGMT-17471: Add maxLength to search input and not allow to select 'No results found' option

### DIFF
--- a/libs/ui-lib/lib/common/components/ui/OpenshiftSelectWithSearch.tsx
+++ b/libs/ui-lib/lib/common/components/ui/OpenshiftSelectWithSearch.tsx
@@ -56,6 +56,12 @@ export const OpenshiftSelectWithSearch: React.FunctionComponent<OpenshiftSelectW
   const [helperText, setHelperText] = React.useState(getHelperText(versions, inputValue, t, true));
 
   React.useEffect(() => {
+    if (textInputRef.current) {
+      textInputRef.current.maxLength = 30;
+    }
+  }, []);
+
+  React.useEffect(() => {
     let newSelectOptions: SelectOptionProps[] = initialSelectOptions;
 
     // Filter menu items based on the text input value when one exists
@@ -68,7 +74,7 @@ export const OpenshiftSelectWithSearch: React.FunctionComponent<OpenshiftSelectW
       if (!newSelectOptions.length) {
         newSelectOptions = [
           {
-            isDisabled: false,
+            isDisabled: true,
             children: `No results found for "${filterValue}"`,
             value: 'no results',
           },


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-17471 and https://issues.redhat.com/browse/MGMT-17472

Add maxLength to search input in OCP custom releases modal and not allow to select 'No results found' option:

![Captura desde 2024-04-09 07-53-42](https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/a5d0a5ef-4cca-47fa-9785-c25f297b02ed)
