### PR TITLE
MGMT-18357: Change alignment of MacIpMapping fields in Static Network Configuration

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/staticIp/components/YamlView/MacIpMapping.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/staticIp/components/YamlView/MacIpMapping.tsx
@@ -74,12 +74,12 @@ export const MacIpMapping = ({
 
   return (
     <Grid className="mac-ip-mapping">
-      <GridItem span={6}>
-        <FieldArray
-          name={fieldName}
-          validateOnChange={false}
-          render={({ push, remove }) => (
-            <Grid hasGutter>
+      <FieldArray
+        name={fieldName}
+        validateOnChange={false}
+        render={({ push, remove }) => (
+          <Grid hasGutter>
+            <GridItem span={6}>
               {macInterfaceMap.map((_, idx) => (
                 <MacMappingItem
                   key={getFormikArrayItemFieldName(fieldName, idx)}
@@ -90,12 +90,11 @@ export const MacIpMapping = ({
                   hostIdx={hostIdx}
                 />
               ))}
-
-              {!isViewerMode && <AddMapping onPush={push} />}
-            </Grid>
-          )}
-        />
-      </GridItem>
+            </GridItem>
+            <GridItem>{!isViewerMode && <AddMapping onPush={push} />}</GridItem>
+          </Grid>
+        )}
+      />
     </Grid>
   );
 };


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-18357

If we create a cluster with Static IP configuration and try to map different Map interfaces the fields don't look aligned.

Before changes:

![image](https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/e0e3cac0-e62f-4e0d-8d35-e5b13ba8f155)


After changes:
![image](https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/bd2ef757-4477-4933-b868-7738786db494)
