### PR TITLE
NO-ISSUE: Change actions/upload-artifact@v4 to actions/upload-artifact@v3 in github actions

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -124,13 +124,13 @@ jobs:
           working-directory: libs/ui-lib-tests
           wait-on: 'http://127.0.0.1:4173'
       - name: Store test execution screenshots on failure
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: cypress-screenshots
           path: libs/ui-lib-tests/cypress/screenshots
       - name: Store test execution video
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: cypress-videos


### PR DESCRIPTION
Change actions/upload-artifact@v4 to actions/upload-artifact@v3

Related to the Deprecation of v3: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/