### PR TITLE
Operators redesign followup

### DIFF
--- a/libs/ui-lib/lib/common/config/docs_links.ts
+++ b/libs/ui-lib/lib/common/config/docs_links.ts
@@ -114,3 +114,26 @@ export const getMtuLink = (ocpVersion?: string) =>
   `https://docs.redhat.com/en/documentation/openshift_container_platform/${getShortOpenshiftVersion(
     ocpVersion,
   )}/html/networking/changing-cluster-network-mtu#nw-cluster-mtu-change-about_changing-cluster-network-mtu`;
+
+export const AUTHORINO_OPERATOR_LINK = 'https://github.com/Kuadrant/authorino-operator';
+
+export const LOCAL_STORAGE_OPERATOR_LINK =
+  'https://docs.openshift.com/container-platform/4.17/storage/persistent_storage/persistent_storage_local/ways-to-provision-local-storage.html';
+
+export const NMSTATE_OPERATOR_LINK =
+  'https://docs.openshift.com/container-platform/4.17/networking/networking_operators/k8s-nmstate-about-the-k8s-nmstate-operator.html';
+
+export const NODE_FEATURE_DISCOVERY_OPERATOR_LINK =
+  'https://docs.openshift.com/container-platform/4.17/hardware_enablement/psap-node-feature-discovery-operator.html';
+
+export const NVIDIA_GPU_OPERATOR_LINK =
+  'https://docs.openshift.com/container-platform/4.17/virt/virtual_machines/advanced_vm_management/virt-configuring-virtual-gpus.html';
+
+export const PIPELINES_OPERATOR_LINK =
+  'https://docs.openshift.com/pipelines/1.17/install_config/installing-pipelines.html';
+
+export const SERVICE_MESH_OPERATOR_LINK =
+  'https://docs.openshift.com/container-platform/4.17/service_mesh/v1x/preparing-ossm-installation.html';
+
+export const SERVERLESS_OPERATOR_LINK =
+  'https://docs.openshift.com/serverless/1.28/install/install-serverless-operator.html#serverless-install-web-console_install-serverless-operator';

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/AuthorinoCheckbox.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/AuthorinoCheckbox.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { FormGroup, HelperText, HelperTextItem, Tooltip } from '@patternfly/react-core';
-import { getFieldId, PopoverIcon } from '../../../../common';
+import { AUTHORINO_OPERATOR_LINK, getFieldId, PopoverIcon } from '../../../../common';
 import { OcmCheckboxField } from '../../ui/OcmFormFields';
 import NewFeatureSupportLevelBadge from '../../../../common/components/newFeatureSupportLevels/NewFeatureSupportLevelBadge';
 import { SupportLevel } from '@openshift-assisted/types/./assisted-installer-service';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons/dist/js/icons/external-link-alt-icon';
 
 const AUTHORINO_FIELD_NAME = 'useAuthorino';
 
@@ -34,6 +35,9 @@ const AuthorinoHelperText = () => {
     <HelperText>
       <HelperTextItem variant="indeterminate">
         Lightweigth external authorization service for tailor-made Zero Trust API security.{' '}
+        <a href={AUTHORINO_OPERATOR_LINK} target="_blank" rel="noopener noreferrer">
+          {'Learn more'} <ExternalLinkAltIcon />
+        </a>
       </HelperTextItem>
     </HelperText>
   );

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/CnvCheckbox.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/CnvCheckbox.tsx
@@ -1,11 +1,18 @@
 import React from 'react';
 import { FormGroup, HelperText, HelperTextItem, Tooltip } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons/dist/js/icons/external-link-alt-icon';
-import { ClusterOperatorProps, CNV_LINK, getFieldId, PopoverIcon } from '../../../../common';
+import {
+  ClusterOperatorProps,
+  CNV_LINK,
+  getFieldId,
+  OperatorsValues,
+  PopoverIcon,
+} from '../../../../common';
 import CnvHostRequirements from './CnvHostRequirements';
 import { OcmCheckboxField } from '../../ui/OcmFormFields';
 import NewFeatureSupportLevelBadge from '../../../../common/components/newFeatureSupportLevels/NewFeatureSupportLevelBadge';
 import { SupportLevel } from '@openshift-assisted/types/assisted-installer-service';
+import { useFormikContext } from 'formik';
 
 const CNV_FIELD_NAME = 'useContainerNativeVirtualization';
 
@@ -66,8 +73,11 @@ const CnvCheckbox = ({
   disabledReason?: string;
   supportLevel?: SupportLevel | undefined;
 }) => {
+  const { setFieldValue } = useFormikContext<OperatorsValues>();
   const fieldId = getFieldId(CNV_FIELD_NAME, 'input');
-
+  const selectLsoOperator = (checked: boolean) => {
+    setFieldValue('useLso', checked);
+  };
   return (
     <FormGroup isInline fieldId={fieldId}>
       <OcmCheckboxField
@@ -82,6 +92,7 @@ const CnvCheckbox = ({
         }
         helperText={<CnvHelperText />}
         isDisabled={!!disabledReason}
+        onChange={selectLsoOperator}
       />
     </FormGroup>
   );

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/LsoCheckbox.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/LsoCheckbox.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { FormGroup, HelperText, HelperTextItem, Tooltip } from '@patternfly/react-core';
-import { getFieldId, PopoverIcon } from '../../../../common';
+import { getFieldId, LOCAL_STORAGE_OPERATOR_LINK, PopoverIcon } from '../../../../common';
 import { OcmCheckboxField } from '../../ui/OcmFormFields';
 import NewFeatureSupportLevelBadge from '../../../../common/components/newFeatureSupportLevels/NewFeatureSupportLevelBadge';
 import { SupportLevel } from '@openshift-assisted/types/./assisted-installer-service';
+import ExternalLinkAltIcon from '@patternfly/react-icons/dist/js/icons/external-link-alt-icon';
 
 const LSO_FIELD_NAME = 'useLso';
 
@@ -34,6 +35,9 @@ const LsoHelperText = () => {
     <HelperText>
       <HelperTextItem variant="indeterminate">
         Allows provisioning of persistent storage by using local volumes.{' '}
+        <a href={LOCAL_STORAGE_OPERATOR_LINK} target="_blank" rel="noopener noreferrer">
+          {'Learn more'} <ExternalLinkAltIcon />
+        </a>
       </HelperTextItem>
     </HelperText>
   );

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/NmstateCheckbox.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/NmstateCheckbox.tsx
@@ -1,10 +1,16 @@
 import React from 'react';
 import { FormGroup, HelperText, HelperTextItem, Tooltip } from '@patternfly/react-core';
-import { getFieldId, PopoverIcon, ClusterOperatorProps } from '../../../../common';
+import {
+  getFieldId,
+  PopoverIcon,
+  ClusterOperatorProps,
+  NMSTATE_OPERATOR_LINK,
+} from '../../../../common';
 import { OcmCheckboxField } from '../../ui/OcmFormFields';
 import NmstateRequirements from './NmstateRequirements';
 import { SupportLevel } from '@openshift-assisted/types/./assisted-installer-service';
 import NewFeatureSupportLevelBadge from '../../../../common/components/newFeatureSupportLevels/NewFeatureSupportLevelBadge';
+import ExternalLinkAltIcon from '@patternfly/react-icons/dist/js/icons/external-link-alt-icon';
 
 const NMSTATE_FIELD_NAME = 'useNmstate';
 
@@ -39,6 +45,9 @@ const NmstateHelperText = () => {
       <HelperTextItem variant="indeterminate">
         Provides users with functionality to configure various network interface types, DNS, and
         routing on cluster nodes.{' '}
+        <a href={NMSTATE_OPERATOR_LINK} target="_blank" rel="noopener noreferrer">
+          {'Learn more'} <ExternalLinkAltIcon />
+        </a>
       </HelperTextItem>
     </HelperText>
   );

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/NodeFeatureDiscoveryCheckbox.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/NodeFeatureDiscoveryCheckbox.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { FormGroup, HelperText, HelperTextItem, Tooltip } from '@patternfly/react-core';
-import { getFieldId, PopoverIcon } from '../../../../common';
+import { getFieldId, NODE_FEATURE_DISCOVERY_OPERATOR_LINK, PopoverIcon } from '../../../../common';
 import { OcmCheckboxField } from '../../ui/OcmFormFields';
 import NewFeatureSupportLevelBadge from '../../../../common/components/newFeatureSupportLevels/NewFeatureSupportLevelBadge';
 import { SupportLevel } from '@openshift-assisted/types/./assisted-installer-service';
+import ExternalLinkAltIcon from '@patternfly/react-icons/dist/js/icons/external-link-alt-icon';
 
 const NODEFEATUREDISCOVERY_FIELD_NAME = 'useNodeFeatureDiscovery';
 
@@ -35,6 +36,9 @@ const NodeFeatureDiscoveryHelperText = () => {
       <HelperTextItem variant="indeterminate">
         Manage the detection of hardware features and configuration by labeling nodes with
         hardware-specific information.{' '}
+        <a href={NODE_FEATURE_DISCOVERY_OPERATOR_LINK} target="_blank" rel="noopener noreferrer">
+          {'Learn more'} <ExternalLinkAltIcon />
+        </a>
       </HelperTextItem>
     </HelperText>
   );

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/NvidiaGpuCheckbox.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/NvidiaGpuCheckbox.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { FormGroup, HelperText, HelperTextItem, Tooltip } from '@patternfly/react-core';
-import { getFieldId, PopoverIcon } from '../../../../common';
+import { getFieldId, NVIDIA_GPU_OPERATOR_LINK, PopoverIcon } from '../../../../common';
 import { OcmCheckboxField } from '../../ui/OcmFormFields';
 import { SupportLevel } from '@openshift-assisted/types/./assisted-installer-service';
 import NewFeatureSupportLevelBadge from '../../../../common/components/newFeatureSupportLevels/NewFeatureSupportLevelBadge';
+import ExternalLinkAltIcon from '@patternfly/react-icons/dist/js/icons/external-link-alt-icon';
 
 const NVIDIAGPU_FIELD_NAME = 'useNvidiaGpu';
 
@@ -34,6 +35,9 @@ const NvidiaGpuHelperText = () => {
     <HelperText>
       <HelperTextItem variant="indeterminate">
         Automate the management of NVIDIA software components needed to provision and monitor GPUs.{' '}
+        <a href={NVIDIA_GPU_OPERATOR_LINK} target="_blank" rel="noopener noreferrer">
+          {'Learn more'} <ExternalLinkAltIcon />
+        </a>
       </HelperTextItem>
     </HelperText>
   );

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/OdfCheckbox.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/OdfCheckbox.tsx
@@ -1,10 +1,17 @@
 import React from 'react';
 import { FormGroup, HelperText, HelperTextItem, Tooltip } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons/dist/js/icons/external-link-alt-icon';
-import { getFieldId, PopoverIcon, ODF_REQUIREMENTS_LINK, ODF_LINK } from '../../../../common';
+import {
+  getFieldId,
+  PopoverIcon,
+  ODF_REQUIREMENTS_LINK,
+  ODF_LINK,
+  OperatorsValues,
+} from '../../../../common';
 import { OcmCheckboxField } from '../../ui/OcmFormFields';
 import NewFeatureSupportLevelBadge from '../../../../common/components/newFeatureSupportLevels/NewFeatureSupportLevelBadge';
 import { SupportLevel } from '@openshift-assisted/types/./assisted-installer-service';
+import { useFormikContext } from 'formik';
 
 const ODF_FIELD_NAME = 'useOpenShiftDataFoundation';
 
@@ -52,8 +59,11 @@ const OdfCheckbox = ({
   disabledReason?: string;
   supportLevel?: SupportLevel | undefined;
 }) => {
+  const { setFieldValue } = useFormikContext<OperatorsValues>();
   const fieldId = getFieldId(ODF_FIELD_NAME, 'input');
-
+  const selectLsoOperator = (checked: boolean) => {
+    setFieldValue('useLso', checked);
+  };
   return (
     <FormGroup isInline fieldId={fieldId}>
       <OcmCheckboxField
@@ -61,6 +71,7 @@ const OdfCheckbox = ({
         label={<OdfLabel disabledReason={disabledReason} supportLevel={supportLevel} />}
         isDisabled={!!disabledReason}
         helperText={<OdfHelperText />}
+        onChange={selectLsoOperator}
       />
     </FormGroup>
   );

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/PipelinesChekbox.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/PipelinesChekbox.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { FormGroup, HelperText, HelperTextItem, Tooltip } from '@patternfly/react-core';
-import { getFieldId, PopoverIcon } from '../../../../common';
+import { getFieldId, PIPELINES_OPERATOR_LINK, PopoverIcon } from '../../../../common';
 import { OcmCheckboxField } from '../../ui/OcmFormFields';
 import { SupportLevel } from '@openshift-assisted/types/./assisted-installer-service';
 import NewFeatureSupportLevelBadge from '../../../../common/components/newFeatureSupportLevels/NewFeatureSupportLevelBadge';
+import ExternalLinkAltIcon from '@patternfly/react-icons/dist/js/icons/external-link-alt-icon';
 
 const PIPELINES_FIELD_NAME = 'usePipelines';
 
@@ -35,6 +36,9 @@ const PipelinesHelperText = () => {
       <HelperTextItem variant="indeterminate">
         Cloud-native continuous integration and delivery (CI/CD) solution for building pipelines
         using Tekton.{' '}
+        <a href={PIPELINES_OPERATOR_LINK} target="_blank" rel="noopener noreferrer">
+          {'Learn more'} <ExternalLinkAltIcon />
+        </a>
       </HelperTextItem>
     </HelperText>
   );

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/ServerlessCheckbox.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/ServerlessCheckbox.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { FormGroup, HelperText, HelperTextItem, Tooltip } from '@patternfly/react-core';
-import { getFieldId, PopoverIcon } from '../../../../common';
+import { getFieldId, PopoverIcon, SERVERLESS_OPERATOR_LINK } from '../../../../common';
 import { OcmCheckboxField } from '../../ui/OcmFormFields';
 import { SupportLevel } from '@openshift-assisted/types/./assisted-installer-service';
 import NewFeatureSupportLevelBadge from '../../../../common/components/newFeatureSupportLevels/NewFeatureSupportLevelBadge';
+import ExternalLinkAltIcon from '@patternfly/react-icons/dist/js/icons/external-link-alt-icon';
 
 const SERVERLESS_FIELD_NAME = 'useServerless';
 
@@ -34,6 +35,9 @@ const ServerlessHelperText = () => {
     <HelperText>
       <HelperTextItem variant="indeterminate">
         Deploy workflow applications based on the CNCF Serverless Workflow specification.{' '}
+        <a href={SERVERLESS_OPERATOR_LINK} target="_blank" rel="noopener noreferrer">
+          {'Learn more'} <ExternalLinkAltIcon />
+        </a>
       </HelperTextItem>
     </HelperText>
   );

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/ServicemeshCheckbox.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/ServicemeshCheckbox.tsx
@@ -5,7 +5,7 @@ import { OcmCheckboxField } from '../../ui/OcmFormFields';
 import { SupportLevel } from '@openshift-assisted/types/./assisted-installer-service';
 import NewFeatureSupportLevelBadge from '../../../../common/components/newFeatureSupportLevels/NewFeatureSupportLevelBadge';
 
-const SERVICEMESH_FIELD_NAME = 'useServiceMesh';
+const SERVICEMESH_FIELD_NAME = 'useServicemesh';
 
 const ServiceMeshLabel = ({
   disabledReason,

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/ServicemeshCheckbox.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/ServicemeshCheckbox.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { FormGroup, HelperText, HelperTextItem, Tooltip } from '@patternfly/react-core';
-import { getFieldId, PopoverIcon } from '../../../../common';
+import { getFieldId, PopoverIcon, SERVICE_MESH_OPERATOR_LINK } from '../../../../common';
 import { OcmCheckboxField } from '../../ui/OcmFormFields';
 import { SupportLevel } from '@openshift-assisted/types/./assisted-installer-service';
 import NewFeatureSupportLevelBadge from '../../../../common/components/newFeatureSupportLevels/NewFeatureSupportLevelBadge';
+import ExternalLinkAltIcon from '@patternfly/react-icons/dist/js/icons/external-link-alt-icon';
 
 const SERVICEMESH_FIELD_NAME = 'useServicemesh';
 
@@ -34,6 +35,9 @@ const ServiceMeshHelperText = () => {
     <HelperText>
       <HelperTextItem variant="indeterminate">
         Platform that provides behavioral insight and operational control over a service mesh.{' '}
+        <a href={SERVICE_MESH_OPERATOR_LINK} target="_blank" rel="noopener noreferrer">
+          {'Learn more'} <ExternalLinkAltIcon />
+        </a>
       </HelperTextItem>
     </HelperText>
   );

--- a/libs/ui-lib/lib/ocm/components/clusterWizard/OperatorsStep.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/OperatorsStep.tsx
@@ -20,6 +20,8 @@ import {
   ClusterOperatorProps,
   ClusterWizardStepHeader,
   numberOfEnabledOperators,
+  OPERATOR_NAME_CNV,
+  OPERATOR_NAME_ODF,
   OperatorsValues,
   PopoverIcon,
 } from '../../../common';
@@ -156,6 +158,9 @@ export const OperatorsStep = (props: ClusterOperatorProps) => {
           newBundleOperators.push(op);
           const fieldId = mapOperatorsToFieldIds[op]; // Obtener el ID del campo correspondiente
           setFieldValue(fieldId, checked);
+          if (op === OPERATOR_NAME_CNV || op === OPERATOR_NAME_ODF) {
+            setFieldValue('useLso', checked);
+          }
         }
       });
     } else {
@@ -165,6 +170,9 @@ export const OperatorsStep = (props: ClusterOperatorProps) => {
       operators.forEach((op) => {
         const fieldId = mapOperatorsToFieldIds[op]; // Obtener el ID del campo correspondiente
         setFieldValue(fieldId, checked);
+        if (op === OPERATOR_NAME_CNV || op === OPERATOR_NAME_ODF) {
+          setFieldValue('useLso', checked);
+        }
       });
     }
 

--- a/libs/ui-lib/lib/ocm/components/clusterWizard/OperatorsStep.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/OperatorsStep.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import {
@@ -219,6 +220,18 @@ export const OperatorsStep = (props: ClusterOperatorProps) => {
     );
   };
 
+  const bundleHasOperatorsNotCompatibles = (
+    operators: string[] | undefined,
+    values: OperatorsValues,
+  ) => {
+    return (
+      operators?.some((operatorKey) => {
+        const disabledReason = getDisabledReasonForOperator(operatorKey, values);
+        return disabledReason !== undefined;
+      }) ?? false
+    );
+  };
+
   const getDisabledReasonForOperator = (operatorKey: string, values: OperatorsValues) => {
     let disabledReason = featureSupportLevelData.getFeatureDisabledReason(
       mapOperatorIdToFeatureId[operatorKey],
@@ -282,75 +295,86 @@ export const OperatorsStep = (props: ClusterOperatorProps) => {
       </StackItem>
       {/* Mostrar bundles como tarjetas */}
       <Gallery hasGutter minWidths={{ default: '350px' }} maxWidths={{ default: '2fr' }}>
-        {filteredBundles.map((bundle) => (
-          <GalleryItem key={bundle.id}>
-            <Tooltip
-              content={
-                bundleHasOperatorsNotSupported(bundle.operators)
-                  ? 'Some operators in this bundle are not supported with the current configuration.'
-                  : isSNO && bundle.id === 'openshift-ai-nvidia'
-                  ? 'This bundle is not available when deploying a Single Node OpenShift.'
-                  : ''
-              }
-              hidden={
-                !bundleHasOperatorsNotSupported(bundle.operators) &&
-                !(isSNO && bundle.id === 'openshift-ai-nvidia')
-              }
-            >
-              <Card
-                style={
-                  bundle.id && selectedBundles[bundle.id]
-                    ? { border: '1px solid #004080', height: '200px' }
-                    : { height: '200px' }
-                }
-                isDisabled={
-                  bundleHasOperatorsNotSupported(bundle.operators) ||
-                  (isSNO && bundle.id === 'openshift-ai-nvidia')
+        {filteredBundles.map((bundle) => {
+          const hasUnsupportedOperators = bundleHasOperatorsNotSupported(bundle.operators);
+          const hasIncompatibleOperators = bundleHasOperatorsNotCompatibles(
+            bundle.operators,
+            values,
+          );
+          const isSnoAndBlockedBundle = isSNO && bundle.id === 'openshift-ai-nvidia';
+
+          const tooltipContent = hasUnsupportedOperators
+            ? 'Some operators in this bundle are not supported with the current configuration.'
+            : hasIncompatibleOperators
+            ? 'Some operators in this bundle can not be installed with some single operators selected.'
+            : isSnoAndBlockedBundle
+            ? 'This bundle is not available when deploying a Single Node OpenShift.'
+            : '';
+
+          return (
+            <GalleryItem key={bundle.id}>
+              <Tooltip
+                content={tooltipContent}
+                hidden={
+                  !hasUnsupportedOperators && !hasIncompatibleOperators && !isSnoAndBlockedBundle
                 }
               >
-                <CardTitle
-                  style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}
+                <Card
+                  style={
+                    bundle.id && selectedBundles[bundle.id]
+                      ? { border: '1px solid #004080', height: '200px' }
+                      : { height: '200px' }
+                  }
+                  isDisabled={
+                    hasUnsupportedOperators || hasIncompatibleOperators || isSnoAndBlockedBundle
+                  }
                 >
-                  <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
-                    {getBundleLabel(bundle.title, bundle.operators)}
-                  </div>
-                  <Checkbox
-                    id={`bundle-${bundle.id || ''}`}
-                    isChecked={bundle.id ? selectedBundles[bundle.id] : false}
-                    onChange={(_event, checked) =>
-                      void handleBundleSelection(bundle.id || '', bundle.operators || [], checked)
-                    }
-                    isDisabled={
-                      bundleHasOperatorsNotSupported(bundle.operators) ||
-                      (isSNO && bundle.id === 'openshift-ai-nvidia')
-                    }
-                  />
-                </CardTitle>
-                <CardBody
-                  style={{
-                    display: 'flex',
-                    flexDirection: 'column',
-                    justifyContent: 'space-between',
-                    height: '100%',
-                  }}
-                >
-                  <div>{bundle.description}</div>
+                  <CardTitle
+                    style={{
+                      display: 'flex',
+                      justifyContent: 'space-between',
+                      alignItems: 'center',
+                    }}
+                  >
+                    <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                      {getBundleLabel(bundle.title, bundle.operators)}
+                    </div>
+                    <Checkbox
+                      id={`bundle-${bundle.id || ''}`}
+                      isChecked={bundle.id ? selectedBundles[bundle.id] : false}
+                      onChange={(_event, checked) =>
+                        void handleBundleSelection(bundle.id || '', bundle.operators || [], checked)
+                      }
+                      isDisabled={
+                        hasUnsupportedOperators || hasIncompatibleOperators || isSnoAndBlockedBundle
+                      }
+                    />
+                  </CardTitle>
+                  <CardBody
+                    style={{
+                      display: 'flex',
+                      flexDirection: 'column',
+                      justifyContent: 'space-between',
+                      height: '100%',
+                    }}
+                  >
+                    <div>{bundle.description}</div>
 
-                  {/* Badge aligned to the bottom-left */}
-
-                  <div style={{ marginTop: '10px', alignSelf: 'flex-end', height: '25px' }}>
-                    {bundle.id === 'openshift-ai-nvidia' && (
-                      <NewFeatureSupportLevelBadge
-                        featureId="OPENSHIFT_AI"
-                        supportLevel="dev-preview"
-                      />
-                    )}
-                  </div>
-                </CardBody>
-              </Card>
-            </Tooltip>
-          </GalleryItem>
-        ))}
+                    {/* Badge aligned to the bottom-left */}
+                    <div style={{ marginTop: '10px', alignSelf: 'flex-end', height: '25px' }}>
+                      {bundle.id === 'openshift-ai-nvidia' && (
+                        <NewFeatureSupportLevelBadge
+                          featureId="OPENSHIFT_AI"
+                          supportLevel="dev-preview"
+                        />
+                      )}
+                    </div>
+                  </CardBody>
+                </Card>
+              </Tooltip>
+            </GalleryItem>
+          );
+        })}
       </Gallery>
       <ExpandableSection
         toggleText={`Single Operators (${supportedOperators.length} | ${


### PR DESCRIPTION
With this PR we solved a list of bugs.

- https://issues.redhat.com/browse/MGMT-19914
- https://issues.redhat.com/browse/MGMT-20033
Selecting single operator that collides with bundle - one of them should be deselected/blocked
With this we avoid the problem to save in ui-settings endpoint the bundles if they are "illegal"
![image](https://github.com/user-attachments/assets/dffd574b-6f7f-42cd-992a-c24e512eb7d7)


- https://issues.redhat.com/browse/MGMT-19942
LSO is disabled and selected after select and deslect a bundle
![image](https://github.com/user-attachments/assets/f3a9d1ff-251d-4b28-ba9c-6354614c7a04)

![image](https://github.com/user-attachments/assets/f21bf4bc-a2cf-48b3-be1d-b21be801528e)


- https://issues.redhat.com/browse/MGMT-20035
Openshift AI bundle helper indicates that servicemesh is going to be installed, but it is not auto-selected
![Captura desde 2025-02-26 07-47-51](https://github.com/user-attachments/assets/0f4b2be6-7314-4d23-96f2-c1103103f88f)

-https://issues.redhat.com/browse/MGMT-20040
Add "Learn more" links to the new operators
![image](https://github.com/user-attachments/assets/a1ac211f-38af-4284-afbd-078ebb3739e2)

