### PR TITLE
MGMT-19497: Not add VLAN configuration to bonds  - 2.36

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/staticIp/data/nmstateYaml.ts
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/staticIp/data/nmstateYaml.ts
@@ -119,7 +119,6 @@ export const getInterface = (
       name: nicName,
       type: NmstateInterfaceType.BOND,
       state: 'up',
-      ...protocolConfigs,
       'link-aggregation': {
         mode: bondType,
         options: {


### PR DESCRIPTION
backport of #2730 