### PR TITLE
MGMT-20084: Same behavior on same operators in different selection - for MTV and CNV

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/MtvOperatorCheckbox.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/MtvOperatorCheckbox.tsx
@@ -70,6 +70,7 @@ const MtvCheckbox = ({
   const selectCNVOperator = (checked: boolean) => {
     if (featureSupportLevelData.isFeatureSupported('CNV'))
       setFieldValue('useContainerNativeVirtualization', checked);
+    if (featureSupportLevelData.isFeatureSupported('LSO')) setFieldValue('useLso', checked);
   };
 
   return (


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-20084

When selecting MTV operator, we need to enable Openshift Virtualization and LSO.
When selecting Openshift Virtualization operator we need to enable MTV and LSO.


https://github.com/user-attachments/assets/40cc2719-2fb9-41fc-bb5d-d5bc1e690da1

