### PR TITLE
MGMT-17504: Adjusting behavior of the OpenshiftVersionModal buttons

### DIFF
--- a/libs/ui-lib/lib/common/components/ui/OpenshiftSelectWithSearch.tsx
+++ b/libs/ui-lib/lib/common/components/ui/OpenshiftSelectWithSearch.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Dispatch, SetStateAction } from 'react';
 import {
   Select,
   SelectOption,
@@ -19,17 +19,17 @@ import TimesIcon from '@patternfly/react-icons/dist/esm/icons/times-icon';
 import { OpenshiftVersionOptionType } from '../../types';
 import { HelperTextType } from './OpenShiftVersionDropdown';
 import { useTranslation } from '../../hooks/use-translation-wrapper';
-import { useFormikContext } from 'formik';
-import { ClusterDetailsValues } from '../clusterWizard';
 
 type OpenshiftSelectWithSearchProps = {
   versions: OpenshiftVersionOptionType[];
   getHelperText: HelperTextType;
+  setCustomOpenshiftSelect: Dispatch<SetStateAction<OpenshiftVersionOptionType | undefined>>;
 };
 
 export const OpenshiftSelectWithSearch: React.FunctionComponent<OpenshiftSelectWithSearchProps> = ({
   versions,
   getHelperText,
+  setCustomOpenshiftSelect,
 }: OpenshiftSelectWithSearchProps) => {
   const initialSelectOptions = React.useMemo(
     () =>
@@ -42,7 +42,7 @@ export const OpenshiftSelectWithSearch: React.FunctionComponent<OpenshiftSelectW
       })),
     [versions],
   );
-  const { setFieldValue } = useFormikContext<ClusterDetailsValues>();
+
   const [isOpen, setIsOpen] = React.useState(false);
   const [selected, setSelected] = React.useState<string>('');
   const [inputValue, setInputValue] = React.useState<string>('');
@@ -108,7 +108,7 @@ export const OpenshiftSelectWithSearch: React.FunctionComponent<OpenshiftSelectW
       setFilterValue('');
       setSelected(value as string);
       const filteredVersions = versions.filter((version) => version.value === value);
-      setFieldValue('customOpenshiftSelect', {
+      setCustomOpenshiftSelect({
         label:
           filteredVersions[0].supportLevel === 'beta'
             ? filteredVersions[0].label + ' - ' + t('ai:Developer preview release')

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/OpenShiftVersionModal.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/OpenShiftVersionModal.tsx
@@ -1,9 +1,11 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Button, ButtonVariant, FormGroup, Modal, ModalVariant } from '@patternfly/react-core';
 import './OpenshiftVersionModal.css';
 import { OpenshiftSelectWithSearch } from '../../../common/components/ui/OpenshiftSelectWithSearch';
 import { useOpenshiftVersions } from '../../hooks';
 import { HelperTextType } from '../../../common/components/ui/OpenShiftVersionDropdown';
+import { useFormikContext } from 'formik';
+import { ClusterDetailsValues, OpenshiftVersionOptionType } from '../../../common';
 
 type OpenShiftVersionModalProps = {
   setOpenshiftVersionModalOpen: (isOpen: boolean) => void;
@@ -16,8 +18,17 @@ export const OpenShiftVersionModal = ({
   isOpen,
   getHelperText,
 }: OpenShiftVersionModalProps) => {
+  const { setFieldValue } = useFormikContext<ClusterDetailsValues>();
   const { versions } = useOpenshiftVersions(false);
   const onClose = () => setOpenshiftVersionModalOpen(false);
+  const [customOpenshiftSelect, setCustomOpenshiftSelect] = useState<OpenshiftVersionOptionType>(); // Cambiar el tipo según lo que esperes aquí
+
+  const handleSelect = () => {
+    if (customOpenshiftSelect) {
+      setFieldValue('customOpenshiftSelect', customOpenshiftSelect);
+    }
+    onClose();
+  };
 
   return (
     <Modal
@@ -25,7 +36,7 @@ export const OpenShiftVersionModal = ({
       id="available-openshift-versions-modal"
       isOpen={isOpen}
       actions={[
-        <Button key="select-custom-ocp" variant={ButtonVariant.primary} onClick={onClose}>
+        <Button key="select-custom-ocp" variant={ButtonVariant.primary} onClick={handleSelect}>
           Select
         </Button>,
         <Button key="close-custom-ocp" variant={ButtonVariant.link} onClick={onClose}>
@@ -41,7 +52,11 @@ export const OpenShiftVersionModal = ({
         label={'OpenShift version'}
         isRequired
       >
-        <OpenshiftSelectWithSearch versions={versions} getHelperText={getHelperText} />
+        <OpenshiftSelectWithSearch
+          versions={versions}
+          getHelperText={getHelperText}
+          setCustomOpenshiftSelect={setCustomOpenshiftSelect}
+        />
       </FormGroup>
     </Modal>
   );


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-17504

In OpenshiftVersionModal add the correct behavior for every button:

- Select button: Select OCP version and add to the OpenshiftVersionDropdown
- Cancel button: Close the modal and don't change the OpenshiftVersionDropdown


https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/2cab4b01-ec59-491b-9db9-a4ca1dcff8aa

