### PR TITLE
MGMT-19940: Fix typo on AI static networking bonding screen

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/staticIp/components/FormViewHosts/FormViewHostsFields.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/staticIp/components/FormViewHosts/FormViewHostsFields.tsx
@@ -76,7 +76,7 @@ const getExpandedHostComponent = (protocolType: StaticProtocolType) => {
               />{' '}
               <OcmInputField
                 name={`${fieldName}.bondSecondaryInterface`}
-                label="Port 2 MAC Adddress"
+                label="Port 2 MAC Address"
                 data-testid={`bond-secondary-interface-${hostIdx}`}
                 isRequired
               />


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-19940

Before changes:
![image](https://github.com/user-attachments/assets/2b321e6d-f43f-4430-828a-ea6fd58dcec6)

After changes:
![image](https://github.com/user-attachments/assets/c7bbf972-1fdf-48fd-8fe9-b2caee2879e0)
