### PR TITLE
MGMT-20053: If some operators are not supported, we don't select automatically

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/CnvCheckbox.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/CnvCheckbox.tsx
@@ -13,6 +13,7 @@ import { OcmCheckboxField } from '../../ui/OcmFormFields';
 import NewFeatureSupportLevelBadge from '../../../../common/components/newFeatureSupportLevels/NewFeatureSupportLevelBadge';
 import { SupportLevel } from '@openshift-assisted/types/assisted-installer-service';
 import { useFormikContext } from 'formik';
+import { useNewFeatureSupportLevel } from '../../../../common/components/newFeatureSupportLevels';
 
 const CNV_FIELD_NAME = 'useContainerNativeVirtualization';
 
@@ -73,10 +74,13 @@ const CnvCheckbox = ({
   disabledReason?: string;
   supportLevel?: SupportLevel | undefined;
 }) => {
+  const featureSupportLevelData = useNewFeatureSupportLevel();
   const { setFieldValue } = useFormikContext<OperatorsValues>();
   const fieldId = getFieldId(CNV_FIELD_NAME, 'input');
-  const selectLsoOperator = (checked: boolean) => {
-    setFieldValue('useLso', checked);
+  const selectOperatorsNeeded = (checked: boolean) => {
+    if (featureSupportLevelData.isFeatureSupported('LSO')) setFieldValue('useLso', checked);
+    if (featureSupportLevelData.isFeatureSupported('MTV'))
+      setFieldValue('useMigrationToolkitforVirtualization', checked);
   };
   return (
     <FormGroup isInline fieldId={fieldId}>
@@ -92,7 +96,7 @@ const CnvCheckbox = ({
         }
         helperText={<CnvHelperText />}
         isDisabled={!!disabledReason}
-        onChange={selectLsoOperator}
+        onChange={selectOperatorsNeeded}
       />
     </FormGroup>
   );

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/MtvOperatorCheckbox.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/MtvOperatorCheckbox.tsx
@@ -13,6 +13,7 @@ import { useFormikContext } from 'formik';
 import MtvRequirements from './MtvRequirements';
 import { SupportLevel } from '@openshift-assisted/types/./assisted-installer-service';
 import NewFeatureSupportLevelBadge from '../../../../common/components/newFeatureSupportLevels/NewFeatureSupportLevelBadge';
+import { useNewFeatureSupportLevel } from '../../../../common/components/newFeatureSupportLevels';
 
 const Mtv_FIELD_NAME = 'useMigrationToolkitforVirtualization';
 
@@ -64,9 +65,11 @@ const MtvCheckbox = ({
 }) => {
   const { setFieldValue } = useFormikContext<OperatorsValues>();
   const fieldId = getFieldId(Mtv_FIELD_NAME, 'input');
+  const featureSupportLevelData = useNewFeatureSupportLevel();
 
   const selectCNVOperator = (checked: boolean) => {
-    setFieldValue('useContainerNativeVirtualization', checked);
+    if (featureSupportLevelData.isFeatureSupported('CNV'))
+      setFieldValue('useContainerNativeVirtualization', checked);
   };
 
   return (

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/OdfCheckbox.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/OdfCheckbox.tsx
@@ -12,6 +12,7 @@ import { OcmCheckboxField } from '../../ui/OcmFormFields';
 import NewFeatureSupportLevelBadge from '../../../../common/components/newFeatureSupportLevels/NewFeatureSupportLevelBadge';
 import { SupportLevel } from '@openshift-assisted/types/./assisted-installer-service';
 import { useFormikContext } from 'formik';
+import { useNewFeatureSupportLevel } from '../../../../common/components/newFeatureSupportLevels';
 
 const ODF_FIELD_NAME = 'useOpenShiftDataFoundation';
 
@@ -60,9 +61,10 @@ const OdfCheckbox = ({
   supportLevel?: SupportLevel | undefined;
 }) => {
   const { setFieldValue } = useFormikContext<OperatorsValues>();
+  const featureSupportLevelData = useNewFeatureSupportLevel();
   const fieldId = getFieldId(ODF_FIELD_NAME, 'input');
   const selectLsoOperator = (checked: boolean) => {
-    setFieldValue('useLso', checked);
+    if (featureSupportLevelData.isFeatureSupported('LSO')) setFieldValue('useLso', checked);
   };
   return (
     <FormGroup isInline fieldId={fieldId}>

--- a/libs/ui-lib/lib/ocm/components/clusterWizard/OperatorsStep.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/OperatorsStep.tsx
@@ -164,7 +164,7 @@ export const OperatorsStep = (props: ClusterOperatorProps) => {
           const fieldId = mapOperatorsToFieldIds[op]; // Obtener el ID del campo correspondiente
           setFieldValue(fieldId, checked);
           if (op === OPERATOR_NAME_CNV || op === OPERATOR_NAME_ODF) {
-            setFieldValue('useLso', checked);
+            if (featureSupportLevelData.isFeatureSupported('LSO')) setFieldValue('useLso', checked);
           }
         }
       });
@@ -176,7 +176,7 @@ export const OperatorsStep = (props: ClusterOperatorProps) => {
         const fieldId = mapOperatorsToFieldIds[op]; // Obtener el ID del campo correspondiente
         setFieldValue(fieldId, checked);
         if (op === OPERATOR_NAME_CNV || op === OPERATOR_NAME_ODF) {
-          setFieldValue('useLso', checked);
+          if (featureSupportLevelData.isFeatureSupported('LSO')) setFieldValue('useLso', checked);
         }
       });
     }
@@ -235,7 +235,9 @@ export const OperatorsStep = (props: ClusterOperatorProps) => {
           disabledReason = getCnvIncompatibleWithLvmReason(values, lvmSupport);
         }
         if (!disabledReason) {
-          disabledReason = getCnvDisabledWithMtvReason(values);
+          if (featureSupportLevelData.isFeatureSupported('MTV')) {
+            disabledReason = getCnvDisabledWithMtvReason(values);
+          }
         }
       }
       if (operatorKey === 'lvm') {


### PR DESCRIPTION
Related with https://issues.redhat.com/browse/MGMT-20053
In new operators page, trying to select and enable cnv, but getting an error about LSO - "
cannot use Local Storage Operator because it's not compatible with the arm64 architecture on version 4.18.1 of OpenShift"

![Captura desde 2025-02-27 12-45-01](https://github.com/user-attachments/assets/04cab448-e7af-42a6-a230-8ff068cfdfe9)
