### PR TITLE
MGMT-19589: Renaming is available in drop-down for a host in removing from cluster state, no warning/error that it's impossible in opened pop-up

### DIFF
--- a/libs/locales/lib/en/translation.json
+++ b/libs/locales/lib/en/translation.json
@@ -800,6 +800,7 @@
   "ai:The generated discovery ISO will contain everything needed to boot.": "The generated discovery ISO will contain everything that is needed to boot.",
   "ai:The host has been discovered and needs to be approved to before further use.": "The host has been discovered and needs to be approved to before further use.",
   "ai:The host machine is powered on": "The host machine is powered on",
+  "ai:The hostname cannot be changed.": "The hostname cannot be changed.",
   "ai:The hosts you selected are using different proxy settings. Configure a proxy that will be applied for these hosts. <bold>Configure at least one of the proxy settings below.</bold>": "The hosts you selected are using different proxy settings. Configure a proxy that will be applied for these hosts. <bold>Configure at least one of the following proxy settings.</bold>",
   "ai:The HTTP proxy URL that agents should use to access the discovery service.": "The HTTP proxy URL that agents should use to access the discovery service.",
   "ai:The IP address pool to use for service IP addresses. You can enter only one IP address pool. If you need to access the services from an external network, configure load balancers and routers to manage the traffic.": "The IP address pool to use for service IP addresses. You can enter only one IP address pool. If you need to access the services from an external network, configure load balancers and routers to manage the traffic.",

--- a/libs/ui-lib/lib/common/components/hosts/EditHostForm.tsx
+++ b/libs/ui-lib/lib/common/components/hosts/EditHostForm.tsx
@@ -56,6 +56,7 @@ const EditHostForm = ({
   onHostSaveError,
   getEditErrorMessage,
 }: EditHostFormProps) => {
+  const { t } = useTranslation();
   const hostnameInputRef = React.useRef<HTMLInputElement>();
   const [isSaveInProgress, setIsSaveInProgress] = React.useState<boolean>(false);
 
@@ -71,7 +72,7 @@ const EditHostForm = ({
     hostId: host.id,
     hostname: requestedHostname || '',
   };
-  const { t } = useTranslation();
+
   return (
     <Formik
       validateOnMount
@@ -110,11 +111,19 @@ const EditHostForm = ({
                 status={status as StatusErrorType}
                 onClose={() => setStatus({ error: null })}
               />
-              <Alert
-                variant={AlertVariant.info}
-                title={t('ai:This name will replace the original discovered hostname.')}
-                isInline
-              />
+              {canHostnameBeChanged(host.status) ? (
+                <Alert
+                  variant={AlertVariant.info}
+                  title={t('ai:This name will replace the original discovered hostname.')}
+                  isInline
+                />
+              ) : (
+                <Alert
+                  variant={AlertVariant.warning}
+                  title={t('ai:The hostname cannot be changed.')}
+                  isInline
+                />
+              )}
               <StaticTextField name="discoveredHostname" label={t('ai:Discovered hostname')}>
                 {hostname || ''}
               </StaticTextField>


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-19589

Resolved by showing an alert:

![image](https://github.com/user-attachments/assets/3ab019ea-a6a1-4f27-a8fa-0be30f28347a)
