### PR TITLE
MGMT-15977: Add warning alert for soft installation timeouts

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusterDetail/ClusterDetailsButtonGroup.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterDetail/ClusterDetailsButtonGroup.tsx
@@ -45,7 +45,7 @@ const ClusterDetailsButtonGroup: React.FC<ClusterDetailsButtonGroupProps> = ({
         <RenderIf condition={cluster.status === 'error'}>
           <Button
             id={getID('button-reset-cluster')}
-            variant={ButtonVariant.primary}
+            variant={ButtonVariant.danger}
             onClick={() => resetClusterDialog.open({ cluster })}
           >
             Reset Cluster

--- a/libs/ui-lib/lib/ocm/components/clusterDetail/ProgressBarAlerts.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterDetail/ProgressBarAlerts.tsx
@@ -215,3 +215,35 @@ export const HostsInstallationSuccess = () => {
     </>
   );
 };
+
+type ClusterInstallationTimeoutProps = {
+  cluster: Cluster;
+};
+
+export const ClusterInstallationTimeout = ({ cluster }: ClusterInstallationTimeoutProps) => {
+  const { addAlert, clearAlerts } = useAlerts();
+  return (
+    <>
+      <Alert
+        isInline
+        variant="warning"
+        title="Cluster installation is taking too long"
+        actionLinks={
+          <>
+            <AlertActionLink
+              id="cluster-installation-logs-button"
+              onClick={() => {
+                void downloadClusterInstallationLogs(addAlert, cluster.id, clearAlerts);
+              }}
+              isDisabled={!canDownloadClusterLogs(cluster)}
+            >
+              Download installation logs
+            </AlertActionLink>
+          </>
+        }
+      >
+        Check the logs to find out why or reset the cluster to start over.
+      </Alert>
+    </>
+  );
+};

--- a/libs/ui-lib/lib/ocm/components/clusterDetail/getProgressBarAlerts.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterDetail/getProgressBarAlerts.tsx
@@ -5,6 +5,7 @@ import {
   HostsInstallationFailed,
   HostInstallationWarning,
   HostsInstallationSuccess,
+  ClusterInstallationTimeout,
 } from './ProgressBarAlerts';
 import {
   Cluster,
@@ -34,6 +35,7 @@ export const getClusterProgressAlerts = (
   const [totalMasters, failedMasters, pendingUserActionMasters] = hostsStatus(hosts, 'master');
   const [totalWorkers, failedWorkers, pendingUserActionWorkers] = hostsStatus(hosts, 'worker');
   const failedOperators = olmOperatorsStatus(olmOperators);
+  const finalizingStageTimeout = cluster?.progress?.finalizingStageTimedOut;
   if (['error', 'cancelled'].includes(cluster.status)) {
     return (
       <Stack>
@@ -44,6 +46,14 @@ export const getClusterProgressAlerts = (
             failedHosts={failedMasters}
             isCriticalNumberOfWorkersFailed={failedWorkers === 1}
           />
+        </StackItem>
+      </Stack>
+    );
+  } else if (finalizingStageTimeout) {
+    return (
+      <Stack>
+        <StackItem>
+          <ClusterInstallationTimeout cluster={cluster} />{' '}
         </StackItem>
       </Stack>
     );


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-15977

The UI will need to explicitly show to the user that the cluster installation is taking longer than expected, and give suggestions on how to proceed.
![Captura desde 2024-05-10 13-47-36](https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/d17749a7-0f8a-4e88-9fa6-12efef21744c)

We also change the "Reset cluster"  button to be in red:
![Captura desde 2024-05-10 13-48-48](https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/35255afd-8425-4003-b994-36c15d43ca3e)
