### PR TITLE
Improvement in the new Operators page behavior

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/AuthorinoCheckbox.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/AuthorinoCheckbox.tsx
@@ -1,11 +1,20 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { FormGroup, HelperText, HelperTextItem, Tooltip } from '@patternfly/react-core';
 import { getFieldId, PopoverIcon } from '../../../../common';
 import { OcmCheckboxField } from '../../ui/OcmFormFields';
+import { useNewFeatureSupportLevel } from '../../../../common/components/newFeatureSupportLevels';
+import NewFeatureSupportLevelBadge from '../../../../common/components/newFeatureSupportLevels/NewFeatureSupportLevelBadge';
+import { SupportLevel } from '@openshift-assisted/types/./assisted-installer-service';
 
 const AUTHORINO_FIELD_NAME = 'useAuthorino';
 
-const AuthorinoLabel = ({ disabledReason }: { disabledReason?: string }) => {
+const AuthorinoLabel = ({
+  disabledReason,
+  supportLevel,
+}: {
+  disabledReason?: string;
+  supportLevel?: SupportLevel;
+}) => {
   return (
     <>
       <Tooltip hidden={!disabledReason} content={disabledReason}>
@@ -16,6 +25,7 @@ const AuthorinoLabel = ({ disabledReason }: { disabledReason?: string }) => {
         component={'a'}
         bodyContent={'No additional requirements needed'}
       />
+      <NewFeatureSupportLevelBadge featureId="AUTHORINO" supportLevel={supportLevel} />
     </>
   );
 };
@@ -32,13 +42,26 @@ const AuthorinoHelperText = () => {
 
 const AuthorinoCheckbox = ({ disabledReason }: { disabledReason?: string }) => {
   const fieldId = getFieldId(AUTHORINO_FIELD_NAME, 'input');
+  const featureSupportLevel = useNewFeatureSupportLevel();
+  const [disabledReasonAuthorino, setDisabledReason] = useState<string | undefined>();
+
+  React.useEffect(() => {
+    const reason = featureSupportLevel.getFeatureDisabledReason('AUTHORINO');
+    setDisabledReason(reason);
+  }, [featureSupportLevel]);
+
   return (
     <FormGroup isInline fieldId={fieldId}>
       <OcmCheckboxField
         name={AUTHORINO_FIELD_NAME}
-        label={<AuthorinoLabel disabledReason={disabledReason} />}
+        label={
+          <AuthorinoLabel
+            disabledReason={disabledReason ? disabledReason : disabledReasonAuthorino}
+            supportLevel={featureSupportLevel.getFeatureSupportLevel('AUTHORINO')}
+          />
+        }
         helperText={<AuthorinoHelperText />}
-        isDisabled={!!disabledReason}
+        isDisabled={!!disabledReason || !!disabledReasonAuthorino}
       />
     </FormGroup>
   );

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/LsoCheckbox.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/LsoCheckbox.tsx
@@ -1,11 +1,20 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { FormGroup, HelperText, HelperTextItem, Tooltip } from '@patternfly/react-core';
 import { getFieldId, PopoverIcon } from '../../../../common';
 import { OcmCheckboxField } from '../../ui/OcmFormFields';
+import { useNewFeatureSupportLevel } from '../../../../common/components/newFeatureSupportLevels';
+import NewFeatureSupportLevelBadge from '../../../../common/components/newFeatureSupportLevels/NewFeatureSupportLevelBadge';
+import { SupportLevel } from '@openshift-assisted/types/./assisted-installer-service';
 
 const LSO_FIELD_NAME = 'useLso';
 
-const LsoLabel = ({ disabledReason }: { disabledReason?: string }) => {
+const LsoLabel = ({
+  disabledReason,
+  supportLevel,
+}: {
+  disabledReason?: string;
+  supportLevel?: SupportLevel;
+}) => {
   return (
     <>
       <Tooltip hidden={!disabledReason} content={disabledReason}>
@@ -16,6 +25,7 @@ const LsoLabel = ({ disabledReason }: { disabledReason?: string }) => {
         component={'a'}
         bodyContent={'No additional requirements needed'}
       />
+      <NewFeatureSupportLevelBadge featureId="LSO" supportLevel={supportLevel} />
     </>
   );
 };
@@ -32,13 +42,25 @@ const LsoHelperText = () => {
 
 const LsoCheckbox = ({ disabledReason }: { disabledReason?: string }) => {
   const fieldId = getFieldId(LSO_FIELD_NAME, 'input');
+  const featureSupportLevel = useNewFeatureSupportLevel();
+  const [disabledReasonLso, setDisabledReason] = useState<string | undefined>();
+
+  React.useEffect(() => {
+    const reason = featureSupportLevel.getFeatureDisabledReason('LSO');
+    setDisabledReason(reason);
+  }, [featureSupportLevel]);
   return (
     <FormGroup isInline fieldId={fieldId}>
       <OcmCheckboxField
         name={LSO_FIELD_NAME}
-        label={<LsoLabel disabledReason={disabledReason} />}
+        label={
+          <LsoLabel
+            disabledReason={disabledReason ? disabledReason : disabledReasonLso}
+            supportLevel={featureSupportLevel.getFeatureSupportLevel('LSO')}
+          />
+        }
         helperText={<LsoHelperText />}
-        isDisabled={!!disabledReason}
+        isDisabled={!!disabledReason || !!disabledReasonLso}
       />
     </FormGroup>
   );

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/MceCheckbox.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/MceCheckbox.tsx
@@ -5,6 +5,8 @@ import { getFieldId, PopoverIcon, getMceDocsLink, ClusterOperatorProps } from '.
 import { OcmCheckboxField } from '../../ui/OcmFormFields';
 import { useNewFeatureSupportLevel } from '../../../../common/components/newFeatureSupportLevels';
 import MceRequirements from './MceRequirements';
+import NewFeatureSupportLevelBadge from '../../../../common/components/newFeatureSupportLevels/NewFeatureSupportLevelBadge';
+import { SupportLevel } from '@openshift-assisted/types/./assisted-installer-service';
 
 const MCE_FIELD_NAME = 'useMultiClusterEngine';
 
@@ -12,10 +14,12 @@ const MceLabel = ({
   disabledReason,
   isVersionEqualsOrMajorThan4_15,
   clusterId,
+  supportLevel,
 }: {
   disabledReason?: string;
   isVersionEqualsOrMajorThan4_15: boolean;
   clusterId: ClusterOperatorProps['clusterId'];
+  supportLevel?: SupportLevel;
 }) => {
   return (
     <>
@@ -33,6 +37,7 @@ const MceLabel = ({
           />
         }
       />
+      <NewFeatureSupportLevelBadge featureId="MCE" supportLevel={supportLevel} />
     </>
   );
 };
@@ -71,6 +76,7 @@ const MceCheckbox = ({
             disabledReason={disabledReason}
             isVersionEqualsOrMajorThan4_15={isVersionEqualsOrMajorThan4_15}
             clusterId={clusterId}
+            supportLevel={featureSupportLevelContext.getFeatureSupportLevel('MCE')}
           />
         }
         isDisabled={!!disabledReason}

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/MtvOperatorCheckbox.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/MtvOperatorCheckbox.tsx
@@ -12,15 +12,19 @@ import { OcmCheckboxField } from '../../ui/OcmFormFields';
 import { useNewFeatureSupportLevel } from '../../../../common/components/newFeatureSupportLevels';
 import { useFormikContext } from 'formik';
 import MtvRequirements from './MtvRequirements';
+import { SupportLevel } from '@openshift-assisted/types/./assisted-installer-service';
+import NewFeatureSupportLevelBadge from '../../../../common/components/newFeatureSupportLevels/NewFeatureSupportLevelBadge';
 
 const Mtv_FIELD_NAME = 'useMigrationToolkitforVirtualization';
 
 const MtvLabel = ({
   disabledReason,
   clusterId,
+  supportLevel,
 }: {
   disabledReason?: string;
   clusterId: string;
+  supportLevel?: SupportLevel;
 }) => (
   <>
     <Tooltip hidden={!disabledReason} content={disabledReason}>
@@ -31,6 +35,7 @@ const MtvLabel = ({
       headerContent="Additional requirements"
       bodyContent={<MtvRequirements clusterId={clusterId} />}
     />
+    <NewFeatureSupportLevelBadge featureId="MTV" supportLevel={supportLevel} />
   </>
 );
 
@@ -80,7 +85,13 @@ const MtvCheckbox = ({
     <FormGroup isInline fieldId={fieldId}>
       <OcmCheckboxField
         name={Mtv_FIELD_NAME}
-        label={<MtvLabel disabledReason={disabledReasonMtv} clusterId={clusterId} />}
+        label={
+          <MtvLabel
+            disabledReason={disabledReasonMtv}
+            clusterId={clusterId}
+            supportLevel={featureSupportLevelContext.getFeatureSupportLevel('MTV')}
+          />
+        }
         isDisabled={!!disabledReasonMtv}
         helperText={<MtvHelperText />}
         onChange={selectCNVOperator}

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/NmstateCheckbox.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/NmstateCheckbox.tsx
@@ -1,17 +1,22 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { FormGroup, HelperText, HelperTextItem, Tooltip } from '@patternfly/react-core';
 import { getFieldId, PopoverIcon, ClusterOperatorProps } from '../../../../common';
 import { OcmCheckboxField } from '../../ui/OcmFormFields';
 import NmstateRequirements from './NmstateRequirements';
+import { SupportLevel } from '@openshift-assisted/types/./assisted-installer-service';
+import NewFeatureSupportLevelBadge from '../../../../common/components/newFeatureSupportLevels/NewFeatureSupportLevelBadge';
+import { useNewFeatureSupportLevel } from '../../../../common/components/newFeatureSupportLevels';
 
 const NMSTATE_FIELD_NAME = 'useNmstate';
 
 const NmstateLabel = ({
   disabledReason,
   clusterId,
+  supportLevel,
 }: {
   disabledReason?: string;
   clusterId: ClusterOperatorProps['clusterId'];
+  supportLevel?: SupportLevel;
 }) => {
   return (
     <>
@@ -24,6 +29,7 @@ const NmstateLabel = ({
         headerContent="Additional requirements"
         bodyContent={<NmstateRequirements clusterId={clusterId} />}
       />
+      <NewFeatureSupportLevelBadge featureId="NMSTATE" supportLevel={supportLevel} />
     </>
   );
 };
@@ -47,13 +53,26 @@ const NmstateCheckbox = ({
   disabledReason?: string;
 }) => {
   const fieldId = getFieldId(NMSTATE_FIELD_NAME, 'input');
+  const featureSupportLevel = useNewFeatureSupportLevel();
+  const [disabledReasonNmstate, setDisabledReason] = useState<string | undefined>();
+
+  React.useEffect(() => {
+    const reason = featureSupportLevel.getFeatureDisabledReason('NMSTATE');
+    setDisabledReason(reason);
+  }, [featureSupportLevel]);
   return (
     <FormGroup isInline fieldId={fieldId}>
       <OcmCheckboxField
         name={NMSTATE_FIELD_NAME}
-        label={<NmstateLabel clusterId={clusterId} disabledReason={disabledReason} />}
+        label={
+          <NmstateLabel
+            clusterId={clusterId}
+            disabledReason={disabledReason ? disabledReason : disabledReasonNmstate}
+            supportLevel={featureSupportLevel.getFeatureSupportLevel('NMSTATE')}
+          />
+        }
         helperText={<NmstateHelperText />}
-        isDisabled={!!disabledReason}
+        isDisabled={!!disabledReason || !!disabledReasonNmstate}
       />
     </FormGroup>
   );

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/NodeFeatureDiscoveryCheckbox.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/NodeFeatureDiscoveryCheckbox.tsx
@@ -1,11 +1,20 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { FormGroup, HelperText, HelperTextItem, Tooltip } from '@patternfly/react-core';
 import { getFieldId, PopoverIcon } from '../../../../common';
 import { OcmCheckboxField } from '../../ui/OcmFormFields';
+import { useNewFeatureSupportLevel } from '../../../../common/components/newFeatureSupportLevels';
+import NewFeatureSupportLevelBadge from '../../../../common/components/newFeatureSupportLevels/NewFeatureSupportLevelBadge';
+import { SupportLevel } from '@openshift-assisted/types/./assisted-installer-service';
 
 const NODEFEATUREDISCOVERY_FIELD_NAME = 'useNodeFeatureDiscovery';
 
-const NodeFeatureDiscoveryLabel = ({ disabledReason }: { disabledReason?: string }) => {
+const NodeFeatureDiscoveryLabel = ({
+  disabledReason,
+  supportLevel,
+}: {
+  disabledReason?: string;
+  supportLevel?: SupportLevel;
+}) => {
   return (
     <>
       <Tooltip hidden={!disabledReason} content={disabledReason}>
@@ -16,6 +25,7 @@ const NodeFeatureDiscoveryLabel = ({ disabledReason }: { disabledReason?: string
         component={'a'}
         bodyContent={'No additional requirements needed'}
       />
+      <NewFeatureSupportLevelBadge featureId="NODE_FEATURE_DISCOVERY" supportLevel={supportLevel} />
     </>
   );
 };
@@ -33,13 +43,25 @@ const NodeFeatureDiscoveryHelperText = () => {
 
 const NodeFeatureDiscoveryCheckbox = ({ disabledReason }: { disabledReason?: string }) => {
   const fieldId = getFieldId(NODEFEATUREDISCOVERY_FIELD_NAME, 'input');
+  const featureSupportLevel = useNewFeatureSupportLevel();
+  const [disabledReasonNmsate, setDisabledReason] = useState<string | undefined>();
+
+  React.useEffect(() => {
+    const reason = featureSupportLevel.getFeatureDisabledReason('NODE_FEATURE_DISCOVERY');
+    setDisabledReason(reason);
+  }, [featureSupportLevel]);
   return (
     <FormGroup isInline fieldId={fieldId}>
       <OcmCheckboxField
         name={NODEFEATUREDISCOVERY_FIELD_NAME}
-        label={<NodeFeatureDiscoveryLabel disabledReason={disabledReason} />}
+        label={
+          <NodeFeatureDiscoveryLabel
+            disabledReason={disabledReason ? disabledReason : disabledReasonNmsate}
+            supportLevel={featureSupportLevel.getFeatureSupportLevel('NODE_FEATURE_DISCOVERY')}
+          />
+        }
         helperText={<NodeFeatureDiscoveryHelperText />}
-        isDisabled={!!disabledReason}
+        isDisabled={!!disabledReason || !!disabledReasonNmsate}
       />
     </FormGroup>
   );

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/NvidiaGpuCheckbox.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/NvidiaGpuCheckbox.tsx
@@ -1,11 +1,20 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { FormGroup, HelperText, HelperTextItem, Tooltip } from '@patternfly/react-core';
 import { getFieldId, PopoverIcon } from '../../../../common';
 import { OcmCheckboxField } from '../../ui/OcmFormFields';
+import { useNewFeatureSupportLevel } from '../../../../common/components/newFeatureSupportLevels';
+import { SupportLevel } from '@openshift-assisted/types/./assisted-installer-service';
+import NewFeatureSupportLevelBadge from '../../../../common/components/newFeatureSupportLevels/NewFeatureSupportLevelBadge';
 
 const NVIDIAGPU_FIELD_NAME = 'useNvidiaGpu';
 
-const NvidiaGpuLabel = ({ disabledReason }: { disabledReason?: string }) => {
+const NvidiaGpuLabel = ({
+  disabledReason,
+  supportLevel,
+}: {
+  disabledReason?: string;
+  supportLevel?: SupportLevel;
+}) => {
   return (
     <>
       <Tooltip hidden={!disabledReason} content={disabledReason}>
@@ -16,6 +25,7 @@ const NvidiaGpuLabel = ({ disabledReason }: { disabledReason?: string }) => {
         component={'a'}
         bodyContent={'No additional requirements needed'}
       />
+      <NewFeatureSupportLevelBadge featureId="NVIDIA_GPU" supportLevel={supportLevel} />
     </>
   );
 };
@@ -32,13 +42,25 @@ const NvidiaGpuHelperText = () => {
 
 const NvidiaGpuCheckbox = ({ disabledReason }: { disabledReason?: string }) => {
   const fieldId = getFieldId(NVIDIAGPU_FIELD_NAME, 'input');
+  const featureSupportLevel = useNewFeatureSupportLevel();
+  const [disabledReasonNvidia, setDisabledReason] = useState<string | undefined>();
+
+  React.useEffect(() => {
+    const reason = featureSupportLevel.getFeatureDisabledReason('NVIDIA_GPU');
+    setDisabledReason(reason);
+  }, [featureSupportLevel]);
   return (
     <FormGroup isInline fieldId={fieldId}>
       <OcmCheckboxField
         name={NVIDIAGPU_FIELD_NAME}
-        label={<NvidiaGpuLabel disabledReason={disabledReason} />}
+        label={
+          <NvidiaGpuLabel
+            disabledReason={disabledReason ? disabledReason : disabledReasonNvidia}
+            supportLevel={featureSupportLevel.getFeatureSupportLevel('NVIDIA_GPU')}
+          />
+        }
         helperText={<NvidiaGpuHelperText />}
-        isDisabled={!!disabledReason}
+        isDisabled={!!disabledReason || !!disabledReasonNvidia}
       />
     </FormGroup>
   );

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/OdfCheckbox.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/OdfCheckbox.tsx
@@ -12,10 +12,18 @@ import { OcmCheckboxField } from '../../ui/OcmFormFields';
 import { useNewFeatureSupportLevel } from '../../../../common/components/newFeatureSupportLevels';
 import { useFormikContext } from 'formik';
 import { getOdfIncompatibleWithLvmsReason } from '../../featureSupportLevels/featureStateUtils';
+import NewFeatureSupportLevelBadge from '../../../../common/components/newFeatureSupportLevels/NewFeatureSupportLevelBadge';
+import { SupportLevel } from '@openshift-assisted/types/./assisted-installer-service';
 
 const ODF_FIELD_NAME = 'useOpenShiftDataFoundation';
 
-const OdfLabel = ({ disabledReason }: { disabledReason?: string }) => (
+const OdfLabel = ({
+  disabledReason,
+  supportLevel,
+}: {
+  disabledReason?: string;
+  supportLevel?: SupportLevel;
+}) => (
   <>
     <Tooltip hidden={!disabledReason} content={disabledReason}>
       <span>Install OpenShift Data Foundation </span>
@@ -29,6 +37,7 @@ const OdfLabel = ({ disabledReason }: { disabledReason?: string }) => (
         </a>
       }
     />
+    <NewFeatureSupportLevelBadge featureId="ODF" supportLevel={supportLevel} />
   </>
 );
 
@@ -67,7 +76,12 @@ const OdfCheckbox = ({ disabledReason }: { disabledReason?: string }) => {
     <FormGroup isInline fieldId={fieldId}>
       <OcmCheckboxField
         name={ODF_FIELD_NAME}
-        label={<OdfLabel disabledReason={disabledReasonOdf} />}
+        label={
+          <OdfLabel
+            disabledReason={disabledReasonOdf}
+            supportLevel={featureSupportLevelContext.getFeatureSupportLevel('ODF')}
+          />
+        }
         isDisabled={!!disabledReasonOdf}
         helperText={<OdfHelperText />}
       />

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/PipelinesChekbox.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/PipelinesChekbox.tsx
@@ -1,11 +1,20 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { FormGroup, HelperText, HelperTextItem, Tooltip } from '@patternfly/react-core';
 import { getFieldId, PopoverIcon } from '../../../../common';
 import { OcmCheckboxField } from '../../ui/OcmFormFields';
+import { SupportLevel } from '@openshift-assisted/types/./assisted-installer-service';
+import NewFeatureSupportLevelBadge from '../../../../common/components/newFeatureSupportLevels/NewFeatureSupportLevelBadge';
+import { useNewFeatureSupportLevel } from '../../../../common/components/newFeatureSupportLevels';
 
 const PIPELINES_FIELD_NAME = 'usePipelines';
 
-const PipelinesLabel = ({ disabledReason }: { disabledReason?: string }) => {
+const PipelinesLabel = ({
+  disabledReason,
+  supportLevel,
+}: {
+  disabledReason?: string;
+  supportLevel?: SupportLevel;
+}) => {
   return (
     <>
       <Tooltip hidden={!disabledReason} content={disabledReason}>
@@ -16,6 +25,7 @@ const PipelinesLabel = ({ disabledReason }: { disabledReason?: string }) => {
         component={'a'}
         bodyContent={'No additional requirements needed'}
       />
+      <NewFeatureSupportLevelBadge featureId="PIPELINES" supportLevel={supportLevel} />
     </>
   );
 };
@@ -33,13 +43,25 @@ const PipelinesHelperText = () => {
 
 const PipelinesCheckbox = ({ disabledReason }: { disabledReason?: string }) => {
   const fieldId = getFieldId(PIPELINES_FIELD_NAME, 'input');
+  const featureSupportLevel = useNewFeatureSupportLevel();
+  const [disabledReasonPipelines, setDisabledReason] = useState<string | undefined>();
+
+  React.useEffect(() => {
+    const reason = featureSupportLevel.getFeatureDisabledReason('PIPELINES');
+    setDisabledReason(reason);
+  }, [featureSupportLevel]);
   return (
     <FormGroup isInline fieldId={fieldId}>
       <OcmCheckboxField
         name={PIPELINES_FIELD_NAME}
-        label={<PipelinesLabel disabledReason={disabledReason} />}
+        label={
+          <PipelinesLabel
+            disabledReason={disabledReason ? disabledReason : disabledReasonPipelines}
+            supportLevel={featureSupportLevel.getFeatureSupportLevel('PIPELINES')}
+          />
+        }
         helperText={<PipelinesHelperText />}
-        isDisabled={!!disabledReason}
+        isDisabled={!!disabledReason || !!disabledReasonPipelines}
       />
     </FormGroup>
   );

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/ServerlessCheckbox.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/ServerlessCheckbox.tsx
@@ -1,11 +1,20 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { FormGroup, HelperText, HelperTextItem, Tooltip } from '@patternfly/react-core';
 import { getFieldId, PopoverIcon } from '../../../../common';
 import { OcmCheckboxField } from '../../ui/OcmFormFields';
+import { useNewFeatureSupportLevel } from '../../../../common/components/newFeatureSupportLevels';
+import { SupportLevel } from '@openshift-assisted/types/./assisted-installer-service';
+import NewFeatureSupportLevelBadge from '../../../../common/components/newFeatureSupportLevels/NewFeatureSupportLevelBadge';
 
 const SERVERLESS_FIELD_NAME = 'useServerless';
 
-const ServerlessLabel = ({ disabledReason }: { disabledReason?: string }) => {
+const ServerlessLabel = ({
+  disabledReason,
+  supportLevel,
+}: {
+  disabledReason?: string;
+  supportLevel?: SupportLevel;
+}) => {
   return (
     <>
       <Tooltip hidden={!disabledReason} content={disabledReason}>
@@ -16,6 +25,7 @@ const ServerlessLabel = ({ disabledReason }: { disabledReason?: string }) => {
         component={'a'}
         bodyContent={'No additional requirements needed'}
       />
+      <NewFeatureSupportLevelBadge featureId="SERVERLESS" supportLevel={supportLevel} />
     </>
   );
 };
@@ -32,13 +42,25 @@ const ServerlessHelperText = () => {
 
 const ServerlessCheckbox = ({ disabledReason }: { disabledReason?: string }) => {
   const fieldId = getFieldId(SERVERLESS_FIELD_NAME, 'input');
+  const featureSupportLevel = useNewFeatureSupportLevel();
+  const [disabledReasonServerless, setDisabledReason] = useState<string | undefined>();
+
+  React.useEffect(() => {
+    const reason = featureSupportLevel.getFeatureDisabledReason('SERVERLESS');
+    setDisabledReason(reason);
+  }, [featureSupportLevel]);
   return (
     <FormGroup isInline fieldId={fieldId}>
       <OcmCheckboxField
         name={SERVERLESS_FIELD_NAME}
-        label={<ServerlessLabel disabledReason={disabledReason} />}
+        label={
+          <ServerlessLabel
+            disabledReason={disabledReason ? disabledReason : disabledReasonServerless}
+            supportLevel={featureSupportLevel.getFeatureSupportLevel('SERVERLESS')}
+          />
+        }
         helperText={<ServerlessHelperText />}
-        isDisabled={!!disabledReason}
+        isDisabled={!!disabledReason || !!disabledReasonServerless}
       />
     </FormGroup>
   );

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/ServicemeshCheckbox.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/ServicemeshCheckbox.tsx
@@ -1,11 +1,20 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { FormGroup, HelperText, HelperTextItem, Tooltip } from '@patternfly/react-core';
 import { getFieldId, PopoverIcon } from '../../../../common';
 import { OcmCheckboxField } from '../../ui/OcmFormFields';
+import { useNewFeatureSupportLevel } from '../../../../common/components/newFeatureSupportLevels/NewFeatureSupportLevelContext';
+import { SupportLevel } from '@openshift-assisted/types/./assisted-installer-service';
+import NewFeatureSupportLevelBadge from '../../../../common/components/newFeatureSupportLevels/NewFeatureSupportLevelBadge';
 
 const SERVICEMESH_FIELD_NAME = 'useServiceMesh';
 
-const ServiceMeshLabel = ({ disabledReason }: { disabledReason?: string }) => {
+const ServiceMeshLabel = ({
+  disabledReason,
+  supportLevel,
+}: {
+  disabledReason?: string;
+  supportLevel?: SupportLevel;
+}) => {
   return (
     <>
       <Tooltip hidden={!disabledReason} content={disabledReason}>
@@ -16,6 +25,7 @@ const ServiceMeshLabel = ({ disabledReason }: { disabledReason?: string }) => {
         component={'a'}
         bodyContent={'No additional requirements needed'}
       />
+      <NewFeatureSupportLevelBadge featureId="SERVICEMESH" supportLevel={supportLevel} />
     </>
   );
 };
@@ -32,13 +42,25 @@ const ServiceMeshHelperText = () => {
 
 const ServiceMeshCheckbox = ({ disabledReason }: { disabledReason?: string }) => {
   const fieldId = getFieldId(SERVICEMESH_FIELD_NAME, 'input');
+  const featureSupportLevel = useNewFeatureSupportLevel();
+  const [disabledReasonServicemesh, setDisabledReason] = useState<string | undefined>();
+
+  React.useEffect(() => {
+    const reason = featureSupportLevel.getFeatureDisabledReason('SERVICEMESH');
+    setDisabledReason(reason);
+  }, [featureSupportLevel]);
   return (
     <FormGroup isInline fieldId={fieldId}>
       <OcmCheckboxField
         name={SERVICEMESH_FIELD_NAME}
-        label={<ServiceMeshLabel disabledReason={disabledReason} />}
+        label={
+          <ServiceMeshLabel
+            disabledReason={disabledReason ? disabledReason : disabledReasonServicemesh}
+            supportLevel={featureSupportLevel.getFeatureSupportLevel('SERVICEMESH')}
+          />
+        }
         helperText={<ServiceMeshHelperText />}
-        isDisabled={!!disabledReason}
+        isDisabled={!!disabledReason || !!disabledReasonServicemesh}
       />
     </FormGroup>
   );

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/SupportedOperators.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/SupportedOperators.tsx
@@ -15,6 +15,7 @@ import PipelinesCheckbox from './PipelinesChekbox';
 import ServiceMeshCheckbox from './ServicemeshCheckbox';
 import NvidiaGpuCheckbox from './NvidiaGpuCheckbox';
 import {
+  FeatureId,
   OPERATOR_NAME_AUTHORINO,
   OPERATOR_NAME_CNV,
   OPERATOR_NAME_LSO,
@@ -87,4 +88,22 @@ export const mapOperatorsToFieldIds: { [key: string]: string } = {
   [OPERATOR_NAME_PIPELINES]: 'usePipelines',
   [OPERATOR_NAME_SERVICEMESH]: 'useServicemesh',
   [OPERATOR_NAME_NVIDIA_GPU]: 'useNvidiaGpu',
+};
+
+export const mapOperatorIdToFeatureId: { [key: string]: FeatureId } = {
+  [OPERATOR_NAME_ODF]: 'ODF',
+  [OPERATOR_NAME_LVM]: 'LVM',
+  [OPERATOR_NAME_CNV]: 'CNV',
+  [OPERATOR_NAME_MCE]: 'MCE',
+  [OPERATOR_NAME_MTV]: 'MTV',
+  [OPERATOR_NAME_OPENSHIFT_AI]: 'OPENSHIFT_AI',
+  [OPERATOR_NAME_OSC]: 'OSC',
+  [OPERATOR_NAME_NODE_FEATURE_DISCOVERY]: 'NODE_FEATURE_DISCOVERY',
+  [OPERATOR_NAME_NMSTATE]: 'NMSTATE',
+  [OPERATOR_NAME_LSO]: 'LSO',
+  [OPERATOR_NAME_SERVERLESS]: 'SERVERLESS',
+  [OPERATOR_NAME_AUTHORINO]: 'AUTHORINO',
+  [OPERATOR_NAME_PIPELINES]: 'PIPELINES',
+  [OPERATOR_NAME_SERVICEMESH]: 'SERVICEMESH',
+  [OPERATOR_NAME_NVIDIA_GPU]: 'NVIDIA_GPU',
 };

--- a/libs/ui-lib/lib/ocm/components/featureSupportLevels/featureStateUtils.ts
+++ b/libs/ui-lib/lib/ocm/components/featureSupportLevels/featureStateUtils.ts
@@ -249,6 +249,46 @@ export const getNewFeatureDisabledReason = (
         return 'Migration Toolkit for Virtualization is not supported in this OpenShift version';
       }
     }
+    case 'AUTHORINO': {
+      if (!isSupported) {
+        return `Authorino is not available with the selected CPU architecture.`;
+      }
+    }
+    case 'LSO': {
+      if (!isSupported) {
+        return `Lso is not available with the selected CPU architecture.`;
+      }
+    }
+    case 'NMSTATE': {
+      if (!isSupported) {
+        return `Nmstate is not available with the selected CPU architecture.`;
+      }
+    }
+    case 'NODE_FEATURE_DISCOVERY': {
+      if (!isSupported) {
+        return `Node Feature Discovery is not available with the selected CPU architecture.`;
+      }
+    }
+    case 'NVIDIA_GPU': {
+      if (!isSupported) {
+        return `NVIDIA GPU is not available with the selected CPU architecture.`;
+      }
+    }
+    case 'PIPELINES': {
+      if (!isSupported) {
+        return `Pipelines is not available with the selected CPU architecture.`;
+      }
+    }
+    case 'SERVERLESS': {
+      if (!isSupported) {
+        return `Serverless is not available with the selected CPU architecture.`;
+      }
+    }
+    case 'SERVICEMESH': {
+      if (!isSupported) {
+        return `Service mesh is not available with the selected CPU architecture.`;
+      }
+    }
     default: {
       return undefined;
     }


### PR DESCRIPTION
Related to:

- https://issues.redhat.com/browse/MGMT-19913
- https://issues.redhat.com/browse/MGMT-19916
I've added the feature support levels to the new bundles and operators.  If some bundle operators are not supported we have to disable all the bundle with a tooltip.
![image](https://github.com/user-attachments/assets/29a27603-bb28-48f7-94bc-78e5b716fb16)

- https://issues.redhat.com/browse/MGMT-19915
The bundles frames have the same size.
![image](https://github.com/user-attachments/assets/d87893b6-cbb0-443f-a5c1-1c4da002f890)

- https://issues.redhat.com/browse/MGMT-19917
Now all the operators are sorted by name. We have the same order all the time.
![image](https://github.com/user-attachments/assets/c513b975-2a91-4730-b23c-7ad8f98dd7c3)

- https://issues.redhat.com/browse/MGMT-19934
For ARM64, Nmstate is not available
![image](https://github.com/user-attachments/assets/e0f217bc-6414-4c8d-8ac2-a8cf7a36450f)


- https://issues.redhat.com/browse/MGMT-19935
I've added the dev-preview flag to the new operators: 
![image](https://github.com/user-attachments/assets/e141e32d-9e1d-43c5-bdff-ff81f32699ec)
![image](https://github.com/user-attachments/assets/d3123c05-7f7f-4833-ac28-bec7789b7465)
