### PR TITLE
MGMT-19605: Add MTV operator to Installation page

### DIFF
--- a/libs/locales/lib/en/translation.json
+++ b/libs/locales/lib/en/translation.json
@@ -508,6 +508,7 @@
   "ai:Memory capacity": "Memory capacity",
   "ai:Message": "Message",
   "ai:Metal3 operator is not configured": "Metal3 operator is not configured",
+  "ai:Migration Toolkit for Virtualization": "Migration Toolkit for Virtualization",
   "ai:Migration toolkit for virtualization requirements": "Migration toolkit for virtualization requirements",
   "ai:Minimal image file: Provision with virtual media": "Minimal image file: Provision with virtual media",
   "ai:Minimal value is 10Gi": "Minimal value is 10Gi",

--- a/libs/ui-lib/lib/common/config/constants.ts
+++ b/libs/ui-lib/lib/common/config/constants.ts
@@ -370,6 +370,7 @@ export const operatorLabels = (
     [OPERATOR_NAME_SERVERLESS]: t('ai:Serverless'),
     [OPERATOR_NAME_OPENSHIFT_AI]: t('ai:OpenShift AI'),
     [OPERATOR_NAME_OSC]: t('ai:OpenShift sandboxed containers'),
+    [OPERATOR_NAME_MTV]: t('ai:Migration Toolkit for Virtualization'),
   };
 };
 


### PR DESCRIPTION
It seems that MTV operator not appears in Installation page.
Related to https://issues.redhat.com/browse/MGMT-19605

![image](https://github.com/user-attachments/assets/fe29c10f-0bcb-415e-b2f3-8b3e912358bc)
