### PR TITLE
MGMT-17511: Sort order of OCP versions should be changed. First GA reason needs to be shown before EC/RC releases

### DIFF
--- a/libs/ui-lib/lib/common/components/ui/OpenShiftVersionDropdown.tsx
+++ b/libs/ui-lib/lib/common/components/ui/OpenShiftVersionDropdown.tsx
@@ -76,7 +76,7 @@ export const OpenShiftVersionDropdown = ({
 
   const parsedVersionsForItems = getParsedVersions(items);
   const dropdownItems = parsedVersionsForItems.parsedVersions.map(({ y, versions }) => {
-    const items = versions.map(({ value, label }) => (
+    const items = versions.reverse().map(({ value, label }) => (
       <DropdownItem key={value} id={value}>
         {label}
       </DropdownItem>
@@ -90,7 +90,7 @@ export const OpenShiftVersionDropdown = ({
 
   const parsedVersionsForCustomItems = getParsedVersions(customItems);
   const customDropdownItems = parsedVersionsForCustomItems.parsedVersions.map(({ y, versions }) => {
-    const customItems = versions.map(({ value, label }) => (
+    const customItems = versions.reverse().map(({ value, label }) => (
       <DropdownItem key={value} id={value}>
         {label}
       </DropdownItem>

--- a/libs/ui-lib/lib/common/components/ui/OpenshiftSelectWithSearch.tsx
+++ b/libs/ui-lib/lib/common/components/ui/OpenshiftSelectWithSearch.tsx
@@ -248,7 +248,7 @@ export const OpenshiftSelectWithSearch: React.FunctionComponent<OpenshiftSelectW
         isScrollable
       >
         <SelectList id="select-typeahead-listbox">
-          {selectOptions.map((option, index) => {
+          {selectOptions.reverse().map((option, index) => {
             const match = (option.value as string).match(/\d+\.(\d+)\.\d+/);
             const y = match ? match[1] : null;
 


### PR DESCRIPTION
Related to MGMT-17511
Sort order of OCP versions should be changed. First GA reason needs to be shown before EC/RC releases

![Captura desde 2024-04-25 12-39-53](https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/2f5b4d79-988c-435f-a682-19fa6d6fedf1)
![Captura desde 2024-04-25 12-39-40](https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/7f78778e-9cc3-421d-a010-aeb345941ef4)
