### PR TITLE
MGMT-19497: Not add VLAN configuration to bonds

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/staticIp/data/nmstateYaml.ts
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/staticIp/data/nmstateYaml.ts
@@ -119,7 +119,6 @@ export const getInterface = (
       name: nicName,
       type: NmstateInterfaceType.BOND,
       state: 'up',
-      ...protocolConfigs,
       'link-aggregation': {
         mode: bondType,
         options: {


### PR DESCRIPTION
Related to  https://issues.redhat.com/browse/MGMT-19497

We don't have to add VLAN configuration to bond interface.

Before change:
![image](https://github.com/user-attachments/assets/1b9d4463-fcad-477a-89aa-30c002857a01)

After change:
![image](https://github.com/user-attachments/assets/f9536849-0f75-468b-89dd-1dd401cd9df6)
