### PR TITLE
MGMT-19611: If user use bonds+ipv4 withoud bound we need to generate the correct nmstate yaml - 2.37

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/staticIp/data/nmstateYaml.ts
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/staticIp/data/nmstateYaml.ts
@@ -119,6 +119,7 @@ export const getInterface = (
       name: nicName,
       type: NmstateInterfaceType.BOND,
       state: 'up',
+      ...(networkWide.useVlan ? {} : protocolConfigs),
       'link-aggregation': {
         mode: bondType,
         options: {


### PR DESCRIPTION
backport of #2747 