### PR TITLE
NO-ISSUE: Update translation instructions

### DIFF
--- a/docs/I18N.md
+++ b/docs/I18N.md
@@ -26,5 +26,9 @@ environment variable called: `TRANSLATION_NAMESPACE` in order to avoid naming co
 
   Add 'ai:' prefix to all strings.
 
-- Running `yarn i18n` updates the JSON files in the `locales` folder when adding or changing
-  messages.
+- Running the following command to update the JSON files in the `locales` folder when adding or changing
+  messages:
+
+  ```
+  yarn workspace @openshift-assisted/locales run process_new_strings
+  ```


### PR DESCRIPTION
Currently the internationalization document says that running `yarn i18n` updates the translation files, but that doesn't work: looks like it was changed but the documentation wasn't. The command seems to be this now:

```
yarn workspace @openshift-assisted/locales run process_new_strings
```

This patch updates the documentation accordingly.