### PR TITLE
MGMT-17501: Show all OCP versions in OpenshiftVersionDropdown (maintenance, production, beta, end-of-life

### DIFF
--- a/libs/ui-lib/lib/common/components/clusterConfiguration/OpenShiftVersionSelect.tsx
+++ b/libs/ui-lib/lib/common/components/clusterConfiguration/OpenShiftVersionSelect.tsx
@@ -35,7 +35,10 @@ const getOpenshiftVersionHelperText =
       return null;
     }
 
-    if (selectedVersion.supportLevel !== 'production') {
+    if (
+      selectedVersion.supportLevel !== 'production' &&
+      selectedVersion.supportLevel !== 'maintenance'
+    ) {
       return (
         <>
           <UiIcon size="sm" status="warning" icon={<ExclamationTriangleIcon />} />
@@ -55,12 +58,10 @@ type OpenShiftVersionSelectProps = {
 const OpenShiftVersionSelect: React.FC<OpenShiftVersionSelectProps> = ({ versions, onChange }) => {
   const selectOptions = React.useMemo(
     () =>
-      versions
-        .filter((version) => version.supportLevel !== 'maintenance')
-        .map((version) => ({
-          label: version.label,
-          value: version.value,
-        })),
+      versions.map((version) => ({
+        label: version.label,
+        value: version.value,
+      })),
     [versions],
   );
   const { t } = useTranslation();

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/OcmOpenShiftVersionSelect.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/OcmOpenShiftVersionSelect.tsx
@@ -44,7 +44,10 @@ const getOpenshiftVersionHelperText = (
     return null;
   }
 
-  if (selectedVersion.supportLevel !== 'production') {
+  if (
+    selectedVersion.supportLevel !== 'production' &&
+    selectedVersion.supportLevel !== 'maintenance'
+  ) {
     let messageSelectedVersion = t('ai:Please note that this version is not production-ready.');
     if (selectedVersion.supportLevel === 'end-of-life') {
       messageSelectedVersion = t('ai:Please note that this version is not maintained anymore.');
@@ -72,17 +75,15 @@ const OcmOpenShiftVersionSelect = ({ versions }: OcmOpenShiftVersionSelectProps)
   } = useFormikContext<ClusterDetailsValues>();
   const selectOptions = React.useMemo(
     () =>
-      versions
-        .filter((version) => version.supportLevel !== 'maintenance')
-        .map((version) => ({
-          label:
-            version.supportLevel === 'beta'
-              ? version.label + ' - ' + t('ai:Developer preview release')
-              : version.label,
-          // This is the "key" from openshift-versions API response
-          // It can either be in the long or short (for default versions) form
-          value: version.value,
-        })),
+      versions.map((version) => ({
+        label:
+          version.supportLevel === 'beta'
+            ? version.label + ' - ' + t('ai:Developer preview release')
+            : version.label,
+        // This is the "key" from openshift-versions API response
+        // It can either be in the long or short (for default versions) form
+        value: version.value,
+      })),
     [versions, t],
   );
   const [isOpenshiftVersionModalOpen, setIsOpenshiftVersionModalOpen] = React.useState(false);


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-17501

Previously in OCP versions dropdown we don't show maintenance versions. With the latest changes in the API (that returns only latest releases in the cluster wizard page) we want to show all versions.

Before changes:
![image](https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/16c20705-1e09-4c57-aead-46b43f188a8b)

After changes:
![image](https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/2b0adac1-f402-4123-945e-4f20372424c0)
