### PR TITLE
MGMT-17955: Show the correct icon next to the nodes  - 2.32

### DIFF
--- a/libs/ui-lib/lib/common/components/hosts/HostStatus.tsx
+++ b/libs/ui-lib/lib/common/components/hosts/HostStatus.tsx
@@ -215,7 +215,7 @@ const WithHostStatusPopover: React.FC<WithHostStatusPopoverProps> = (props) => (
 );
 
 const getHostStatusIcon = (icon: React.ReactNode, progress: HostProgressInfo | undefined) => {
-  if (progress?.stageTimedOut === undefined) {
+  if (progress?.stageTimedOut !== undefined) {
     return (
       <Popover
         bodyContent={


### PR DESCRIPTION
backport of #2587 