### PR TITLE
MGMT-17569: Patch Manifest - Second attempt to upload invalid content of manifest not declined

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/manifestsConfiguration/components/CustomManifestsForm.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/manifestsConfiguration/components/CustomManifestsForm.tsx
@@ -52,14 +52,6 @@ const AutosaveWithParentUpdate = ({
   return null;
 };
 
-const manifestUpdated = (manifest: CustomManifestValues, oldManifest: CustomManifestValues) => {
-  return (
-    oldManifest.filename !== manifest.filename ||
-    oldManifest.folder !== manifest.folder ||
-    oldManifest.manifestYaml !== manifest.manifestYaml
-  );
-};
-
 export const CustomManifestsForm = ({
   onFormStateChange,
   getEmptyValues,
@@ -105,10 +97,7 @@ export const CustomManifestsForm = ({
             } else {
               // manifest updated
               const oldManifest = customManifestsLocalRef.current[index];
-
-              if (manifestUpdated(manifest, oldManifest)) {
-                await ClustersService.updateCustomManifest(oldManifest, manifest, cluster.id);
-              }
+              await ClustersService.updateCustomManifest(oldManifest, manifest, cluster.id);
             }
           } catch (error) {
             const errorArray = new Array(manifests.length).fill(undefined);


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-17569

Validate every updated manifest when user changes something (folder, file name or content)


https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/bc487921-c301-4cc7-a2d9-ac1a3e0b1d88

