### PR TITLE
Work with OCM-UI router v6 ugprade

### DIFF
--- a/libs/ui-lib/lib/ocm/components/Routes.tsx
+++ b/libs/ui-lib/lib/ocm/components/Routes.tsx
@@ -1,6 +1,13 @@
 import React from 'react';
 import { Provider } from 'react-redux';
-import { Routes, Route, Navigate, Outlet } from 'react-router-dom-v5-compat';
+import {
+  Routes,
+  Route,
+  Navigate,
+  Outlet,
+  unstable_HistoryRouter as HistoryRouter,
+  HistoryRouterProps,
+} from 'react-router-dom-v5-compat';
 import { Clusters, ClusterPage, NewClusterPage } from './clusters';
 import type { FeatureListType } from '../../common/features/featureGate';
 import { AssistedUILibVersion } from './ui';
@@ -10,24 +17,38 @@ import { useFeatureDetection } from '../hooks/use-feature-detection';
 export const UILibRoutes = ({
   allEnabledFeatures,
   children,
+  history,
+  basename,
 }: {
   allEnabledFeatures: FeatureListType;
   children?: React.ReactNode;
+  history?: HistoryRouterProps['history'];
+  basename?: string;
 }) => {
   useFeatureDetection(allEnabledFeatures);
+
+  const routes = (
+    <Routes>
+      <Route path="assisted-installer/clusters" element={<Outlet />}>
+        <Route path="~new" element={<NewClusterPage />} />
+        <Route path=":clusterId" element={<ClusterPage />} />
+        <Route index element={<Clusters />} />
+      </Route>
+      {children}
+      <Route path="assisted-installer/*" element={<Navigate to="clusters" />} />
+    </Routes>
+  );
 
   return (
     <Provider store={storeDay1}>
       <AssistedUILibVersion />
-      <Routes>
-        <Route path="clusters" element={<Outlet />}>
-          <Route path="~new" element={<NewClusterPage />} />
-          <Route path=":clusterId" element={<ClusterPage />} />
-          <Route index element={<Clusters />} />
-        </Route>
-        {children}
-        <Route path="*" element={<Navigate to="clusters" />} />
-      </Routes>
+      {history ? (
+        <HistoryRouter history={history} basename={basename || '/'}>
+          {routes}
+        </HistoryRouter>
+      ) : (
+        routes
+      )}
     </Provider>
   );
 };

--- a/libs/ui-lib/lib/ocm/components/clusters/ClusterBreadcrumbs.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusters/ClusterBreadcrumbs.tsx
@@ -12,7 +12,7 @@ const ClusterBreadcrumbs = ({ clusterName }: { clusterName?: string }) => (
   <PageSection variant={PageSectionVariants.light}>
     {(clusterName || isInOcm) && (
       <Breadcrumb>
-        <BreadcrumbItem render={() => <Link to={'/'}>Clusters</Link>} />
+        <BreadcrumbItem render={() => <Link to={'/'}>Cluster List</Link>} />
 
         {clusterName ? (
           <BreadcrumbItem>

--- a/libs/ui-lib/package.json
+++ b/libs/ui-lib/package.json
@@ -28,6 +28,8 @@
     "prism-react-renderer": "^1.1.1",
     "react-error-boundary": "^3.1.4",
     "react-measure": "^2.5.2",
+    "react-router-dom": "^5.3.3",
+    "react-router-dom-v5-compat": "^6.21.2",
     "swr": "^2",
     "tslib": "^2.6.1",
     "unique-names-generator": "^4.2.0"
@@ -101,7 +103,6 @@
     "react-i18next": ">11.7.3",
     "react-monaco-editor": "^0.55.0",
     "react-redux": "^8.0.5",
-    "react-router-dom-v5-compat": "^6.21.2",
     "react-tagsinput": "^3.20",
     "redux": "^4",
     "uuid": "^8.1",

--- a/libs/ui-lib/package.json
+++ b/libs/ui-lib/package.json
@@ -28,7 +28,6 @@
     "prism-react-renderer": "^1.1.1",
     "react-error-boundary": "^3.1.4",
     "react-measure": "^2.5.2",
-    "react-router-dom": "^5.3.3",
     "react-router-dom-v5-compat": "^6.21.2",
     "swr": "^2",
     "tslib": "^2.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -902,6 +902,8 @@ __metadata:
     prism-react-renderer: ^1.1.1
     react-error-boundary: ^3.1.4
     react-measure: ^2.5.2
+    react-router-dom: ^5.3.3
+    react-router-dom-v5-compat: ^6.21.2
     swr: ^2
     tslib: ^2.6.1
     unique-names-generator: ^4.2.0
@@ -916,7 +918,6 @@ __metadata:
     react-i18next: ">11.7.3"
     react-monaco-editor: ^0.55.0
     react-redux: ^8.0.5
-    react-router-dom-v5-compat: ^6.21.2
     react-tagsinput: ^3.20
     redux: ^4
     uuid: ^8.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -902,7 +902,6 @@ __metadata:
     prism-react-renderer: ^1.1.1
     react-error-boundary: ^3.1.4
     react-measure: ^2.5.2
-    react-router-dom: ^5.3.3
     react-router-dom-v5-compat: ^6.21.2
     swr: ^2
     tslib: ^2.6.1


### PR DESCRIPTION
After making these changes it works with the react-router-dom v6 upgrade on OCM-UI ([gitlab MR here](https://gitlab.cee.redhat.com/service/uhc-portal/-/merge_requests/5830))

```
// In OCM-UI:
import { Route } from 'react-router-dom'; // V6
import { UILibRoutes as AssistedInstallerRoutes } from '@openshift-assisted/ui-lib/ocm';
import useChrome from '@redhat-cloud-services/frontend-components/useChrome';

const { chromeHistory } = useChrome();

<Route
          path="/assisted-installer/*"
          element={
            <AssistedInstallerRoutes
              // this is a required prop, why?
              allEnabledFeatures={{}}
              history={chromeHistory}
              basename="/openshift"
            />
          }
        />
```

**Note: I have not tested these changes outside of OCM-UI**

**Note 2: I've released these changes to [npm](https://www.npmjs.com/package/@breakaway/ui-lib) to temporarily test this out and enable review of OCM-UI MR**