### PR TITLE
MGMT-16996: Show only LVMS requirements messages from BE

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/LvmHostRequirements.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/LvmHostRequirements.tsx
@@ -23,18 +23,11 @@ const LvmHostRequirements = ({ clusterId }: { clusterId: ClusterOperatorProps['c
     (operatorRequirements) => operatorRequirements.operatorName === OPERATOR_NAME_LVM,
   );
 
-  const { qualitative = [], quantitative } = lvmRequirements?.requirements
+  const { qualitative = [] } = lvmRequirements?.requirements
     ?.master as HostTypeHardwareRequirements;
 
   return (
     <List>
-      {quantitative && (
-        <ListItem>
-          The host node requires an additional {quantitative.ramMib} MiB of memory{' '}
-          {quantitative.diskSizeGb ? ',' : ' and'} {quantitative.cpuCores} CPUs
-          {quantitative?.diskSizeGb ? ` and ${quantitative?.diskSizeGb} storage space` : ''}
-        </ListItem>
-      )}
       {qualitative.map((qualitativeItem, index) => (
         <ListItem key={index}>{qualitativeItem}</ListItem>
       ))}


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-16996

UI displays message parsing required information and show's API information which are the same.

Before changes:
![Captura desde 2024-06-12 10-47-57](https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/cf1700a4-ede1-469a-8a21-c57cc9fd76c1)

After changes:
![Captura desde 2024-06-12 10-56-58](https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/f695941b-92f5-453e-9618-f4e3a862d947)
