### PR TITLE
MGMT-19276: Add SNO tooltip information for MTV operator

### DIFF
--- a/libs/ui-lib/lib/ocm/components/featureSupportLevels/featureStateUtils.ts
+++ b/libs/ui-lib/lib/ocm/components/featureSupportLevels/featureStateUtils.ts
@@ -222,6 +222,9 @@ export const getNewFeatureDisabledReason = (
       }
     }
     case 'MTV': {
+      if (cluster && isSNO(cluster)) {
+        return 'Migration Toolkit for Virtualization is not supported for Single-Node OpenShift';
+      }
       if (!isSupported) {
         return 'Migration Toolkit for Virtualization is not supported in this OpenShift version';
       }


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-19276

MTV Operator - SNO Cluster misleading tooltip information:
![Captura desde 2024-11-15 10-55-45](https://github.com/user-attachments/assets/ddee3813-19ca-4808-898c-5524237ba505)
