### PR TITLE
MGMT-8534: Adjusting UI documentation links to OCP version selected

### DIFF
--- a/libs/ui-lib/lib/common/components/clusterConfiguration/DiskEncryptionFields/DiskEncryptionControlGroup.tsx
+++ b/libs/ui-lib/lib/common/components/clusterConfiguration/DiskEncryptionFields/DiskEncryptionControlGroup.tsx
@@ -30,12 +30,14 @@ export interface DiskEncryptionControlGroupProps {
   values: DiskEncryptionValues;
   isSNO: boolean;
   isDisabled?: boolean;
+  docVersion?: string;
 }
 
 const DiskEncryptionControlGroup = ({
   values,
   isSNO = false,
   isDisabled = false,
+  docVersion,
 }: DiskEncryptionControlGroupProps) => {
   const {
     enableDiskEncryptionOnMasters,
@@ -108,6 +110,7 @@ const DiskEncryptionControlGroup = ({
               diskEncryptionMode={diskEncryptionMode}
               isDisabled={isDisabled}
               tooltipProps={tooltipProps}
+              docVersion={docVersion || ''}
             />
           </StackItem>
         </RenderIf>

--- a/libs/ui-lib/lib/common/components/clusterConfiguration/DiskEncryptionFields/DiskEncryptionMode.tsx
+++ b/libs/ui-lib/lib/common/components/clusterConfiguration/DiskEncryptionFields/DiskEncryptionMode.tsx
@@ -11,14 +11,14 @@ import {
   TooltipProps,
   Tooltip,
 } from '@patternfly/react-core';
-import { ENCRYPTING_DISK_DURING_INSTALLATION } from '../../../config';
+import { getEncryptingDiskDuringInstallationDocsLink } from '../../../config';
 import PopoverIcon from '../../ui/PopoverIcon';
 import { RadioField } from '../../ui/formik';
 import { TangServers } from './TangServers';
 import { DiskEncryption } from '@openshift-assisted/types/assisted-installer-service';
 import { useTranslation } from '../../../hooks/use-translation-wrapper';
 
-const DiskEncryptionModeTPMv2 = () => {
+const DiskEncryptionModeTPMv2 = ({ docVersion }: { docVersion: string }) => {
   const { t } = useTranslation();
   return (
     <>
@@ -32,7 +32,11 @@ const DiskEncryptionModeTPMv2 = () => {
               'ai:TPM v2 stores passphrases in a secure cryptoprocessor contained within as server.',
             )}
             &nbsp;
-            <a href={ENCRYPTING_DISK_DURING_INSTALLATION} target="_blank" rel="noopener noreferrer">
+            <a
+              href={getEncryptingDiskDuringInstallationDocsLink(docVersion)}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
               {t('ai:Learn more')} <ExternalLinkAltIcon />
             </a>
           </p>
@@ -42,7 +46,7 @@ const DiskEncryptionModeTPMv2 = () => {
   );
 };
 
-const DiskEncryptionModeTang = () => {
+const DiskEncryptionModeTang = ({ docVersion }: { docVersion: string }) => {
   const { t } = useTranslation();
   return (
     <>
@@ -53,7 +57,11 @@ const DiskEncryptionModeTang = () => {
         bodyContent={
           <p>
             {t('ai:Tang server component that enable network-bound disk encryption (NBDE).')} &nbsp;
-            <a href={ENCRYPTING_DISK_DURING_INSTALLATION} target="_blank" rel="noopener noreferrer">
+            <a
+              href={getEncryptingDiskDuringInstallationDocsLink(docVersion)}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
               {t('ai:Learn more')} <ExternalLinkAltIcon />
             </a>
           </p>
@@ -67,12 +75,14 @@ export interface DiskEncryptionModeProps {
   isDisabled: boolean;
   diskEncryptionMode: DiskEncryption['mode'];
   tooltipProps: TooltipProps;
+  docVersion: string;
 }
 
 export const DiskEncryptionMode = ({
   diskEncryptionMode,
   isDisabled,
   tooltipProps,
+  docVersion,
 }: DiskEncryptionModeProps) => {
   const { t } = useTranslation();
   return (
@@ -84,7 +94,7 @@ export const DiskEncryptionMode = ({
               <RadioField
                 isDisabled={isDisabled}
                 name="diskEncryptionMode"
-                label={<DiskEncryptionModeTPMv2 />}
+                label={<DiskEncryptionModeTPMv2 docVersion={docVersion} />}
                 id="TPMV2-button"
                 value="tpmv2"
               />
@@ -95,7 +105,7 @@ export const DiskEncryptionMode = ({
               <RadioField
                 isDisabled={isDisabled}
                 name="diskEncryptionMode"
-                label={<DiskEncryptionModeTang />}
+                label={<DiskEncryptionModeTang docVersion={docVersion} />}
                 id="tang-button"
                 value="tang"
               />

--- a/libs/ui-lib/lib/common/components/hosts/HostStatus.tsx
+++ b/libs/ui-lib/lib/common/components/hosts/HostStatus.tsx
@@ -29,8 +29,8 @@ import { HostStatusProps } from './types';
 import { UpdateDay2ApiVipPropsType } from './HostValidationGroups';
 import { UnknownIcon } from '@patternfly/react-icons/dist/js/icons/unknown-icon';
 import { useTranslation } from '../../hooks/use-translation-wrapper';
-import { APPROVE_NODES_IN_CL_LINK } from '../../config';
 import { hostStatus } from './status';
+import { getApproveNodesInClLink } from '../../config';
 
 const getTitleWithProgress = (host: Host, status: HostStatusProps['status']) => {
   const stages = getHostProgressStages(host);
@@ -43,12 +43,14 @@ type HostStatusPopoverContentProps = ValidationInfoActionProps & {
   validationsInfo: ValidationsInfo;
   autoCSR?: boolean;
   additionalPopoverContent?: React.ReactNode;
+  openshiftVersion?: string;
 };
 
 const HostStatusPopoverContent: React.FC<HostStatusPopoverContentProps> = ({
   details,
   autoCSR,
   additionalPopoverContent,
+  openshiftVersion,
   ...props
 }) => {
   const { host } = props;
@@ -99,7 +101,7 @@ const HostStatusPopoverContent: React.FC<HostStatusPopoverContentProps> = ({
             {t('ai:It may take a few minutes for the join request to appear.')}
             <br />
             {t('ai:If you prefer using the CLI, follow the instructions in')}&nbsp;
-            <ExternalLink href={APPROVE_NODES_IN_CL_LINK}>
+            <ExternalLink href={getApproveNodesInClLink(openshiftVersion)}>
               {t('ai:How to approve nodes using the CLI')}
             </ExternalLink>
           </>
@@ -187,6 +189,7 @@ type WithHostStatusPopoverProps = AdditionNtpSourcePropsType &
     zIndex?: number;
     autoCSR?: boolean;
     additionalPopoverContent?: React.ReactNode;
+    openshiftVersion?: string;
   };
 
 const WithHostStatusPopover: React.FC<WithHostStatusPopoverProps> = (props) => (
@@ -221,6 +224,7 @@ const HostStatus: React.FC<HostStatusProps> = ({
   zIndex,
   autoCSR,
   additionalPopoverContent,
+  openshiftVersion,
 }) => {
   const [keepOnOutsideClick, onValidationActionToggle] = React.useState(false);
 
@@ -245,6 +249,7 @@ const HostStatus: React.FC<HostStatusProps> = ({
     zIndex,
     autoCSR,
     additionalPopoverContent,
+    openshiftVersion,
   };
 
   return (

--- a/libs/ui-lib/lib/common/components/hosts/types.ts
+++ b/libs/ui-lib/lib/common/components/hosts/types.ts
@@ -91,4 +91,5 @@ export type HostStatusProps = AdditionNtpSourcePropsType &
     zIndex?: number;
     autoCSR?: boolean;
     additionalPopoverContent?: React.ReactNode;
+    openshiftVersion?: string;
   };

--- a/libs/ui-lib/lib/common/config/constants.ts
+++ b/libs/ui-lib/lib/common/config/constants.ts
@@ -38,8 +38,10 @@ export const FEEDBACK_FORM_LINK =
 
 export const TECH_SUPPORT_LEVEL_LINK = 'https://access.redhat.com/support/offerings/techpreview';
 
-export const ENCRYPTING_DISK_DURING_INSTALLATION =
-  'https://docs.openshift.com/container-platform/4.7/installing/install_config/installing-customizing.html#installation-special-config-encrypt-disk_installing-customizing';
+export const getEncryptingDiskDuringInstallationDocsLink = (ocpVersion?: string) =>
+  `https://docs.openshift.com/container-platform/${
+    getShortOpenshiftVersion(ocpVersion) || '4.12'
+  }/installing/install_config/installing-customizing.html#installation-special-config-encrypt-disk_installing-customizing`;
 
 export const getOcpConsoleNodesPage = (ocpConsoleUrl: string) =>
   `${ocpConsoleUrl}/k8s/cluster/nodes`;
@@ -52,13 +54,17 @@ export const CNV_LINK = 'https://cloud.redhat.com/learn/topics/virtualization/';
 
 export const ODF_LINK = 'https://www.redhat.com/en/resources/openshift-data-foundation-datasheet';
 
-export const LVMS_LINK =
-  'https://docs.openshift.com/container-platform/4.12/storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.html';
+export const getLvmsDocsLink = (ocpVersion?: string) =>
+  `https://docs.openshift.com/container-platform/${
+    getShortOpenshiftVersion(ocpVersion) || '4.12'
+  }/storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.html`;
 
 export const NMSTATE_EXAMPLES_LINK = 'https://nmstate.io/examples.html';
 
-export const APPROVE_NODES_IN_CL_LINK =
-  'https://docs.openshift.com/container-platform/4.11/installing/installing_platform_agnostic/installing-platform-agnostic.html#installation-approve-csrs_installing-platform-agnostic';
+export const getApproveNodesInClLink = (ocpVersion?: string) =>
+  `https://docs.openshift.com/container-platform/${
+    getShortOpenshiftVersion(ocpVersion) || '4.11'
+  }/installing/installing_platform_agnostic/installing-platform-agnostic.html#installation-approve-csrs_installing-platform-agnostic`;
 
 // TODO(mlibra): Retrieve branding dynamically, if needed, i.e. via injecting to the "window" object
 export const getProductBrandingCode = () => 'redhat';
@@ -383,8 +389,15 @@ export const CHANGE_ISO_PASSWORD_FILE_LINK =
 export const CUSTOM_MANIFESTS_HELP_LINK =
   'https://docs.openshift.com/container-platform/4.12/installing/install_config/installing-customizing.html';
 
+export const getCustomManifestsDocsLink = (ocpVersion?: string) =>
+  `https://docs.openshift.com/container-platform/${
+    getShortOpenshiftVersion(ocpVersion) || '4.12'
+  }/installing/install_config/installing-customizing.html`;
+
 export const HOW_TO_KNOW_IF_CLUSTER_SUPPORTS_MULTIPLE_CPU_ARCHS =
   'https://access.redhat.com/documentation/en-us/assisted_installer_for_openshift_container_platform/2022/html-single/assisted_installer_for_openshift_container_platform/index#checking-for-multiple-architectures_expanding-the-cluster';
 
-export const MCE_LINK =
-  'https://docs.openshift.com/container-platform/4.14/architecture/mce-overview-ocp.html';
+export const getMceDocsLink = (ocpVersion?: string) =>
+  `https://docs.openshift.com/container-platform/${
+    getShortOpenshiftVersion(ocpVersion) || '4.12'
+  }/architecture/mce-overview-ocp.html`;

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/OcmClusterDetailsFormFields.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/OcmClusterDetailsFormFields.tsx
@@ -201,6 +201,7 @@ export const OcmClusterDetailsFormFields = ({
         values={values}
         isDisabled={isPullSecretSet}
         isSNO={isSNO({ highAvailabilityMode })}
+        docVersion={openshiftVersion}
       />
     </Form>
   );

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/LvmCheckbox.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/LvmCheckbox.tsx
@@ -10,8 +10,8 @@ import {
   OPERATOR_NAME_LVM,
   ExposedOperatorName,
   ExternalLink,
-  LVMS_LINK,
   OPERATOR_NAME_LVMS,
+  getLvmsDocsLink,
 } from '../../../../common';
 import LvmHostRequirements from './LvmHostRequirements';
 import { OcmCheckboxField } from '../../ui/OcmFormFields';
@@ -32,13 +32,19 @@ type LvmLabelProps = ClusterOperatorProps & {
   supportLevel?: SupportLevel;
 };
 
-const LvmHelperText = ({ operatorName }: { operatorName: ExposedOperatorName }) => {
+const LvmHelperText = ({
+  operatorName,
+  docsVersion,
+}: {
+  operatorName: ExposedOperatorName;
+  docsVersion: string;
+}) => {
   return (
     <HelperText>
       <HelperTextItem variant="indeterminate">
         Storage virtualization that offers a more flexible approach for disk space management.{' '}
         {operatorName === OPERATOR_NAME_LVMS && (
-          <ExternalLink href={LVMS_LINK}>Learn more</ExternalLink>
+          <ExternalLink href={getLvmsDocsLink(docsVersion)}>Learn more</ExternalLink>
         )}
       </HelperTextItem>
     </HelperText>
@@ -61,7 +67,13 @@ const LvmLabel = ({ clusterId, operatorLabel, disabledReason, supportLevel }: Lv
   );
 };
 
-const LvmCheckbox = ({ clusterId }: ClusterOperatorProps) => {
+const LvmCheckbox = ({
+  clusterId,
+  openshiftVersion,
+}: {
+  clusterId: ClusterOperatorProps['clusterId'];
+  openshiftVersion?: ClusterOperatorProps['openshiftVersion'];
+}) => {
   const fieldId = getFieldId(LVM_FIELD_NAME, 'input');
 
   const featureSupportLevel = useNewFeatureSupportLevel();
@@ -103,7 +115,12 @@ const LvmCheckbox = ({ clusterId }: ClusterOperatorProps) => {
             supportLevel={featureSupportLevel.getFeatureSupportLevel('LVM')}
           />
         }
-        helperText={<LvmHelperText operatorName={operatorInfo.operatorName} />}
+        helperText={
+          <LvmHelperText
+            operatorName={operatorInfo.operatorName}
+            docsVersion={openshiftVersion || ''}
+          />
+        }
         isDisabled={!!disabledReason}
       />
     </FormGroup>

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/MceCheckbox.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/MceCheckbox.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { FormGroup, HelperText, HelperTextItem, Tooltip } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons/dist/js/icons/external-link-alt-icon';
-import { getFieldId, PopoverIcon, MCE_LINK } from '../../../../common';
+import { getFieldId, PopoverIcon, getMceDocsLink } from '../../../../common';
 import { OcmCheckboxField } from '../../ui/OcmFormFields';
 import { useNewFeatureSupportLevel } from '../../../../common/components/newFeatureSupportLevels';
 import { useSelector } from 'react-redux';
@@ -35,12 +35,12 @@ const MceLabel = ({
   );
 };
 
-const MceHelperText = () => {
+const MceHelperText = ({ docsVersion }: { docsVersion: string }) => {
   return (
     <HelperText>
       <HelperTextItem variant="indeterminate">
         Create, import, and manage multiple clusters from this cluster.{' '}
-        <a href={MCE_LINK} target="_blank" rel="noopener noreferrer">
+        <a href={getMceDocsLink(docsVersion)} target="_blank" rel="noopener noreferrer">
           {'Learn more'} <ExternalLinkAltIcon />
         </a>
       </HelperTextItem>
@@ -50,8 +50,10 @@ const MceHelperText = () => {
 
 const MceCheckbox = ({
   isVersionEqualsOrMajorThan4_15,
+  openshiftVersion,
 }: {
   isVersionEqualsOrMajorThan4_15: boolean;
+  openshiftVersion?: string;
 }) => {
   const isSNO = useSelector(selectIsCurrentClusterSNO);
   const featureSupportLevelContext = useNewFeatureSupportLevel();
@@ -69,7 +71,7 @@ const MceCheckbox = ({
           />
         }
         isDisabled={!!disabledReason}
-        helperText={<MceHelperText />}
+        helperText={<MceHelperText docsVersion={openshiftVersion || ''} />}
       />
     </FormGroup>
   );

--- a/libs/ui-lib/lib/ocm/components/clusterWizard/OperatorsStep.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/OperatorsStep.tsx
@@ -24,7 +24,10 @@ export const OperatorsStep = (props: ClusterOperatorProps) => {
         <CnvCheckbox {...props} isVersionEqualsOrMajorThan4_15={isVersionEqualsOrMajorThan4_15} />
       </StackItem>
       <StackItem>
-        <MceCheckbox isVersionEqualsOrMajorThan4_15={isVersionEqualsOrMajorThan4_15} />
+        <MceCheckbox
+          isVersionEqualsOrMajorThan4_15={isVersionEqualsOrMajorThan4_15}
+          openshiftVersion={props.openshiftVersion}
+        />
       </StackItem>
       {isVersionEqualsOrMajorThan4_15 ? (
         <>

--- a/libs/ui-lib/lib/ocm/components/hosts/HardwareStatus.tsx
+++ b/libs/ui-lib/lib/ocm/components/hosts/HardwareStatus.tsx
@@ -21,6 +21,7 @@ type HardwareStatusProps = {
   validationsInfo: ValidationsInfo;
   onEditHostname?: () => void;
   isWithinModal?: boolean;
+  openshiftVersion?: string;
 };
 
 const DELETE_MODAL_STATUS_Z_INDEX = 500;
@@ -53,6 +54,7 @@ const HardwareStatus = (props: HardwareStatusProps) => {
       status={{ ...status, sublabel }}
       validationsInfo={validationsInfo}
       AdditionalNTPSourcesDialogToggleComponent={AdditionalNTPSourcesDialogToggle}
+      openshiftVersion={props.openshiftVersion}
     />
   );
 };
@@ -60,9 +62,11 @@ const HardwareStatus = (props: HardwareStatusProps) => {
 export const hardwareStatusColumn = ({
   onEditHostname,
   isWithinModal,
+  openshiftVersion,
 }: {
   onEditHostname?: HostsTableActions['onEditHost'];
   isWithinModal?: boolean;
+  openshiftVersion?: string;
 }): TableRow<Host> => {
   return {
     header: {
@@ -82,6 +86,7 @@ export const hardwareStatusColumn = ({
             onEditHostname={editHostname}
             validationsInfo={validationsInfo}
             isWithinModal={isWithinModal}
+            openshiftVersion={openshiftVersion}
           />
         ),
         props: { 'data-testid': 'host-hw-status' },

--- a/libs/ui-lib/lib/ocm/components/hosts/HostsDiscoveryTable.tsx
+++ b/libs/ui-lib/lib/ocm/components/hosts/HostsDiscoveryTable.tsx
@@ -70,7 +70,10 @@ const HostsDiscoveryTable = ({ cluster }: HostsDiscoveryTableProps) => {
         selectSchedulableMasters(cluster),
         cluster.kind,
       ),
-      hardwareStatusColumn({ onEditHostname: onEditHost }),
+      hardwareStatusColumn({
+        onEditHostname: onEditHost,
+        openshiftVersion: cluster.openshiftVersion,
+      }),
       discoveredAtColumn(t),
       cpuCoresColumn(t),
       memoryColumn(t),


### PR DESCRIPTION
- Links that appear after the users choose an Openshift version must display docs for that specific version.

Some examples:

![image](https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/c47389b5-dee9-4de3-938c-969dbdee8e33)

![image](https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/aceff42b-9323-474c-86a6-48f3fbe78ec1)


