### PR TITLE
MGMT-20055: Bundle error helper text is unclear

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusterWizard/OperatorsStep.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/OperatorsStep.tsx
@@ -320,10 +320,10 @@ export const OperatorsStep = (props: ClusterOperatorProps) => {
 
           const tooltipContent = hasUnsupportedOperators
             ? 'Some operators in this bundle are not supported with the current configuration.'
-            : hasIncompatibleOperators
-            ? 'Some operators in this bundle can not be installed with some single operators selected.'
             : isSnoAndBlockedBundle
             ? 'This bundle is not available when deploying a Single Node OpenShift.'
+            : hasIncompatibleOperators
+            ? 'Some operators in this bundle can not be installed with some single operators selected.'
             : '';
 
           return (


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-20055

Selecting sno cluster and hovering over the bundle boxes needs to show the correct text:
![Captura desde 2025-03-05 12-37-41](https://github.com/user-attachments/assets/a82f9ff9-cd37-4cef-86bb-da49921db7cc)
