### PR TITLE
MGMT-17804: Change validation for patch manifests 

### DIFF
--- a/libs/ui-lib-tests/cypress/integration/custom-manifests/2-modifying-existing-custom-manifest.cy.ts
+++ b/libs/ui-lib-tests/cypress/integration/custom-manifests/2-modifying-existing-custom-manifest.cy.ts
@@ -119,5 +119,22 @@ describe(`Assisted Installer Custom manifests step`, () => {
         .attachFile(`custom-manifests/files/manifest_multiple.yaml`);
       commonActions.verifyNextIsEnabled();
     });
+
+    it('Testing that incorrect patch name for manifests is not allowed', () => {
+      CustomManifestsForm.initManifest(0);
+      CustomManifestsForm.expandedManifest(0).fileName().clear().type('test.yaml.patch.aaa');
+      CustomManifestsForm.expandedManifest(0)
+        .fileNameError()
+        .should(
+          'contain.text',
+          'Must have a yaml, yml, json, yaml.patch or yml.patch extension and can not contain /.',
+        );
+
+      CustomManifestsForm.validationAlert().should(
+        'contain.text',
+        'Custom manifests configuration contains missing or invalid fields',
+      );
+      commonActions.verifyNextIsDisabled();
+    });
   });
 });

--- a/libs/ui-lib/lib/common/utils.ts
+++ b/libs/ui-lib/lib/common/utils.ts
@@ -4,7 +4,7 @@ import isString from 'lodash-es/isString.js';
 import { loadAll } from 'js-yaml';
 import { MAX_FILE_SIZE_BYTES, MAX_FILE_SIZE_OFFSET_FACTOR } from './configurations';
 
-export const FILENAME_REGEX = /^[^/]*\.(yaml|yml|json|yaml.patch.*|yml.patch.*)$/;
+export const FILENAME_REGEX = /^[^\/]*\.(json|ya?ml(\.patch_?[a-zA-Z0-9_]*)?)$/;
 
 export const FILE_TYPE_MESSAGE = 'Unsupported file type. Please provide a valid YAML file.';
 export const INCORRECT_TYPE_FILE_MESSAGE =

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/manifestsConfiguration/components/CustomManifestsForm.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/manifestsConfiguration/components/CustomManifestsForm.tsx
@@ -76,13 +76,12 @@ export const CustomManifestsForm = ({
 
   const handleSubmit: FormikConfig<ManifestFormData>['onSubmit'] = React.useCallback(
     async ({ manifests }, actions) => {
+      clearAlerts();
       if (manifests.length < customManifestsLocalRef.current.length) {
         // submit was triggered by deleting a manifest
-
         customManifestsLocalRef.current = manifests;
         return;
       } else {
-        clearAlerts();
         actions.setSubmitting(true);
 
         for (let index = 0; index < manifests.length; index++) {


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-17804

Align regexp to validate manifests file name with the same regexp from assisted-service.
And also changes the code to clear alerts when form is submitting.

![image](https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/1c820fc0-f912-4d5e-8f6b-ba0ed9adcdd1)
