### PR TITLE
MGMT-19298: Disable CNV operator when user selects MTV operator

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/CnvCheckbox.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/CnvCheckbox.tsx
@@ -10,7 +10,10 @@ import {
   PopoverIcon,
 } from '../../../../common';
 import CnvHostRequirements from './CnvHostRequirements';
-import { getCnvIncompatibleWithLvmReason } from '../../featureSupportLevels/featureStateUtils';
+import {
+  getCnvDisabledWithMtvReason,
+  getCnvIncompatibleWithLvmReason,
+} from '../../featureSupportLevels/featureStateUtils';
 import { OcmCheckboxField } from '../../ui/OcmFormFields';
 import { useNewFeatureSupportLevel } from '../../../../common/components/newFeatureSupportLevels';
 import NewFeatureSupportLevelBadge from '../../../../common/components/newFeatureSupportLevels/NewFeatureSupportLevelBadge';
@@ -82,6 +85,9 @@ const CnvCheckbox = ({
     if (!reason) {
       const lvmSupport = featureSupportLevel.getFeatureSupportLevel('LVM');
       reason = getCnvIncompatibleWithLvmReason(values, lvmSupport);
+    }
+    if (!reason) {
+      reason = getCnvDisabledWithMtvReason(values);
     }
     setDisabledReason(reason);
   }, [values, featureSupportLevel]);

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/MtvOperatorCheckbox.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/MtvOperatorCheckbox.tsx
@@ -55,8 +55,9 @@ const MtvCheckbox = ({ clusterId }: { clusterId: ClusterOperatorProps['clusterId
   const fieldId = getFieldId(Mtv_FIELD_NAME, 'input');
   const [disabledReason, setDisabledReason] = useState<string | undefined>();
 
-  const selectCNVOperator = (checked: boolean) =>
+  const selectCNVOperator = (checked: boolean) => {
     setFieldValue('useContainerNativeVirtualization', checked);
+  };
 
   React.useEffect(() => {
     const disabledReason = featureSupportLevelContext.getFeatureDisabledReason('MTV');

--- a/libs/ui-lib/lib/ocm/components/featureSupportLevels/featureStateUtils.ts
+++ b/libs/ui-lib/lib/ocm/components/featureSupportLevels/featureStateUtils.ts
@@ -19,6 +19,7 @@ const LVMS_OPERATOR_LABEL = 'Logical Volume Manager Storage';
 const LVM_OPERATOR_LABEL = 'Logical Volume Manager';
 const ODF_OPERATOR_LABEL = 'OpenShift Data Foundation';
 const OPENSHIFT_AI_OPERATOR_LABEL = 'OpenShift AI';
+const MTV_OPERATOR_LABEL = 'Migration Toolkit for Virtualization';
 
 export const clusterExistsReason = 'This option is not editable after the draft cluster is created';
 
@@ -279,4 +280,13 @@ const getOpenShiftAIDisabledReason = (
     return `The installer cannot currently enable ${OPENSHIFT_AI_OPERATOR_LABEL} with the selected OpenShift version, but it can be enabled later through the OpenShift Console once the installation is complete.`;
   }
   return undefined;
+};
+
+export const getCnvDisabledWithMtvReason = (operatorValues: OperatorsValues) => {
+  const mustDisableCnv =
+    operatorValues.useContainerNativeVirtualization &&
+    operatorValues.useMigrationToolkitforVirtualization;
+  return mustDisableCnv
+    ? `Currently, you need to install ${CNV_OPERATOR_LABEL} operator at the same time as ${MTV_OPERATOR_LABEL} operator.`
+    : undefined;
 };


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-19298

MTV operator requires CNV. The better option is disable the CNV operator checkbox when MTV is selected:

![image](https://github.com/user-attachments/assets/031167ea-4139-4ee9-ad1f-e4960d878252)
