### PR TITLE
MGMT-17206: Add information to hosts inventory table about host stage timeout in Installation page

### DIFF
--- a/libs/ui-lib/lib/common/components/hosts/HostStatus.tsx
+++ b/libs/ui-lib/lib/common/components/hosts/HostStatus.tsx
@@ -12,9 +12,9 @@ import {
 import { PopoverProps } from '@patternfly/react-core/dist/js/components/Popover/Popover';
 import hdate from 'human-date';
 
-import { Host } from '@openshift-assisted/types/assisted-installer-service';
+import { Host, HostProgressInfo } from '@openshift-assisted/types/assisted-installer-service';
 import { ValidationsInfo } from '../../types/hosts';
-import { ExternalLink, getHumanizedDateTime } from '../ui';
+import { ExternalLink, UiIcon, getHumanizedDateTime } from '../ui';
 
 import HostProgress from './HostProgress';
 import { getHostProgressStageNumber, getHostProgressStages } from './utils';
@@ -31,6 +31,7 @@ import { UnknownIcon } from '@patternfly/react-icons/dist/js/icons/unknown-icon'
 import { useTranslation } from '../../hooks/use-translation-wrapper';
 import { hostStatus } from './status';
 import { getApproveNodesInClLink } from '../../config';
+import { ExclamationTriangleIcon } from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
 
 const getTitleWithProgress = (host: Host, status: HostStatusProps['status']) => {
   const stages = getHostProgressStages(host);
@@ -213,6 +214,24 @@ const WithHostStatusPopover: React.FC<WithHostStatusPopoverProps> = (props) => (
   </Popover>
 );
 
+const getHostStatusIcon = (icon: React.ReactNode, progress: HostProgressInfo | undefined) => {
+  if (progress?.stageTimedOut === undefined) {
+    return (
+      <Popover
+        bodyContent={
+          <small>
+            Waiting for control plane has been active more than the expected completion time.
+          </small>
+        }
+        minWidth="20rem"
+        maxWidth="30rem"
+      >
+        <UiIcon size="sm" status="warning" icon={<ExclamationTriangleIcon />} />
+      </Popover>
+    );
+  } else return icon;
+};
+
 const HostStatus: React.FC<HostStatusProps> = ({
   host,
   validationsInfo,
@@ -252,13 +271,14 @@ const HostStatus: React.FC<HostStatusProps> = ({
     openshiftVersion,
   };
 
+  const hostIcon = getHostStatusIcon(icon, host.progress);
   return (
     <Flex alignItems={{ default: 'alignItemsCenter' }} spaceItems={{ default: 'spaceItemsXs' }}>
       {
         <FlexItem>
           {(autoCSR && status.key === 'added-to-existing-cluster'
             ? hostStatus(t).installed.icon
-            : icon) || <UnknownIcon />}
+            : hostIcon) || <UnknownIcon />}
         </FlexItem>
       }
 

--- a/libs/ui-lib/lib/ocm/components/clusterDetail/HostInventoryExpandable.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterDetail/HostInventoryExpandable.tsx
@@ -1,11 +1,12 @@
 import React, { useState } from 'react';
-import { hostStatus } from '../../../common';
+import { UiIcon, hostStatus } from '../../../common';
 import ClusterHostsTable from '../hosts/ClusterHostsTable';
-import { getMostSevereHostStatus } from './utils';
+import { getHostsWithTimeout, getMostSevereHostStatus } from './utils';
 import { ExpandableSection } from '@patternfly/react-core';
 import './HostInventoryExpandable.css';
 import { Cluster } from '@openshift-assisted/types/assisted-installer-service';
 import { useTranslation } from '../../../common/hooks/use-translation-wrapper';
+import ExclamationTriangleIcon from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
 
 type HostInventoryExpandableProps = {
   cluster: Cluster;
@@ -31,11 +32,15 @@ const HostInventoryExpandable = ({ cluster }: HostInventoryExpandableProps) => {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-assignment
   const mostSevereHostStatus = getMostSevereHostStatus(hosts);
   const hostStatusDef = mostSevereHostStatus ? hostStatus(t)[mostSevereHostStatus] : null;
-
+  const someHostHasTimeout = getHostsWithTimeout(hosts);
+  const warningIcon = <UiIcon size="sm" status="warning" icon={<ExclamationTriangleIcon />} />;
   return (
     <ExpandableSection
       toggleContent={
-        <ExpandableSectionTitle hostsCount={hosts.length} icon={hostStatusDef?.icon} />
+        <ExpandableSectionTitle
+          hostsCount={hosts.length}
+          icon={someHostHasTimeout ? warningIcon : hostStatusDef?.icon}
+        />
       }
       onToggle={() => setIsExpanded(!isExpanded)}
       isExpanded={isExpanded}

--- a/libs/ui-lib/lib/ocm/components/clusterDetail/utils.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterDetail/utils.tsx
@@ -99,3 +99,13 @@ export const getMostSevereHostStatus = (hosts: Host[]) => {
   }
   return status;
 };
+
+export const getHostsWithTimeout = (hosts: Host[]) => {
+  for (let i = 0; i < hosts.length; i++) {
+    const host = hosts[i];
+    if (host.progress?.stageTimedOut !== undefined) {
+      return host.progress?.stageTimedOut;
+    }
+  }
+  return false;
+};


### PR DESCRIPTION
Related to [MGMT-17206](https://issues.redhat.com//browse/MGMT-17206)

When some of the hosts has a timeout in installation we see a warning icon next to "Host inventory" title:
![Captura desde 2024-05-16 14-32-02](https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/ba508b9f-3061-4bd4-879f-6c85015ab507)


And if user expands the "Host inventory" section can see info about the timeout in hosts:
![image](https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/32a37d62-11ce-4222-aa68-fed856c388fd)

And when host.progress.stagedtimeout is false then the icon changes another time:
![image](https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/7d561480-0639-4c7d-8c39-c14772fc3cac)

