### PR TITLE
NO-ISSUE: Fix Github actions to deploy Assisted UI lib

### DIFF
--- a/apps/assisted-ui/Containerfile
+++ b/apps/assisted-ui/Containerfile
@@ -26,7 +26,7 @@ RUN npm install -g corepack@0.24.1
 WORKDIR "${APP_ROOT}/src/repo"
 RUN yarn install --immutable && yarn build:all
 
-FROM registry.access.redhat.com/ubi8/nginx-120 AS assisted-ui
+FROM registry.access.redhat.com/ubi8/nginx-122 AS assisted-ui
 COPY --from=devcontainer /opt/app-root/src/repo/apps/assisted-ui/build/ "${NGINX_APP_ROOT}/src/"
 COPY --from=devcontainer /opt/app-root/src/repo/apps/assisted-ui/deploy/ /deploy/
 CMD [ "/deploy/start.sh" ]


### PR DESCRIPTION
We have an issue in Container file with nginx-1.20 image:
![image](https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/0b14994d-b804-48d1-9079-732503fddfb5)

It's depecrated since March 2024. We change it to nginx-1.22 image.
