### PR TITLE
MGMT-18358: Clear alerts when change from one view to another in Static network configurations step

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/staticIp/components/StaticIpViewRadioGroup.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/staticIp/components/StaticIpViewRadioGroup.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Alert, AlertVariant, ButtonVariant, Form, FormGroup } from '@patternfly/react-core';
 import { StaticIpView } from '../data/dataTypes';
-import { getFieldId } from '../../../../../common';
+import { getFieldId, useAlerts } from '../../../../../common';
 import ConfirmationModal from '../../../../../common/components/ui/ConfirmationModal';
 import { OcmRadio } from '../../../ui/OcmFormFields';
 
@@ -16,6 +16,7 @@ const StaticIpViewRadioGroup = ({
   confirmOnChangeView,
   onChangeView,
 }: StaticIpViewRadioGroupProps) => {
+  const { clearAlerts } = useAlerts();
   const GROUP_NAME = 'select-static-ip-view';
   const [confirmView, setConfirmView] = React.useState<StaticIpView>();
   const [view, setView] = React.useState<StaticIpView>(initialView);
@@ -30,6 +31,7 @@ const StaticIpViewRadioGroup = ({
   };
 
   const onConfirm = (selectedView: StaticIpView) => {
+    clearAlerts();
     setView(selectedView);
     setConfirmView(undefined);
     onChangeView(selectedView);


### PR DESCRIPTION
Related with https://issues.redhat.com/browse/MGMT-18358

In "Static Network Configurations" page, in Yaml view if you add invalid YAML and some mac interface mapping and change to Form view the error alert don't dissapears


https://github.com/openshift-assisted/assisted-installer-ui/assets/11390125/155792a0-db46-473c-ae41-bd67d71dfa41

