### PR TITLE
MGMT-20093: Solving problems with docs links

### DIFF
--- a/libs/ui-lib/lib/common/config/docs_links.ts
+++ b/libs/ui-lib/lib/common/config/docs_links.ts
@@ -1,7 +1,12 @@
 const DEFAULT_OPENSHIFT_DOCS_VERSION = '4.15';
 
-export const getShortOpenshiftVersion = (ocpVersion?: string) =>
-  ocpVersion ? ocpVersion.split('.').slice(0, 2).join('.') : DEFAULT_OPENSHIFT_DOCS_VERSION;
+export const getShortOpenshiftVersion = (ocpVersion?: string) => {
+  let shortOcpVersion = ocpVersion
+    ? ocpVersion.split('.').slice(0, 2).join('.')
+    : DEFAULT_OPENSHIFT_DOCS_VERSION;
+  if (shortOcpVersion < '4.14') shortOcpVersion = '4.14';
+  return shortOcpVersion;
+};
 
 export const getYearForAssistedInstallerDocumentationLink = () => {
   return new Date().getFullYear();


### PR DESCRIPTION
Related with https://issues.redhat.com/browse/MGMT-20093

Some doc links were broken in old OCP versions. We force to use 4.14 version if the cluster's version is below 4.14.

https://docs.openshift.com/container-platform/4.14/virt/virtual_machines/advanced_vm_management/virt-configuring-virtual-gpus.html