### PR TITLE
MGMT-19938: Get disabled reason for all the operators when the operators page is loaded

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/AuthorinoCheckbox.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/AuthorinoCheckbox.tsx
@@ -1,8 +1,7 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { FormGroup, HelperText, HelperTextItem, Tooltip } from '@patternfly/react-core';
 import { getFieldId, PopoverIcon } from '../../../../common';
 import { OcmCheckboxField } from '../../ui/OcmFormFields';
-import { useNewFeatureSupportLevel } from '../../../../common/components/newFeatureSupportLevels';
 import NewFeatureSupportLevelBadge from '../../../../common/components/newFeatureSupportLevels/NewFeatureSupportLevelBadge';
 import { SupportLevel } from '@openshift-assisted/types/./assisted-installer-service';
 
@@ -40,28 +39,22 @@ const AuthorinoHelperText = () => {
   );
 };
 
-const AuthorinoCheckbox = ({ disabledReason }: { disabledReason?: string }) => {
+const AuthorinoCheckbox = ({
+  disabledReason,
+  supportLevel,
+}: {
+  disabledReason?: string;
+  supportLevel?: SupportLevel | undefined;
+}) => {
   const fieldId = getFieldId(AUTHORINO_FIELD_NAME, 'input');
-  const featureSupportLevel = useNewFeatureSupportLevel();
-  const [disabledReasonAuthorino, setDisabledReason] = useState<string | undefined>();
-
-  React.useEffect(() => {
-    const reason = featureSupportLevel.getFeatureDisabledReason('AUTHORINO');
-    setDisabledReason(reason);
-  }, [featureSupportLevel]);
 
   return (
     <FormGroup isInline fieldId={fieldId}>
       <OcmCheckboxField
         name={AUTHORINO_FIELD_NAME}
-        label={
-          <AuthorinoLabel
-            disabledReason={disabledReason ? disabledReason : disabledReasonAuthorino}
-            supportLevel={featureSupportLevel.getFeatureSupportLevel('AUTHORINO')}
-          />
-        }
+        label={<AuthorinoLabel disabledReason={disabledReason} supportLevel={supportLevel} />}
         helperText={<AuthorinoHelperText />}
-        isDisabled={!!disabledReason || !!disabledReasonAuthorino}
+        isDisabled={!!disabledReason}
       />
     </FormGroup>
   );

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/CnvCheckbox.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/CnvCheckbox.tsx
@@ -1,21 +1,9 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { FormGroup, HelperText, HelperTextItem, Tooltip } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons/dist/js/icons/external-link-alt-icon';
-import { useFormikContext } from 'formik';
-import {
-  ClusterOperatorProps,
-  CNV_LINK,
-  getFieldId,
-  OperatorsValues,
-  PopoverIcon,
-} from '../../../../common';
+import { ClusterOperatorProps, CNV_LINK, getFieldId, PopoverIcon } from '../../../../common';
 import CnvHostRequirements from './CnvHostRequirements';
-import {
-  getCnvDisabledWithMtvReason,
-  getCnvIncompatibleWithLvmReason,
-} from '../../featureSupportLevels/featureStateUtils';
 import { OcmCheckboxField } from '../../ui/OcmFormFields';
-import { useNewFeatureSupportLevel } from '../../../../common/components/newFeatureSupportLevels';
 import NewFeatureSupportLevelBadge from '../../../../common/components/newFeatureSupportLevels/NewFeatureSupportLevelBadge';
 import { SupportLevel } from '@openshift-assisted/types/assisted-installer-service';
 
@@ -71,28 +59,14 @@ const CnvCheckbox = ({
   clusterId,
   isVersionEqualsOrMajorThan4_15,
   disabledReason,
+  supportLevel,
 }: {
   clusterId: ClusterOperatorProps['clusterId'];
   isVersionEqualsOrMajorThan4_15: boolean;
   disabledReason?: string;
+  supportLevel?: SupportLevel | undefined;
 }) => {
   const fieldId = getFieldId(CNV_FIELD_NAME, 'input');
-
-  const featureSupportLevel = useNewFeatureSupportLevel();
-  const { values } = useFormikContext<OperatorsValues>();
-  const [disabledReasonCnv, setDisabledReason] = useState<string | undefined>();
-
-  React.useEffect(() => {
-    let reason = featureSupportLevel.getFeatureDisabledReason('CNV');
-    if (!reason) {
-      const lvmSupport = featureSupportLevel.getFeatureSupportLevel('LVM');
-      reason = getCnvIncompatibleWithLvmReason(values, lvmSupport);
-    }
-    if (!reason) {
-      reason = getCnvDisabledWithMtvReason(values);
-    }
-    setDisabledReason(reason);
-  }, [values, featureSupportLevel]);
 
   return (
     <FormGroup isInline fieldId={fieldId}>
@@ -101,13 +75,13 @@ const CnvCheckbox = ({
         label={
           <CnvLabel
             clusterId={clusterId}
-            disabledReason={disabledReason ? disabledReason : disabledReasonCnv}
+            disabledReason={disabledReason}
             isVersionEqualsOrMajorThan4_15={isVersionEqualsOrMajorThan4_15}
-            supportLevel={featureSupportLevel.getFeatureSupportLevel('CNV')}
+            supportLevel={supportLevel}
           />
         }
         helperText={<CnvHelperText />}
-        isDisabled={!!disabledReason || !!disabledReasonCnv}
+        isDisabled={!!disabledReason}
       />
     </FormGroup>
   );

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/LsoCheckbox.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/LsoCheckbox.tsx
@@ -1,8 +1,7 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { FormGroup, HelperText, HelperTextItem, Tooltip } from '@patternfly/react-core';
 import { getFieldId, PopoverIcon } from '../../../../common';
 import { OcmCheckboxField } from '../../ui/OcmFormFields';
-import { useNewFeatureSupportLevel } from '../../../../common/components/newFeatureSupportLevels';
 import NewFeatureSupportLevelBadge from '../../../../common/components/newFeatureSupportLevels/NewFeatureSupportLevelBadge';
 import { SupportLevel } from '@openshift-assisted/types/./assisted-installer-service';
 
@@ -40,27 +39,22 @@ const LsoHelperText = () => {
   );
 };
 
-const LsoCheckbox = ({ disabledReason }: { disabledReason?: string }) => {
+const LsoCheckbox = ({
+  disabledReason,
+  supportLevel,
+}: {
+  disabledReason?: string;
+  supportLevel?: SupportLevel | undefined;
+}) => {
   const fieldId = getFieldId(LSO_FIELD_NAME, 'input');
-  const featureSupportLevel = useNewFeatureSupportLevel();
-  const [disabledReasonLso, setDisabledReason] = useState<string | undefined>();
 
-  React.useEffect(() => {
-    const reason = featureSupportLevel.getFeatureDisabledReason('LSO');
-    setDisabledReason(reason);
-  }, [featureSupportLevel]);
   return (
     <FormGroup isInline fieldId={fieldId}>
       <OcmCheckboxField
         name={LSO_FIELD_NAME}
-        label={
-          <LsoLabel
-            disabledReason={disabledReason ? disabledReason : disabledReasonLso}
-            supportLevel={featureSupportLevel.getFeatureSupportLevel('LSO')}
-          />
-        }
+        label={<LsoLabel disabledReason={disabledReason} supportLevel={supportLevel} />}
         helperText={<LsoHelperText />}
-        isDisabled={!!disabledReason || !!disabledReasonLso}
+        isDisabled={!!disabledReason}
       />
     </FormGroup>
   );

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/LvmCheckbox.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/LvmCheckbox.tsx
@@ -1,12 +1,10 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { FormGroup, HelperText, HelperTextItem, Tooltip } from '@patternfly/react-core';
-import { useFormikContext } from 'formik';
 import {
   ClusterOperatorProps,
   getFieldId,
   PopoverIcon,
   operatorLabels,
-  OperatorsValues,
   OPERATOR_NAME_LVM,
   ExposedOperatorName,
   ExternalLink,
@@ -16,10 +14,6 @@ import {
 import LvmHostRequirements from './LvmHostRequirements';
 import { OcmCheckboxField } from '../../ui/OcmFormFields';
 import { useTranslation } from '../../../../common/hooks/use-translation-wrapper';
-import {
-  getLvmIncompatibleWithCnvReason,
-  getLvmsIncompatibleWithOdfReason,
-} from '../../featureSupportLevels/featureStateUtils';
 import { useNewFeatureSupportLevel } from '../../../../common/components/newFeatureSupportLevels';
 import NewFeatureSupportLevelBadge from '../../../../common/components/newFeatureSupportLevels/NewFeatureSupportLevelBadge';
 import { SupportLevel } from '@openshift-assisted/types/assisted-installer-service';
@@ -70,38 +64,26 @@ const LvmLabel = ({ clusterId, operatorLabel, disabledReason, supportLevel }: Lv
 const LvmCheckbox = ({
   clusterId,
   openshiftVersion,
+  disabledReason,
+  supportLevel,
 }: {
   clusterId: ClusterOperatorProps['clusterId'];
   openshiftVersion?: ClusterOperatorProps['openshiftVersion'];
+  disabledReason?: string;
+  supportLevel?: SupportLevel | undefined;
 }) => {
   const fieldId = getFieldId(LVM_FIELD_NAME, 'input');
 
   const featureSupportLevel = useNewFeatureSupportLevel();
   const { t } = useTranslation();
-  const { values } = useFormikContext<OperatorsValues>();
-  const [disabledReason, setDisabledReason] = useState<string | undefined>();
 
   const operatorInfo = React.useMemo(() => {
-    const lvmSupport = featureSupportLevel.getFeatureSupportLevel('LVM');
-
     const operatorLabel = operatorLabels(t, featureSupportLevel)[OPERATOR_NAME_LVM];
     return {
-      lvmSupport,
       operatorLabel,
-      operatorName: lvmSupport === 'supported' ? OPERATOR_NAME_LVMS : OPERATOR_NAME_LVM,
+      operatorName: supportLevel === 'supported' ? OPERATOR_NAME_LVMS : OPERATOR_NAME_LVM,
     };
-  }, [t, featureSupportLevel]);
-
-  React.useEffect(() => {
-    let reason = featureSupportLevel.getFeatureDisabledReason('LVM');
-    if (!reason) {
-      reason = getLvmIncompatibleWithCnvReason(values, operatorInfo.lvmSupport);
-      if (!reason) {
-        reason = getLvmsIncompatibleWithOdfReason(values);
-      }
-    }
-    setDisabledReason(reason);
-  }, [values, featureSupportLevel, operatorInfo.lvmSupport]);
+  }, [featureSupportLevel, supportLevel, t]);
 
   return (
     <FormGroup isInline fieldId={fieldId}>
@@ -112,7 +94,7 @@ const LvmCheckbox = ({
             clusterId={clusterId}
             operatorLabel={operatorInfo.operatorLabel}
             disabledReason={disabledReason}
-            supportLevel={featureSupportLevel.getFeatureSupportLevel('LVM')}
+            supportLevel={supportLevel}
           />
         }
         helperText={

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/MceCheckbox.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/MceCheckbox.tsx
@@ -3,7 +3,6 @@ import { FormGroup, HelperText, HelperTextItem, Tooltip } from '@patternfly/reac
 import { ExternalLinkAltIcon } from '@patternfly/react-icons/dist/js/icons/external-link-alt-icon';
 import { getFieldId, PopoverIcon, getMceDocsLink, ClusterOperatorProps } from '../../../../common';
 import { OcmCheckboxField } from '../../ui/OcmFormFields';
-import { useNewFeatureSupportLevel } from '../../../../common/components/newFeatureSupportLevels';
 import MceRequirements from './MceRequirements';
 import NewFeatureSupportLevelBadge from '../../../../common/components/newFeatureSupportLevels/NewFeatureSupportLevelBadge';
 import { SupportLevel } from '@openshift-assisted/types/./assisted-installer-service';
@@ -59,14 +58,16 @@ const MceCheckbox = ({
   clusterId,
   isVersionEqualsOrMajorThan4_15,
   openshiftVersion,
+  supportLevel,
+  disabledReason,
 }: {
   isVersionEqualsOrMajorThan4_15: boolean;
   openshiftVersion?: string;
   clusterId: ClusterOperatorProps['clusterId'];
+  supportLevel?: SupportLevel | undefined;
+  disabledReason?: string;
 }) => {
-  const featureSupportLevelContext = useNewFeatureSupportLevel();
   const fieldId = getFieldId(MCE_FIELD_NAME, 'input');
-  const disabledReason = featureSupportLevelContext.getFeatureDisabledReason('MCE');
   return (
     <FormGroup isInline fieldId={fieldId}>
       <OcmCheckboxField
@@ -76,7 +77,7 @@ const MceCheckbox = ({
             disabledReason={disabledReason}
             isVersionEqualsOrMajorThan4_15={isVersionEqualsOrMajorThan4_15}
             clusterId={clusterId}
-            supportLevel={featureSupportLevelContext.getFeatureSupportLevel('MCE')}
+            supportLevel={supportLevel}
           />
         }
         isDisabled={!!disabledReason}

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/MtvOperatorCheckbox.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/MtvOperatorCheckbox.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { FormGroup, HelperText, HelperTextItem, Tooltip } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons/dist/js/icons/external-link-alt-icon';
 import {
@@ -9,7 +9,6 @@ import {
   ClusterOperatorProps,
 } from '../../../../common';
 import { OcmCheckboxField } from '../../ui/OcmFormFields';
-import { useNewFeatureSupportLevel } from '../../../../common/components/newFeatureSupportLevels';
 import { useFormikContext } from 'formik';
 import MtvRequirements from './MtvRequirements';
 import { SupportLevel } from '@openshift-assisted/types/./assisted-installer-service';
@@ -57,29 +56,18 @@ const MtvHelperText = () => {
 const MtvCheckbox = ({
   clusterId,
   disabledReason,
+  supportLevel,
 }: {
   clusterId: ClusterOperatorProps['clusterId'];
   disabledReason?: string;
+  supportLevel?: SupportLevel | undefined;
 }) => {
-  // eslint-disable-next-line no-console
-  console.log(disabledReason);
-  const featureSupportLevelContext = useNewFeatureSupportLevel();
-  const { values, setFieldValue } = useFormikContext<OperatorsValues>();
+  const { setFieldValue } = useFormikContext<OperatorsValues>();
   const fieldId = getFieldId(Mtv_FIELD_NAME, 'input');
-  const [disabledReasonMtv, setDisabledReason] = useState<string | undefined>('');
 
   const selectCNVOperator = (checked: boolean) => {
     setFieldValue('useContainerNativeVirtualization', checked);
   };
-
-  React.useEffect(() => {
-    const disabledReason = featureSupportLevelContext.getFeatureDisabledReason('MTV');
-    if (disabledReason !== undefined) setDisabledReason(disabledReason);
-  }, [values, featureSupportLevelContext]);
-
-  React.useEffect(() => {
-    setDisabledReason(disabledReason);
-  }, [disabledReason]);
 
   return (
     <FormGroup isInline fieldId={fieldId}>
@@ -87,12 +75,12 @@ const MtvCheckbox = ({
         name={Mtv_FIELD_NAME}
         label={
           <MtvLabel
-            disabledReason={disabledReasonMtv}
+            disabledReason={disabledReason}
             clusterId={clusterId}
-            supportLevel={featureSupportLevelContext.getFeatureSupportLevel('MTV')}
+            supportLevel={supportLevel}
           />
         }
-        isDisabled={!!disabledReasonMtv}
+        isDisabled={!!disabledReason}
         helperText={<MtvHelperText />}
         onChange={selectCNVOperator}
       />

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/NmstateCheckbox.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/NmstateCheckbox.tsx
@@ -1,11 +1,10 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { FormGroup, HelperText, HelperTextItem, Tooltip } from '@patternfly/react-core';
 import { getFieldId, PopoverIcon, ClusterOperatorProps } from '../../../../common';
 import { OcmCheckboxField } from '../../ui/OcmFormFields';
 import NmstateRequirements from './NmstateRequirements';
 import { SupportLevel } from '@openshift-assisted/types/./assisted-installer-service';
 import NewFeatureSupportLevelBadge from '../../../../common/components/newFeatureSupportLevels/NewFeatureSupportLevelBadge';
-import { useNewFeatureSupportLevel } from '../../../../common/components/newFeatureSupportLevels';
 
 const NMSTATE_FIELD_NAME = 'useNmstate';
 
@@ -48,18 +47,14 @@ const NmstateHelperText = () => {
 const NmstateCheckbox = ({
   clusterId,
   disabledReason,
+  supportLevel,
 }: {
   clusterId: ClusterOperatorProps['clusterId'];
   disabledReason?: string;
+  supportLevel?: SupportLevel | undefined;
 }) => {
   const fieldId = getFieldId(NMSTATE_FIELD_NAME, 'input');
-  const featureSupportLevel = useNewFeatureSupportLevel();
-  const [disabledReasonNmstate, setDisabledReason] = useState<string | undefined>();
 
-  React.useEffect(() => {
-    const reason = featureSupportLevel.getFeatureDisabledReason('NMSTATE');
-    setDisabledReason(reason);
-  }, [featureSupportLevel]);
   return (
     <FormGroup isInline fieldId={fieldId}>
       <OcmCheckboxField
@@ -67,12 +62,12 @@ const NmstateCheckbox = ({
         label={
           <NmstateLabel
             clusterId={clusterId}
-            disabledReason={disabledReason ? disabledReason : disabledReasonNmstate}
-            supportLevel={featureSupportLevel.getFeatureSupportLevel('NMSTATE')}
+            disabledReason={disabledReason}
+            supportLevel={supportLevel}
           />
         }
         helperText={<NmstateHelperText />}
-        isDisabled={!!disabledReason || !!disabledReasonNmstate}
+        isDisabled={!!disabledReason}
       />
     </FormGroup>
   );

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/NodeFeatureDiscoveryCheckbox.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/NodeFeatureDiscoveryCheckbox.tsx
@@ -1,8 +1,7 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { FormGroup, HelperText, HelperTextItem, Tooltip } from '@patternfly/react-core';
 import { getFieldId, PopoverIcon } from '../../../../common';
 import { OcmCheckboxField } from '../../ui/OcmFormFields';
-import { useNewFeatureSupportLevel } from '../../../../common/components/newFeatureSupportLevels';
 import NewFeatureSupportLevelBadge from '../../../../common/components/newFeatureSupportLevels/NewFeatureSupportLevelBadge';
 import { SupportLevel } from '@openshift-assisted/types/./assisted-installer-service';
 
@@ -41,27 +40,24 @@ const NodeFeatureDiscoveryHelperText = () => {
   );
 };
 
-const NodeFeatureDiscoveryCheckbox = ({ disabledReason }: { disabledReason?: string }) => {
+const NodeFeatureDiscoveryCheckbox = ({
+  disabledReason,
+  supportLevel,
+}: {
+  disabledReason?: string;
+  supportLevel?: SupportLevel | undefined;
+}) => {
   const fieldId = getFieldId(NODEFEATUREDISCOVERY_FIELD_NAME, 'input');
-  const featureSupportLevel = useNewFeatureSupportLevel();
-  const [disabledReasonNmsate, setDisabledReason] = useState<string | undefined>();
 
-  React.useEffect(() => {
-    const reason = featureSupportLevel.getFeatureDisabledReason('NODE_FEATURE_DISCOVERY');
-    setDisabledReason(reason);
-  }, [featureSupportLevel]);
   return (
     <FormGroup isInline fieldId={fieldId}>
       <OcmCheckboxField
         name={NODEFEATUREDISCOVERY_FIELD_NAME}
         label={
-          <NodeFeatureDiscoveryLabel
-            disabledReason={disabledReason ? disabledReason : disabledReasonNmsate}
-            supportLevel={featureSupportLevel.getFeatureSupportLevel('NODE_FEATURE_DISCOVERY')}
-          />
+          <NodeFeatureDiscoveryLabel disabledReason={disabledReason} supportLevel={supportLevel} />
         }
         helperText={<NodeFeatureDiscoveryHelperText />}
-        isDisabled={!!disabledReason || !!disabledReasonNmsate}
+        isDisabled={!!disabledReason}
       />
     </FormGroup>
   );

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/NvidiaGpuCheckbox.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/NvidiaGpuCheckbox.tsx
@@ -1,8 +1,7 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { FormGroup, HelperText, HelperTextItem, Tooltip } from '@patternfly/react-core';
 import { getFieldId, PopoverIcon } from '../../../../common';
 import { OcmCheckboxField } from '../../ui/OcmFormFields';
-import { useNewFeatureSupportLevel } from '../../../../common/components/newFeatureSupportLevels';
 import { SupportLevel } from '@openshift-assisted/types/./assisted-installer-service';
 import NewFeatureSupportLevelBadge from '../../../../common/components/newFeatureSupportLevels/NewFeatureSupportLevelBadge';
 
@@ -40,27 +39,22 @@ const NvidiaGpuHelperText = () => {
   );
 };
 
-const NvidiaGpuCheckbox = ({ disabledReason }: { disabledReason?: string }) => {
+const NvidiaGpuCheckbox = ({
+  disabledReason,
+  supportLevel,
+}: {
+  disabledReason?: string;
+  supportLevel?: SupportLevel | undefined;
+}) => {
   const fieldId = getFieldId(NVIDIAGPU_FIELD_NAME, 'input');
-  const featureSupportLevel = useNewFeatureSupportLevel();
-  const [disabledReasonNvidia, setDisabledReason] = useState<string | undefined>();
 
-  React.useEffect(() => {
-    const reason = featureSupportLevel.getFeatureDisabledReason('NVIDIA_GPU');
-    setDisabledReason(reason);
-  }, [featureSupportLevel]);
   return (
     <FormGroup isInline fieldId={fieldId}>
       <OcmCheckboxField
         name={NVIDIAGPU_FIELD_NAME}
-        label={
-          <NvidiaGpuLabel
-            disabledReason={disabledReason ? disabledReason : disabledReasonNvidia}
-            supportLevel={featureSupportLevel.getFeatureSupportLevel('NVIDIA_GPU')}
-          />
-        }
+        label={<NvidiaGpuLabel disabledReason={disabledReason} supportLevel={supportLevel} />}
         helperText={<NvidiaGpuHelperText />}
-        isDisabled={!!disabledReason || !!disabledReasonNvidia}
+        isDisabled={!!disabledReason}
       />
     </FormGroup>
   );

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/OdfCheckbox.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/OdfCheckbox.tsx
@@ -1,17 +1,8 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { FormGroup, HelperText, HelperTextItem, Tooltip } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons/dist/js/icons/external-link-alt-icon';
-import {
-  getFieldId,
-  PopoverIcon,
-  ODF_REQUIREMENTS_LINK,
-  ODF_LINK,
-  OperatorsValues,
-} from '../../../../common';
+import { getFieldId, PopoverIcon, ODF_REQUIREMENTS_LINK, ODF_LINK } from '../../../../common';
 import { OcmCheckboxField } from '../../ui/OcmFormFields';
-import { useNewFeatureSupportLevel } from '../../../../common/components/newFeatureSupportLevels';
-import { useFormikContext } from 'formik';
-import { getOdfIncompatibleWithLvmsReason } from '../../featureSupportLevels/featureStateUtils';
 import NewFeatureSupportLevelBadge from '../../../../common/components/newFeatureSupportLevels/NewFeatureSupportLevelBadge';
 import { SupportLevel } from '@openshift-assisted/types/./assisted-installer-service';
 
@@ -54,35 +45,21 @@ const OdfHelperText = () => {
   );
 };
 
-const OdfCheckbox = ({ disabledReason }: { disabledReason?: string }) => {
-  const featureSupportLevelContext = useNewFeatureSupportLevel();
-  const { values } = useFormikContext<OperatorsValues>();
+const OdfCheckbox = ({
+  disabledReason,
+  supportLevel,
+}: {
+  disabledReason?: string;
+  supportLevel?: SupportLevel | undefined;
+}) => {
   const fieldId = getFieldId(ODF_FIELD_NAME, 'input');
-  const [disabledReasonOdf, setDisabledReason] = useState<string | undefined>();
-
-  React.useEffect(() => {
-    let disabledReason = featureSupportLevelContext.getFeatureDisabledReason('ODF');
-    if (!disabledReason) {
-      disabledReason = getOdfIncompatibleWithLvmsReason(values);
-    }
-    setDisabledReason(disabledReason);
-  }, [values, featureSupportLevelContext]);
-
-  React.useEffect(() => {
-    setDisabledReason(disabledReason);
-  }, [disabledReason]);
 
   return (
     <FormGroup isInline fieldId={fieldId}>
       <OcmCheckboxField
         name={ODF_FIELD_NAME}
-        label={
-          <OdfLabel
-            disabledReason={disabledReasonOdf}
-            supportLevel={featureSupportLevelContext.getFeatureSupportLevel('ODF')}
-          />
-        }
-        isDisabled={!!disabledReasonOdf}
+        label={<OdfLabel disabledReason={disabledReason} supportLevel={supportLevel} />}
+        isDisabled={!!disabledReason}
         helperText={<OdfHelperText />}
       />
     </FormGroup>

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/OpenShiftAICheckbox.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/OpenShiftAICheckbox.tsx
@@ -1,14 +1,11 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { FormGroup, HelperText, HelperTextItem, Tooltip } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons/dist/js/icons/external-link-alt-icon';
-import { useFormikContext } from 'formik';
-import { getFieldId, PopoverIcon, OPENSHIFT_AI_LINK, OperatorsValues } from '../../../../common';
+import { getFieldId, PopoverIcon, OPENSHIFT_AI_LINK } from '../../../../common';
 import OpenShiftAIRequirements from './OpenShiftAIRequirements';
 import { OcmCheckboxField } from '../../ui/OcmFormFields';
-import { useNewFeatureSupportLevel } from '../../../../common/components/newFeatureSupportLevels';
 import NewFeatureSupportLevelBadge from '../../../../common/components/newFeatureSupportLevels/NewFeatureSupportLevelBadge';
 import { SupportLevel } from '@openshift-assisted/types/assisted-installer-service';
-import { getOpenShiftAIIncompatibleWithLvmsReason } from '../../featureSupportLevels/featureStateUtils';
 
 const OPENSHIFT_AI_FIELD_NAME = 'useOpenShiftAI';
 
@@ -46,35 +43,21 @@ const OpenShiftAIHelperText = () => {
   );
 };
 
-const OpenShiftAICheckbox = ({ disabledReason }: { disabledReason?: string }) => {
-  const featureSupportLevel = useNewFeatureSupportLevel();
-  const { values } = useFormikContext<OperatorsValues>();
+const OpenShiftAICheckbox = ({
+  disabledReason,
+  supportLevel,
+}: {
+  disabledReason?: string;
+  supportLevel?: SupportLevel | undefined;
+}) => {
   const fieldId = getFieldId(OPENSHIFT_AI_FIELD_NAME, 'input');
-  const [disabledReasonAI, setDisabledReason] = useState<string | undefined>();
-
-  React.useEffect(() => {
-    let disabledReason = featureSupportLevel.getFeatureDisabledReason('OPENSHIFT_AI');
-    if (!disabledReason) {
-      disabledReason = getOpenShiftAIIncompatibleWithLvmsReason(values);
-    }
-    setDisabledReason(disabledReason);
-  }, [values, featureSupportLevel]);
-
-  React.useEffect(() => {
-    setDisabledReason(disabledReason);
-  }, [disabledReason]);
 
   return (
     <FormGroup isInline fieldId={fieldId}>
       <OcmCheckboxField
         name={OPENSHIFT_AI_FIELD_NAME}
-        label={
-          <OpenShiftAILabel
-            disabledReason={disabledReasonAI}
-            supportLevel={featureSupportLevel.getFeatureSupportLevel('OPENSHIFT_AI')}
-          />
-        }
-        isDisabled={!!disabledReasonAI}
+        label={<OpenShiftAILabel disabledReason={disabledReason} supportLevel={supportLevel} />}
+        isDisabled={!!disabledReason}
         helperText={<OpenShiftAIHelperText />}
       />
     </FormGroup>

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/OscCheckbox.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/OscCheckbox.tsx
@@ -1,16 +1,8 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { FormGroup, HelperText, HelperTextItem, Tooltip } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons/dist/js/icons/external-link-alt-icon';
-import { useFormikContext } from 'formik';
-import {
-  getFieldId,
-  PopoverIcon,
-  OSC_REQUIREMENTS_LINK,
-  OSC_LINK,
-  OperatorsValues,
-} from '../../../../common';
+import { getFieldId, PopoverIcon, OSC_REQUIREMENTS_LINK, OSC_LINK } from '../../../../common';
 import { OcmCheckboxField } from '../../ui/OcmFormFields';
-import { useNewFeatureSupportLevel } from '../../../../common/components/newFeatureSupportLevels';
 import NewFeatureSupportLevelBadge from '../../../../common/components/newFeatureSupportLevels/NewFeatureSupportLevelBadge';
 import { SupportLevel } from '@openshift-assisted/types/assisted-installer-service';
 
@@ -57,27 +49,20 @@ const OscHelperText = () => {
   );
 };
 
-const OscCheckbox = () => {
-  const featureSupportLevel = useNewFeatureSupportLevel();
-  const { values } = useFormikContext<OperatorsValues>();
+const OscCheckbox = ({
+  disabledReason,
+  supportLevel,
+}: {
+  disabledReason?: string;
+  supportLevel?: SupportLevel | undefined;
+}) => {
   const fieldId = getFieldId(OSC_FIELD_NAME, 'input');
-  const [disabledReason, setDisabledReason] = useState<string | undefined>();
-
-  React.useEffect(() => {
-    const disabledReason = featureSupportLevel.getFeatureDisabledReason('OSC');
-    setDisabledReason(disabledReason);
-  }, [values, featureSupportLevel]);
 
   return (
     <FormGroup isInline fieldId={fieldId}>
       <OcmCheckboxField
         name={OSC_FIELD_NAME}
-        label={
-          <OscLabel
-            disabledReason={disabledReason}
-            supportLevel={featureSupportLevel.getFeatureSupportLevel('OSC')}
-          />
-        }
+        label={<OscLabel disabledReason={disabledReason} supportLevel={supportLevel} />}
         isDisabled={!!disabledReason}
         helperText={<OscHelperText />}
       />

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/PipelinesChekbox.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/PipelinesChekbox.tsx
@@ -1,10 +1,9 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { FormGroup, HelperText, HelperTextItem, Tooltip } from '@patternfly/react-core';
 import { getFieldId, PopoverIcon } from '../../../../common';
 import { OcmCheckboxField } from '../../ui/OcmFormFields';
 import { SupportLevel } from '@openshift-assisted/types/./assisted-installer-service';
 import NewFeatureSupportLevelBadge from '../../../../common/components/newFeatureSupportLevels/NewFeatureSupportLevelBadge';
-import { useNewFeatureSupportLevel } from '../../../../common/components/newFeatureSupportLevels';
 
 const PIPELINES_FIELD_NAME = 'usePipelines';
 
@@ -41,27 +40,22 @@ const PipelinesHelperText = () => {
   );
 };
 
-const PipelinesCheckbox = ({ disabledReason }: { disabledReason?: string }) => {
+const PipelinesCheckbox = ({
+  disabledReason,
+  supportLevel,
+}: {
+  disabledReason?: string;
+  supportLevel?: SupportLevel | undefined;
+}) => {
   const fieldId = getFieldId(PIPELINES_FIELD_NAME, 'input');
-  const featureSupportLevel = useNewFeatureSupportLevel();
-  const [disabledReasonPipelines, setDisabledReason] = useState<string | undefined>();
 
-  React.useEffect(() => {
-    const reason = featureSupportLevel.getFeatureDisabledReason('PIPELINES');
-    setDisabledReason(reason);
-  }, [featureSupportLevel]);
   return (
     <FormGroup isInline fieldId={fieldId}>
       <OcmCheckboxField
         name={PIPELINES_FIELD_NAME}
-        label={
-          <PipelinesLabel
-            disabledReason={disabledReason ? disabledReason : disabledReasonPipelines}
-            supportLevel={featureSupportLevel.getFeatureSupportLevel('PIPELINES')}
-          />
-        }
+        label={<PipelinesLabel disabledReason={disabledReason} supportLevel={supportLevel} />}
         helperText={<PipelinesHelperText />}
-        isDisabled={!!disabledReason || !!disabledReasonPipelines}
+        isDisabled={!!disabledReason}
       />
     </FormGroup>
   );

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/ServerlessCheckbox.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/ServerlessCheckbox.tsx
@@ -1,8 +1,7 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { FormGroup, HelperText, HelperTextItem, Tooltip } from '@patternfly/react-core';
 import { getFieldId, PopoverIcon } from '../../../../common';
 import { OcmCheckboxField } from '../../ui/OcmFormFields';
-import { useNewFeatureSupportLevel } from '../../../../common/components/newFeatureSupportLevels';
 import { SupportLevel } from '@openshift-assisted/types/./assisted-installer-service';
 import NewFeatureSupportLevelBadge from '../../../../common/components/newFeatureSupportLevels/NewFeatureSupportLevelBadge';
 
@@ -40,27 +39,22 @@ const ServerlessHelperText = () => {
   );
 };
 
-const ServerlessCheckbox = ({ disabledReason }: { disabledReason?: string }) => {
+const ServerlessCheckbox = ({
+  disabledReason,
+  supportLevel,
+}: {
+  disabledReason?: string;
+  supportLevel?: SupportLevel | undefined;
+}) => {
   const fieldId = getFieldId(SERVERLESS_FIELD_NAME, 'input');
-  const featureSupportLevel = useNewFeatureSupportLevel();
-  const [disabledReasonServerless, setDisabledReason] = useState<string | undefined>();
 
-  React.useEffect(() => {
-    const reason = featureSupportLevel.getFeatureDisabledReason('SERVERLESS');
-    setDisabledReason(reason);
-  }, [featureSupportLevel]);
   return (
     <FormGroup isInline fieldId={fieldId}>
       <OcmCheckboxField
         name={SERVERLESS_FIELD_NAME}
-        label={
-          <ServerlessLabel
-            disabledReason={disabledReason ? disabledReason : disabledReasonServerless}
-            supportLevel={featureSupportLevel.getFeatureSupportLevel('SERVERLESS')}
-          />
-        }
+        label={<ServerlessLabel disabledReason={disabledReason} supportLevel={supportLevel} />}
         helperText={<ServerlessHelperText />}
-        isDisabled={!!disabledReason || !!disabledReasonServerless}
+        isDisabled={!!disabledReason}
       />
     </FormGroup>
   );

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/ServicemeshCheckbox.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/ServicemeshCheckbox.tsx
@@ -1,8 +1,7 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { FormGroup, HelperText, HelperTextItem, Tooltip } from '@patternfly/react-core';
 import { getFieldId, PopoverIcon } from '../../../../common';
 import { OcmCheckboxField } from '../../ui/OcmFormFields';
-import { useNewFeatureSupportLevel } from '../../../../common/components/newFeatureSupportLevels/NewFeatureSupportLevelContext';
 import { SupportLevel } from '@openshift-assisted/types/./assisted-installer-service';
 import NewFeatureSupportLevelBadge from '../../../../common/components/newFeatureSupportLevels/NewFeatureSupportLevelBadge';
 
@@ -40,27 +39,22 @@ const ServiceMeshHelperText = () => {
   );
 };
 
-const ServiceMeshCheckbox = ({ disabledReason }: { disabledReason?: string }) => {
+const ServiceMeshCheckbox = ({
+  disabledReason,
+  supportLevel,
+}: {
+  disabledReason?: string;
+  supportLevel?: SupportLevel | undefined;
+}) => {
   const fieldId = getFieldId(SERVICEMESH_FIELD_NAME, 'input');
-  const featureSupportLevel = useNewFeatureSupportLevel();
-  const [disabledReasonServicemesh, setDisabledReason] = useState<string | undefined>();
 
-  React.useEffect(() => {
-    const reason = featureSupportLevel.getFeatureDisabledReason('SERVICEMESH');
-    setDisabledReason(reason);
-  }, [featureSupportLevel]);
   return (
     <FormGroup isInline fieldId={fieldId}>
       <OcmCheckboxField
         name={SERVICEMESH_FIELD_NAME}
-        label={
-          <ServiceMeshLabel
-            disabledReason={disabledReason ? disabledReason : disabledReasonServicemesh}
-            supportLevel={featureSupportLevel.getFeatureSupportLevel('SERVICEMESH')}
-          />
-        }
+        label={<ServiceMeshLabel disabledReason={disabledReason} supportLevel={supportLevel} />}
         helperText={<ServiceMeshHelperText />}
-        isDisabled={!!disabledReason || !!disabledReasonServicemesh}
+        isDisabled={!!disabledReason}
       />
     </FormGroup>
   );

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/SupportedOperators.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/SupportedOperators.tsx
@@ -32,6 +32,7 @@ import {
   OPERATOR_NAME_SERVERLESS,
   OPERATOR_NAME_SERVICEMESH,
 } from '../../../../common';
+import { SupportLevel } from '@openshift-assisted/types/./assisted-installer-service';
 
 interface OperatorProps {
   clusterId: string;
@@ -39,6 +40,7 @@ interface OperatorProps {
   isVersionEqualsOrMajorThan4_15: boolean;
   isSNO: boolean;
   disabledReason?: string;
+  supportLevel?: SupportLevel | undefined;
 }
 
 export interface ComponentItem {
@@ -51,17 +53,11 @@ export const operatorComponentMap: Record<string, (props: OperatorProps) => JSX.
     <CnvCheckbox {...props} isVersionEqualsOrMajorThan4_15={props.isVersionEqualsOrMajorThan4_15} />
   ),
   mtv: (props) => <MtvOperatorCheckbox {...props} />,
-  mce: (props) => (
-    <MceCheckbox
-      clusterId={props.clusterId}
-      isVersionEqualsOrMajorThan4_15={props.isVersionEqualsOrMajorThan4_15}
-      openshiftVersion={props.openshiftVersion}
-    />
-  ),
+  mce: (props) => <MceCheckbox {...props} />,
   lvm: (props) => <LvmCheckbox {...props} />,
   odf: (props) => <OdfCheckbox {...props} />,
   'openshift-ai': (props) => <OpenShiftAICheckbox {...props} />,
-  osc: () => <OscCheckbox />,
+  osc: (props) => <OscCheckbox {...props} />,
   lso: (props) => <LsoCheckbox {...props} />,
   'node-feature-discovery': () => <NodeFeatureDiscoveryCheckbox />,
   nmstate: (props) => <NmstateCheckbox {...props} />,


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-19938

MTV and Openshift AI get disabled  (they should be disabled) only after few seconds (around 10 seconds) after the page is loaded

Before changes:

https://github.com/user-attachments/assets/0a63ad3a-6181-47a4-b2e0-2a6a9ed513bb

After change:

https://github.com/user-attachments/assets/7b904fae-e011-4fb7-8534-4b7c08b41681

