### PR TITLE
MGMT-19321: Deselect bond and cancel wouldn't have to remove the bond

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/staticIp/components/FormViewHosts/FormViewHostsFields.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/staticIp/components/FormViewHosts/FormViewHostsFields.tsx
@@ -42,6 +42,7 @@ const getExpandedHostComponent = (protocolType: StaticProtocolType) => {
     };
 
     const handleModalCancel = () => {
+      setFieldValue(`${fieldName}.useBond`, true);
       setIsModalOpen(false);
     };
     return (


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-19321

Deselect bond and Cancel still remove bond.
Cancelling the deselection should remain the bond selected and with all filled data


https://github.com/user-attachments/assets/d1f78abb-3230-414a-92b2-dda50b88bb4d

