### PR TITLE
MGMT-18050: UI warning icon not changed to error icon on 24 hours timeout in hosts table

### DIFF
--- a/libs/ui-lib/lib/common/components/hosts/HostStatus.tsx
+++ b/libs/ui-lib/lib/common/components/hosts/HostStatus.tsx
@@ -214,8 +214,12 @@ const WithHostStatusPopover: React.FC<WithHostStatusPopoverProps> = (props) => (
   </Popover>
 );
 
-const getHostStatusIcon = (icon: React.ReactNode, progress: HostProgressInfo | undefined) => {
-  if (progress?.stageTimedOut !== undefined) {
+const getHostStatusIcon = (
+  icon: React.ReactNode,
+  progress: HostProgressInfo | undefined,
+  status: HostStatusProps['status'],
+) => {
+  if (progress?.stageTimedOut !== undefined && status.title !== 'Error') {
     return (
       <Popover
         bodyContent={
@@ -271,7 +275,7 @@ const HostStatus: React.FC<HostStatusProps> = ({
     openshiftVersion,
   };
 
-  const hostIcon = getHostStatusIcon(icon, host.progress);
+  const hostIcon = getHostStatusIcon(icon, host.progress, status);
   return (
     <Flex alignItems={{ default: 'alignItemsCenter' }} spaceItems={{ default: 'spaceItemsXs' }}>
       {


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-18050

When timeout occured during installation  there is  a yellow triangle for warnning
In case total timeout 24 hours , hosts ((all) changed to error RED.

Before changes:
![image](https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/f904f137-9491-4477-b3da-dffa0769e87d)

After changes:
![image](https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/dbc6640d-22f1-442a-b140-973b99a7fb8e)
