### PR TITLE
MGMT-19202: Changes related with Assisted Migration

### DIFF
--- a/libs/ui-lib/lib/common/config/constants.ts
+++ b/libs/ui-lib/lib/common/config/constants.ts
@@ -321,3 +321,5 @@ export const operatorLabels = (
 };
 
 export const AI_UI_TAG = 'ui_ocm';
+
+export const AI_ASSISTED_MIGRATION_TAG = 'assisted_migration';

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/CustomManifestCheckbox.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/CustomManifestCheckbox.tsx
@@ -13,6 +13,7 @@ import { useClusterWizardContext } from '../clusterWizard/ClusterWizardContext';
 import DeleteCustomManifestModal from './manifestsConfiguration/DeleteCustomManifestModal';
 import { ClustersService } from '../../services';
 import { ClustersAPI } from '../../services/apis';
+import { useLocation } from 'react-router-dom-v5-compat';
 
 const Label = () => {
   return (
@@ -37,6 +38,18 @@ const CustomManifestCheckbox = ({ clusterId, isDisabled }: CustomManifestCheckbo
   const fieldId = getFieldId(name, 'input');
   const clusterWizardContext = useClusterWizardContext();
   const [isDeleteCustomManifestsOpen, setDeleteCustomManifestsOpen] = React.useState(false);
+  const location = useLocation();
+
+  React.useEffect(() => {
+    const searchParams = new URLSearchParams(location.search);
+    const isAssistedMigration = searchParams.get('source') === 'assisted_migration';
+
+    if (isAssistedMigration) {
+      setValue(true);
+      clusterWizardContext.setCustomManifestsStep(true);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [location]);
 
   const cleanCustomManifests = React.useCallback(async () => {
     const { data: manifests } = await ClustersAPI.getManifests(clusterId);

--- a/libs/ui-lib/lib/ocm/components/clusterWizard/ClusterDetails.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/ClusterDetails.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom-v5-compat';
+import { useLocation, useNavigate } from 'react-router-dom-v5-compat';
 import { useDispatch } from 'react-redux';
 import { useAlerts, LoadingState, ClusterWizardStep, ErrorState } from '../../../common';
 import { usePullSecret } from '../../hooks';
@@ -37,6 +37,7 @@ const ClusterDetails = ({ cluster, infraEnv }: ClusterDetailsProps) => {
     loading: loadingOCPVersions,
     latestVersions: versions,
   } = useOpenshiftVersionsContext();
+  const location = useLocation();
 
   const handleClusterUpdate = React.useCallback(
     async (
@@ -72,7 +73,9 @@ const ClusterDetails = ({ cluster, infraEnv }: ClusterDetailsProps) => {
     async (params: ClusterCreateParamsWithStaticNetworking, addCustomManifests: boolean) => {
       clearAlerts();
       try {
-        const cluster = await ClustersService.create(params);
+        const searchParams = new URLSearchParams(location.search);
+        const isAssistedMigration = searchParams.get('source') === 'assisted_migration';
+        const cluster = await ClustersService.create(params, isAssistedMigration);
         navigate(`../${cluster.id}`, { state: ClusterWizardFlowStateNew });
         await UISettingService.update(cluster.id, { addCustomManifests });
       } catch (e) {
@@ -84,7 +87,7 @@ const ClusterDetails = ({ cluster, infraEnv }: ClusterDetailsProps) => {
         }
       }
     },
-    [clearAlerts, navigate, addAlert, dispatch],
+    [clearAlerts, location.search, navigate, addAlert, dispatch],
   );
 
   const navigation = <ClusterWizardNavigation cluster={cluster} />;

--- a/libs/ui-lib/lib/ocm/services/ClustersService.ts
+++ b/libs/ui-lib/lib/ocm/services/ClustersService.ts
@@ -14,7 +14,7 @@ import omit from 'lodash-es/omit.js';
 import ClustersAPI from '../../common/api/assisted-service/ClustersAPI';
 import HostsService from './HostsService';
 import InfraEnvsService from './InfraEnvsService';
-import { AI_UI_TAG } from '../../common/config/constants';
+import { AI_ASSISTED_MIGRATION_TAG, AI_UI_TAG } from '../../common/config/constants';
 import { isInOcm } from '../../common/api/axiosClient';
 
 const ClustersService = {
@@ -22,7 +22,10 @@ const ClustersService = {
     return hosts.find((host) => host.id === hostId);
   },
 
-  async create(params: ClusterCreateParamsWithStaticNetworking) {
+  async create(params: ClusterCreateParamsWithStaticNetworking, isAssistedMigration?: boolean) {
+    if (isAssistedMigration) {
+      params.tags = AI_ASSISTED_MIGRATION_TAG;
+    }
     const { data: cluster } = await ClustersAPI.register(omit(params, 'staticNetworkConfig'));
     const infraEnvCreateParams: InfraEnvCreateParams = {
       name: `${params.name}_infra-env`,


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-19202
JIRA tickets related :

- https://issues.redhat.com/browse/ECOPROJECT-2217
- https://issues.redhat.com/browse/ECOPROJECT-2301 
- https://issues.redhat.com/browse/ECOPROJECT-2260

When we come from Assisted Migration we  implement this:

- Add a tag for the service dashboard ('assisted_migration')
- Check the manifest checkbox automatically
- Add a parameter to know that we come from Assisted Migration (source=assisted_migraiton)

When the URL contains the parameter "source=assisted_migration" we fill some fields i n the cluster creation automatically:


https://github.com/user-attachments/assets/7b2f8d8e-3676-4468-83bf-fb186bff4a8b




