### PR TITLE
ACM-13211: Low text visibility in label input field due to dark background color in ACM infrastructure environment creation page

### DIFF
--- a/libs/ui-lib/lib/common/components/ui/formik/LabelField.css
+++ b/libs/ui-lib/lib/common/components/ui/formik/LabelField.css
@@ -6,6 +6,11 @@
   border: 1px solid transparent;
   outline: none;
   width: 100%;
+  background-color: initial;
+}
+
+.label-field__input::placeholder {
+  color: var(--pf-v5-c-form-control--m-placeholder--Color);
 }
 
 .label-field .react-autosuggest__suggestions-list {


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-13211
Version for master of https://github.com/openshift-assisted/assisted-installer-ui/pull/2689

**Before:**
![image](https://github.com/user-attachments/assets/55d1050a-d689-431e-8dcd-18554d9a46cc)


**After:**
![image](https://github.com/user-attachments/assets/3aef25a9-5e33-43b6-8789-27eab05a58a1)
