### PR TITLE
MGMT-19726: Add predefined custom manifests when cluster is created from Assisted Migration

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusterWizard/ClusterDetails.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/ClusterDetails.tsx
@@ -78,6 +78,10 @@ const ClusterDetails = ({ cluster, infraEnv }: ClusterDetailsProps) => {
         const cluster = await ClustersService.create(params, isAssistedMigration);
         navigate(`../${cluster.id}`, { state: ClusterWizardFlowStateNew });
         await UISettingService.update(cluster.id, { addCustomManifests });
+        //TO-DO: Assisted-Migration. Provisional code. Needs to be removed when MTV integration be finished
+        if (isAssistedMigration) {
+          await ClustersService.createClusterManifestsForAssistedMigration(cluster.id);
+        }
       } catch (e) {
         handleApiError(e, () =>
           addAlert({ title: 'Failed to create new cluster', message: getApiErrorMessage(e) }),

--- a/libs/ui-lib/lib/ocm/config/constants.ts
+++ b/libs/ui-lib/lib/ocm/config/constants.ts
@@ -39,3 +39,159 @@ export const ocmPermissionsToAIPermissions = (
   }
   return permissions;
 };
+
+//TO-DO: Assisted-Migration. Provisional code. Needs to be removed when MTV integration be finished
+export const yamlContentAssistedMigration1 = `apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-gitops-operator
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-gitops-operator
+  namespace: openshift-gitops-operator
+spec:
+  upgradeStrategy: Default
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: openshift-gitops-operator
+  namespace: openshift-gitops-operator
+spec:
+  channel: latest
+  installPlanApproval: Automatic
+  name: openshift-gitops-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+`;
+
+export const yamlContentAssistedMigration2 = `apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: namespace-manager
+rules:
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "create", "update", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: namespace-manager-binding
+subjects:
+  - kind: ServiceAccount
+    name: openshift-gitops-argocd-application-controller
+    namespace: openshift-gitops
+roleRef:
+  kind: ClusterRole
+  name: namespace-manager
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: persistentvolumeclaim-manager
+  namespace: openshift-image-registry
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "create", "update", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: persistentvolumeclaim-manager-binding
+  namespace: openshift-image-registry
+subjects:
+  - kind: ServiceAccount
+    name: openshift-gitops-argocd-application-controller
+    namespace: openshift-gitops
+roleRef:
+  kind: Role
+  name: persistentvolumeclaim-manager
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: job-manager
+rules:
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get", "create", "update", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: job-manager-binding
+subjects:
+  - kind: ServiceAccount
+    name: openshift-gitops-argocd-application-controller
+    namespace: openshift-gitops
+roleRef:
+  kind: ClusterRole
+  name: job-manager
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: argocd-application-controller
+rules:
+  - apiGroups: [""]
+    resources: ["serviceaccounts", "services", "secrets"]
+    verbs: ["create", "get", "list", "update", "delete", "patch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["create", "get", "list", "update", "delete", "patch"]
+  - apiGroups: ["route.openshift.io"]
+    resources: ["routes"]
+    verbs: ["create", "get", "list", "update", "delete", "patch"]
+  - apiGroups: ["image.openshift.io"]
+    resources: ["imagestreams"]
+    verbs: ["create", "get", "list", "update", "delete", "patch"]
+  - apiGroups: ["build.openshift.io"]
+    resources: ["buildconfigs"]
+    verbs: ["create", "get", "list", "update", "delete", "patch"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: argocd-application-controller-binding
+subjects:
+  - kind: ServiceAccount
+    name: openshift-gitops-argocd-application-controller
+    namespace: openshift-gitops
+roleRef:
+  kind: ClusterRole
+  name: argocd-application-controller
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: argocd-secrets-role
+  namespace: openshift-mtv
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create", "get", "list", "update", "delete", "patch"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: argocd-secrets-rolebinding
+  namespace: openshift-mtv
+subjects:
+  - kind: ServiceAccount
+    name: openshift-gitops-argocd-application-controller
+    namespace: openshift-gitops
+roleRef:
+  kind: Role
+  name: argocd-secrets-role
+  apiGroup: rbac.authorization.k8s.io
+`;

--- a/libs/ui-lib/lib/ocm/services/ClustersService.ts
+++ b/libs/ui-lib/lib/ocm/services/ClustersService.ts
@@ -20,6 +20,8 @@ import {
   AI_UI_TAG,
 } from '../../common/config/constants';
 import { isInOcm } from '../../common/api/axiosClient';
+import { yamlContentAssistedMigration1, yamlContentAssistedMigration2 } from '../config';
+import jsYaml from 'js-yaml';
 
 const ClustersService = {
   findHost(hosts: Cluster['hosts'] = [], hostId: Host['id']) {
@@ -164,6 +166,32 @@ const ClustersService = {
       clusterId,
       this.getUpdateManifestParams(existingManifest, updatedManifest),
     );
+  },
+
+  //TO-DO: Assisted-Migration. Provisional code. Needs to be removed when MTV integration be finished
+  async createClusterManifestsForAssistedMigration(clusterId: Cluster['id']) {
+    const manifests: CustomManifestValues[] = [];
+
+    const parsedYaml1 = jsYaml.dump(yamlContentAssistedMigration1);
+    manifests.push({
+      folder: 'openshift',
+      filename: '0gitops.yaml',
+      manifestYaml: parsedYaml1,
+      created: true,
+    });
+
+    const parsedYaml2 = jsYaml.dump(yamlContentAssistedMigration2);
+    manifests.push({
+      folder: 'openshift',
+      filename: '1rolebindings.yaml',
+      manifestYaml: parsedYaml2,
+      created: true,
+    });
+
+    const promises = manifests.map((manifest) => {
+      return ClustersAPI.createCustomManifest(clusterId, this.transformFormViewManifest(manifest));
+    });
+    return Promise.all(promises);
   },
 };
 


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-19726

When cluster is created from Assisted Migration we have to add predefined custom manifests (until the MTV integration be finished).

![Captura desde 2025-01-15 16-04-29](https://github.com/user-attachments/assets/ea82ff3d-ce22-47df-8d36-12f103cef2bf)

![Captura desde 2025-01-15 16-04-40](https://github.com/user-attachments/assets/c2b07ec6-12f9-40d8-a307-fd35d4e5047d)

![Captura desde 2025-01-15 16-04-49](https://github.com/user-attachments/assets/bc28071f-eeb1-4841-9158-e0197cdd7830)

