### PR TITLE
Log string literal format shown with "special" characters

### DIFF
--- a/libs/ui-lib/lib/common/components/hosts/HostValidationGroups.tsx
+++ b/libs/ui-lib/lib/common/components/hosts/HostValidationGroups.tsx
@@ -64,7 +64,8 @@ const ValidationsAlert = ({
       <ul>
         {validations.map((v) => (
           <li key={v.id}>
-            <strong>{hostValidationLabels(t)[v.id] || v.id}:</strong>&nbsp;{toSentence(v.message)}{' '}
+            <strong>{hostValidationLabels(t)[v.id] || v.id}:</strong>&nbsp;
+            {toSentence(v.message.replace(/\\n/, ' '))}{' '}
             {v.status === 'failure' && hostValidationFailureHints(t)[v.id]}
           </li>
         ))}


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-17388

Apparently, there was a problem with `\n` in host validation status messages as well (see image). This PR should fix that.

![image](https://github.com/user-attachments/assets/282c152f-bfa7-4e42-a8ee-8dd2f73da08d)
