### PR TITLE
MGMT-19160: Remove not highly available cluster text from Control Plane Nodes dropdown

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/ControlPlaneNodesDropdown.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/ControlPlaneNodesDropdown.tsx
@@ -78,7 +78,7 @@ const ControlPlaneNodesDropdown: React.FC<ControlPlaneNodesDropdownProps> = ({
   );
 
   const options: ControlPlaneNodesOption[] = [
-    { value: '1', label: '1 (Single Node OpenShift - not highly available cluster)' },
+    { value: '1', label: '1 (Single Node OpenShift)' },
     { value: '3', label: '3 (highly available cluster)' },
     { value: '4', label: '4 (highly available cluster+)' },
     { value: '5', label: '5 (highly available cluster++)' },


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-19610

Before changes:
![image](https://github.com/user-attachments/assets/ec857eae-dc39-40a3-8fa7-b869c5254cb2)


After changes:
![image](https://github.com/user-attachments/assets/d7a8dec1-ab6e-4839-9761-e0d736c5e951)
