### PR TITLE
MGMT-17139: Enable "Change" button in Mass Change Hostname Modal when hostname value is not empty

### DIFF
--- a/libs/ui-lib/lib/common/components/hosts/MassChangeHostnameModal.tsx
+++ b/libs/ui-lib/lib/common/components/hosts/MassChangeHostnameModal.tsx
@@ -251,7 +251,11 @@ const MassChangeHostnameForm = ({
         </Stack>
       </ModalBoxBody>
       <ModalBoxFooter>
-        <Button key="submit" type={ButtonType.submit} isDisabled={isSubmitting || !isValid}>
+        <Button
+          key="submit"
+          type={ButtonType.submit}
+          isDisabled={isSubmitting || !isValid || !hostnameInputRef.current?.value.trim()}
+        >
           {t('ai:Change')}
         </Button>
         <Button onClick={onClose} variant={ButtonVariant.secondary} isDisabled={isSubmitting}>


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-17139

In  Mass host rename modal "Change" button needs to be disabled at start

![image](https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/85a4ed8d-506b-45bc-8701-0546e07eafd1)
