### PR TITLE
MGMT-19322: Bonds Mac Addresses should be required fields

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/staticIp/components/FormViewHosts/formViewHostsValidationSchema.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/staticIp/components/FormViewHosts/formViewHostsValidationSchema.tsx
@@ -82,13 +82,17 @@ const getHostValidationSchema = (networkWideValues: FormViewNetworkWideValues) =
     bondPrimaryInterface: Yup.mixed().when('useBond', {
       is: true,
       then: () =>
-        macAddressValidationSchema.concat(getUniqueValidationSchema(getAllBondInterfaces)),
+        macAddressValidationSchema
+          .required(requiredMsg)
+          .concat(getUniqueValidationSchema(getAllBondInterfaces)),
       otherwise: () => Yup.mixed().notRequired(),
     }),
     bondSecondaryInterface: Yup.mixed().when('useBond', {
       is: true,
       then: () =>
-        macAddressValidationSchema.concat(getUniqueValidationSchema(getAllBondInterfaces)),
+        macAddressValidationSchema
+          .required(requiredMsg)
+          .concat(getUniqueValidationSchema(getAllBondInterfaces)),
       otherwise: () => Yup.mixed().notRequired(),
     }),
   });


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-19322

UI needs to don't allow to proceed with only one mac address instead of 2 in bond fields

![image](https://github.com/user-attachments/assets/af6c16ff-08e3-41a8-98b9-223e594bfa35)
