### PR TITLE
MGMT-17388: Log string literal format shown with "special" characters

### DIFF
--- a/libs/ui-lib/lib/common/components/ui/EventsList.tsx
+++ b/libs/ui-lib/lib/common/components/ui/EventsList.tsx
@@ -86,7 +86,7 @@ const EventsList = ({ events, resetFilters }: EventsListProps) => {
                 </Label>{' '}
               </>
             )}
-            {event.message}
+            {event.message.replace(/\\n/, ' ')}
           </>
         ),
       },


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-17388

![image](https://github.com/openshift-assisted/assisted-installer-ui/assets/87187179/6feed1cf-80cd-4253-878f-a3910f1b8635)

Replacing `\n` with a space is probably the best we can do here.