### PR TITLE
MGMT-17473: Add scrollbar to OpenshiftVersionDropdown component

### DIFF
--- a/libs/ui-lib/lib/common/components/ui/OpenShiftVersionDropdown.tsx
+++ b/libs/ui-lib/lib/common/components/ui/OpenShiftVersionDropdown.tsx
@@ -23,6 +23,7 @@ import { getFieldId } from './formik';
 import ExternalLink from './ExternalLink';
 import { OCP_RELEASES_PAGE } from '../../config';
 import { ClusterDetailsValues, ItemDropdown } from '../clusterWizard';
+import './OpenshiftVersionDropdown.css';
 
 export type HelperTextType = (
   versions: OpenshiftVersionOptionType[],

--- a/libs/ui-lib/lib/common/components/ui/OpenshiftVersionDropdown.css
+++ b/libs/ui-lib/lib/common/components/ui/OpenshiftVersionDropdown.css
@@ -1,0 +1,4 @@
+#form-input-openshiftVersion-field .pf-v5-c-dropdown__menu {
+  max-height: 22vh;
+  overflow: auto;
+}


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-17473

Adding scrollbar to OpenshiftVersionDropdown component avoid problems about changing window layout.

![Captura desde 2024-04-09 09-36-13](https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/e73ef491-d290-4d9b-b40f-1303b0126dc6)
