### PR TITLE
NO-ISSUE: Link to self managed OpenShift AI

### DIFF
--- a/libs/ui-lib/lib/common/config/docs_links.ts
+++ b/libs/ui-lib/lib/common/config/docs_links.ts
@@ -68,7 +68,7 @@ export const ODF_REQUIREMENTS_LINK =
   'https://docs.redhat.com/en/documentation/red_hat_openshift_data_foundation';
 
 export const OPENSHIFT_AI_REQUIREMENTS_LINK =
-  'https://docs.redhat.com/en/documentation/red_hat_openshift_ai_cloud_service/1/html/installing_the_openshift_ai_cloud_service/requirements-for-openshift-ai_install#requirements-for-openshift-ai_install';
+  'https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/2.16/html/installing_and_uninstalling_openshift_ai_self-managed/installing-and-deploying-openshift-ai_install#requirements-for-openshift-ai-self-managed_install';
 
 export const OSC_REQUIREMENTS_LINK =
   'https://docs.redhat.com/en/documentation/openshift_sandboxed_containers/1.8/html/user_guide/deploying-osc-bare-metal#osc-resource-requirements_deploying-bare-metal';


### PR DESCRIPTION
This patch changes the "learn more" link of the OpenShift AI operators so that it points to the "self managed" documentation, which is more appropriate for bare metal installations.