### PR TITLE
MGMT-17904: Custom manifests page - UI not validating filename field before sending it to BE

### DIFF
--- a/libs/ui-lib-tests/cypress/integration/custom-manifests/3-removing-adding-custom-manifests.cy.ts
+++ b/libs/ui-lib-tests/cypress/integration/custom-manifests/3-removing-adding-custom-manifests.cy.ts
@@ -99,7 +99,10 @@ describe(`Assisted Installer Custom manifests step`, () => {
       CustomManifestsForm.initManifest(0, true);
       CustomManifestsForm.collapsedManifest(0).name();
       CustomManifestsForm.initManifest(1, true);
-      CustomManifestsForm.collapsedManifest(1).error();
+      CustomManifestsForm.collapsedManifest(1).name();
+      CustomManifestsForm.collapseManifest(2);
+      CustomManifestsForm.initManifest(2, true);
+      CustomManifestsForm.collapsedManifest(2).error();
     });
   });
 });

--- a/libs/ui-lib-tests/cypress/views/forms/CustomManifests/CustomManifestsForm.ts
+++ b/libs/ui-lib-tests/cypress/views/forms/CustomManifests/CustomManifestsForm.ts
@@ -38,4 +38,8 @@ export const CustomManifestsForm = {
         .as(`ExpandedManifest-${index}`);
     }
   },
+
+  collapseManifest: (index: number) => {
+    CustomManifestsForm.body().findByTestId(`toggle-manifest-${index}`).click();
+  },
 };

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/manifestsConfiguration/components/customManifestsValidationSchema.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/manifestsConfiguration/components/customManifestsValidationSchema.tsx
@@ -7,51 +7,86 @@ import {
   validateFileType,
   INCORRECT_TYPE_FILE_MESSAGE,
 } from '../../../../../common/utils';
+
+import * as yup from 'yup';
+
+/* eslint-disable */
+type CustomManifestMapper = (a: CustomManifestValues) => string;
+
+declare module 'yup' {
+  interface ArraySchema<
+    TIn extends any[] | null | undefined,
+    TContext,
+    TDefault = undefined,
+    TFlags extends Yup.Flags = '',
+  > {
+    uniqueManifestFiles(message: string, mapper: CustomManifestMapper): this;
+  }
+}
+/* eslint-enable */
+
+Yup.addMethod(
+  Yup.array,
+  'uniqueManifestFiles',
+  function (message: string, mapper: CustomManifestMapper) {
+    return this.test('unique', message, function (list: CustomManifestValues[] | undefined) {
+      if (!list) return true;
+
+      const seen = new Set();
+      const errors: yup.ValidationError[] = [];
+
+      list.forEach((item, index) => {
+        const mappedValue = mapper(item);
+        if (seen.has(mappedValue)) {
+          errors.push(
+            this.createError({
+              path: `${this.path}[${index}].filename`,
+              message,
+            }),
+          );
+        }
+        seen.add(mappedValue);
+      });
+
+      if (errors.length > 0) {
+        throw new yup.ValidationError(errors);
+      }
+
+      return true;
+    });
+  },
+);
+
 const INCORRECT_FILENAME =
   'Must have a yaml, yml, json, yaml.patch or yml.patch extension and can not contain /.';
 
 const UNIQUE_FOLDER_FILENAME = 'Ensure unique file names to avoid conflicts and errors.';
 
-export const getUniqueValidationSchema = Yup.string().test(
-  'unique',
-  UNIQUE_FOLDER_FILENAME,
-  (value, testContext: Yup.TestContext) => {
-    const context = testContext.options.context as Yup.TestContext & { values?: ManifestFormData };
-    if (!context || !context.values) {
-      return testContext.createError({
-        message: 'Unexpected error: Yup test context should contain form values',
-      });
-    }
-
-    const values = context.values.manifests.map((manifest) => manifest.filename);
-    return values.filter((path) => path === value).length === 1;
-  },
-);
-
 export const getFormViewManifestsValidationSchema = Yup.object<ManifestFormData>({
-  manifests: Yup.array<CustomManifestValues>().of(
-    Yup.object({
-      folder: Yup.mixed().required('Required'),
-      filename: Yup.string()
-        .required('Required')
-        .min(1, 'Number of characters must be 1-255')
-        .max(255, 'Number of characters must be 1-255')
-        .test('not-correct-filename', INCORRECT_FILENAME, (value: string) => {
-          return validateFileName(value);
-        })
-        .concat(getUniqueValidationSchema),
-      manifestYaml: Yup.string().when('filename', {
-        is: (filename: string) => !filename.includes('patch'),
-        then: () =>
-          Yup.string()
-            .required('Required')
-            .test('not-big-file', getMaxFileSizeMessage, validateFileSize)
-            .test('not-valid-file', INCORRECT_TYPE_FILE_MESSAGE, validateFileType),
-        otherwise: () =>
-          Yup.string()
-            .required('Required')
-            .test('not-big-file', getMaxFileSizeMessage, validateFileSize), // Validation of file content is not required if filename contains 'patch'
+  manifests: Yup.array<CustomManifestValues>()
+    .of(
+      Yup.object({
+        folder: Yup.mixed().required('Required'),
+        filename: Yup.string()
+          .required('Required')
+          .min(1, 'Number of characters must be 1-255')
+          .max(255, 'Number of characters must be 1-255')
+          .test('not-correct-filename', INCORRECT_FILENAME, (value: string) => {
+            return validateFileName(value);
+          }),
+        manifestYaml: Yup.string().when('filename', {
+          is: (filename: string) => !filename.includes('patch'),
+          then: () =>
+            Yup.string()
+              .required('Required')
+              .test('not-big-file', getMaxFileSizeMessage, validateFileSize)
+              .test('not-valid-file', INCORRECT_TYPE_FILE_MESSAGE, validateFileType),
+          otherwise: () =>
+            Yup.string()
+              .required('Required')
+              .test('not-big-file', getMaxFileSizeMessage, validateFileSize), // Validation of file content is not required if filename contains 'patch'
+        }),
       }),
-    }),
-  ),
+    )
+    .uniqueManifestFiles(UNIQUE_FOLDER_FILENAME, (val: CustomManifestValues) => val.filename),
 });


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-17904

Custm manifests page - UI not validating filename field before sending it to BE, thus every request sent to BE contains an illegal filename (even in PATCH).

Implementation of unique method in Yup.array comes from here: https://github.com/jquense/yup/issues/345

