### PR TITLE
MGMT-19409: Disable OpenShift AI when LVM is enabled

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/OpenShiftAICheckbox.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/OpenShiftAICheckbox.tsx
@@ -8,6 +8,7 @@ import { OcmCheckboxField } from '../../ui/OcmFormFields';
 import { useNewFeatureSupportLevel } from '../../../../common/components/newFeatureSupportLevels';
 import NewFeatureSupportLevelBadge from '../../../../common/components/newFeatureSupportLevels/NewFeatureSupportLevelBadge';
 import { SupportLevel } from '@openshift-assisted/types/assisted-installer-service';
+import { getOpenShiftAIIncompatibleWithLvmsReason } from '../../featureSupportLevels/featureStateUtils';
 
 const OPENSHIFT_AI_FIELD_NAME = 'useOpenShiftAI';
 
@@ -52,7 +53,10 @@ const OpenShiftAICheckbox = () => {
   const [disabledReason, setDisabledReason] = useState<string | undefined>();
 
   React.useEffect(() => {
-    const disabledReason = featureSupportLevel.getFeatureDisabledReason('OPENSHIFT_AI');
+    let disabledReason = featureSupportLevel.getFeatureDisabledReason('OPENSHIFT_AI');
+    if (!disabledReason) {
+      disabledReason = getOpenShiftAIIncompatibleWithLvmsReason(values);
+    }
     setDisabledReason(disabledReason);
   }, [values, featureSupportLevel]);
 

--- a/libs/ui-lib/lib/ocm/components/featureSupportLevels/featureStateUtils.ts
+++ b/libs/ui-lib/lib/ocm/components/featureSupportLevels/featureStateUtils.ts
@@ -251,6 +251,14 @@ export const getOdfIncompatibleWithLvmsReason = (operatorValues: OperatorsValues
     : undefined;
 };
 
+export const getOpenShiftAIIncompatibleWithLvmsReason = (operatorValues: OperatorsValues) => {
+  // Currently OpenShift AI requires ODF, and that is incompatible with LVM.
+  const mustDisableOpenShiftAI = operatorValues.useOdfLogicalVolumeManager;
+  return mustDisableOpenShiftAI
+    ? `Currently the ${OPENSHIFT_AI_OPERATOR_LABEL} requires ${ODF_OPERATOR_LABEL}, and you cannot install that at the same time as ${LVMS_OPERATOR_LABEL} operator.`
+    : undefined;
+};
+
 export const getLvmsIncompatibleWithOdfReason = (operatorValues: OperatorsValues) => {
   const mustDisableLvms = operatorValues.useOpenShiftDataFoundation;
   // In versions >= 4.15, it's not possible to select ODF + LVMS


### PR DESCRIPTION
The OpenShift AI operator requires ODF, which in turn is incompatible with the LVM operator. But the UI isn't aware of that. As a result when the user selects the LVM operator and then tries to select the OpenShift AI operator the UI allows it, but the backend returns an error. To avoid that this patch changes the UI so that when LVM is selected the OpenShift AI option be automatically disabled.

Related: https://issues.redhat.com/browse/MGMT-19409