### PR TITLE
MGMT-18567: Solving errors in clusters list

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusters/ClustersListToolbar.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusters/ClustersListToolbar.tsx
@@ -102,6 +102,11 @@ const ClustersListToolbar: React.FC<ClustersListToolbarProps> = ({
     </>
   );
   const { t } = useTranslation();
+
+  React.useEffect(() => {
+    window.addEventListener('resize', () => setStatusExpanded(false));
+  }, []);
+
   return (
     <Toolbar
       id="clusters-list-toolbar"


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-18567

Try to solve the error that happens in Assisted Installer clusters list:

![image](https://github.com/user-attachments/assets/dcd70176-5e29-461e-9b2a-00b97e6ebb85)
