### PR TITLE
MGMT-19611: If user use bonds+ipv4 withoud bound we need to generate the correct nmstate yaml

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/staticIp/data/nmstateYaml.ts
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/staticIp/data/nmstateYaml.ts
@@ -119,6 +119,7 @@ export const getInterface = (
       name: nicName,
       type: NmstateInterfaceType.BOND,
       state: 'up',
+      ...(networkWide.useVlan ? {} : protocolConfigs),
       'link-aggregation': {
         mode: bondType,
         options: {


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-19611

Selecting bonds with no vlan and ipv4 UI creates illegal nmstate.

![image](https://github.com/user-attachments/assets/4e79fe07-5a54-46c9-a096-1863d573126f)

The nmstate:
![image](https://github.com/user-attachments/assets/e67745a4-9416-498b-a8fa-bc58a014389e)

