### PR TITLE
MGMT-19587: Show MTU validation only in networking step

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusterWizard/wizardTransition.ts
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/wizardTransition.ts
@@ -189,7 +189,6 @@ const hostDiscoveryStepValidationsMap: WizardStepValidationMap = {
       'nvidia-gpu-requirements-satisfied',
       'openshift-ai-requirements-satisfied',
       'osc-requirements-satisfied',
-      'mtu-valid',
     ],
   },
   softValidationIds: ['no-skip-installation-disk', 'no-skip-missing-disk'],


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-19587

The warning for MTU validation should only appear during the networking step and should not block users from proceeding with the installation.