### PR TITLE
MGMT-19330: MTV on SNO - operator enabled

### DIFF
--- a/libs/ui-lib/lib/ocm/components/featureSupportLevels/featureStateUtils.ts
+++ b/libs/ui-lib/lib/ocm/components/featureSupportLevels/featureStateUtils.ts
@@ -222,9 +222,6 @@ export const getNewFeatureDisabledReason = (
       }
     }
     case 'MTV': {
-      if (cluster && isSNO(cluster)) {
-        return 'Migration Toolkit for Virtualization is not supported for Single-Node OpenShift';
-      }
       if (!isSupported) {
         return 'Migration Toolkit for Virtualization is not supported in this OpenShift version';
       }


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-19330

When cluster is SNO, the MTV operator should be enabled because is supported:

![image](https://github.com/user-attachments/assets/2576c4a8-3d1e-40e3-a964-47370654e326)
