### PR TITLE
MGMT-17955: Show the correct icon next to the nodes

### DIFF
--- a/libs/ui-lib/lib/common/components/hosts/HostStatus.tsx
+++ b/libs/ui-lib/lib/common/components/hosts/HostStatus.tsx
@@ -215,7 +215,7 @@ const WithHostStatusPopover: React.FC<WithHostStatusPopoverProps> = (props) => (
 );
 
 const getHostStatusIcon = (icon: React.ReactNode, progress: HostProgressInfo | undefined) => {
-  if (progress?.stageTimedOut === undefined) {
+  if (progress?.stageTimedOut !== undefined) {
     return (
       <Popover
         bodyContent={


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-17955

With latest changes, warning sign/icon appears next to the nodes although should be green. It seems it's a wrong condition in HostStatus file.

Before:
![image](https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/6d34c05b-c9e7-4d86-9ee4-50a8b02c0197)

After:
![image](https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/77945104-67f5-4157-b3ee-219ecdc6763c)

