### PR TITLE
MGMT-19285: Change data-testid='nic-status' in networking page to data-testid='host-status'

### DIFF
--- a/libs/ui-lib-tests/cypress/support/variables/networking.ts
+++ b/libs/ui-lib-tests/cypress/support/variables/networking.ts
@@ -9,7 +9,7 @@ Cypress.env('shareDiscoverySshKeyFieldId', '#form-checkbox-shareDiscoverySshKey-
 Cypress.env('inputSshPublicKeyFieldId', '#form-input-sshPublicKey-field');
 Cypress.env('networkingVmsAlert', 'networking-vms-alert');
 Cypress.env('vipAutoAllocSupportLevel', `[data-testid=VIP_AUTO_ALLOC-support-level]`);
-Cypress.env('nicStatus', `[data-testid=nic-status]`);
+Cypress.env('nicStatus', `[data-testid=host-status]`);
 Cypress.env('apiVipFieldHelperId', '#form-input-apiVip-field-helper');
 Cypress.env('clusterNetworkCidrFieldHelperId', '#form-input-clusterNetworks-0-cidr-field-helper');
 Cypress.env(

--- a/libs/ui-lib-tests/cypress/views/networkingPage.ts
+++ b/libs/ui-lib-tests/cypress/views/networkingPage.ts
@@ -63,12 +63,15 @@ export const networkingPage = {
   },
   waitForNetworkStatusToNotContain: (text, timeout = Cypress.env('HOST_READY_TIMEOUT')) => {
     cy.get('table.hosts-table > tbody > tr:not([hidden])').each((row) =>
-      cy.wrap(row).find('td[data-testid="nic-status"]', { timeout }).should('not.contain', text),
+      cy.wrap(row).find('td[data-testid="host-status"]', { timeout }).should('not.contain', text),
     );
   },
   waitForNetworkStatus: (status, timeout = Cypress.env('HOST_READY_TIMEOUT')) => {
     cy.get('table.hosts-table > tbody > tr:not([hidden])').each((row) =>
-      cy.wrap(row).find('td[data-testid="nic-status"]', { timeout }).should('contain.text', status),
+      cy
+        .wrap(row)
+        .find('td[data-testid="host-status"]', { timeout })
+        .should('contain.text', status),
     );
   },
   waitForHostNetworkStatusInsufficient: (
@@ -77,7 +80,7 @@ export const networkingPage = {
   ) => {
     // host row index starts at 0 and increments by 2
     cy.newByDataTestId(`host-row-${idx}`).within(() => {
-      cy.newByDataTestId('nic-status', timeout).should('contain.text', 'Insufficient');
+      cy.newByDataTestId('host-status', timeout).should('contain.text', 'Insufficient');
     });
   },
   getClusterNetworkCidr: () => {

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfigurationTableBase.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfigurationTableBase.tsx
@@ -38,7 +38,7 @@ export const networkingStatusColumn = (
           validationsInfo={validationsInfo}
         />
       ),
-      props: { 'data-testid': 'nic-status' },
+      props: { 'data-testid': 'host-status' },
       sortableValue: status,
     };
   },


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-19285

Change data-testid="nic-status" in networking page to data-testid="host-status":
![image](https://github.com/user-attachments/assets/baec4c09-3aa9-475f-914d-a0aefed51f39)

