### PR TITLE
MGMT-20056: When user selects CNV operator the MTV operator is also selected

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/CnvCheckbox.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/CnvCheckbox.tsx
@@ -75,8 +75,9 @@ const CnvCheckbox = ({
 }) => {
   const { setFieldValue } = useFormikContext<OperatorsValues>();
   const fieldId = getFieldId(CNV_FIELD_NAME, 'input');
-  const selectLsoOperator = (checked: boolean) => {
+  const selectOperatorsNeeded = (checked: boolean) => {
     setFieldValue('useLso', checked);
+    setFieldValue('useMigrationToolkitforVirtualization', checked);
   };
   return (
     <FormGroup isInline fieldId={fieldId}>
@@ -92,7 +93,7 @@ const CnvCheckbox = ({
         }
         helperText={<CnvHelperText />}
         isDisabled={!!disabledReason}
-        onChange={selectLsoOperator}
+        onChange={selectOperatorsNeeded}
       />
     </FormGroup>
   );


### PR DESCRIPTION
Related with https://issues.redhat.com/browse/MGMT-20056

When user selects CNV operator, the MTV operator is also selected because is needed.

![image](https://github.com/user-attachments/assets/220bbd9e-e80f-4ed4-bb9e-dc0db4b86516)
