### PR TITLE
MGMT-17477: Show dev preview badge when select custom OCP versions

### DIFF
--- a/libs/ui-lib/lib/common/components/ui/OpenshiftSelectWithSearch.tsx
+++ b/libs/ui-lib/lib/common/components/ui/OpenshiftSelectWithSearch.tsx
@@ -103,7 +103,10 @@ export const OpenshiftSelectWithSearch: React.FunctionComponent<OpenshiftSelectW
       setSelected(value as string);
       const filteredVersions = versions.filter((version) => version.value === value);
       setFieldValue('customOpenshiftSelect', {
-        label: filteredVersions[0].label,
+        label:
+          filteredVersions[0].supportLevel === 'beta'
+            ? filteredVersions[0].label + ' - ' + t('ai:Developer preview release')
+            : filteredVersions[0].label,
         value: filteredVersions[0].value,
         version: filteredVersions[0].version,
         default: filteredVersions[0].default,


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-17477


https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/fba5ade4-73e3-4243-973d-5d5f5a4af4fa

