### PR TITLE
MGMT-20084: Same behavior on same operators in different selection - for MTV and CNV - 2.38

### DIFF
--- a/libs/ui-lib-tests/cypress/integration/use-cases/create-cluster/with-mtv-operator.cy.ts
+++ b/libs/ui-lib-tests/cypress/integration/use-cases/create-cluster/with-mtv-operator.cy.ts
@@ -26,7 +26,11 @@ describe(`Create cluster with MTV operator enabled`, () => {
       commonActions.toNextStepAfter('Operators');
 
       cy.wait('@update-cluster').then(({ request }) => {
-        expect(request.body.olm_operators).to.deep.equal([{ name: 'cnv' }, { name: 'mtv' }]);
+        expect(request.body.olm_operators).to.deep.equal([
+          { name: 'cnv' },
+          { name: 'mtv' },
+          { name: 'lso' },
+        ]);
       });
     });
   });

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/MtvOperatorCheckbox.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/MtvOperatorCheckbox.tsx
@@ -70,6 +70,7 @@ const MtvCheckbox = ({
   const selectCNVOperator = (checked: boolean) => {
     if (featureSupportLevelData.isFeatureSupported('CNV'))
       setFieldValue('useContainerNativeVirtualization', checked);
+    if (featureSupportLevelData.isFeatureSupported('LSO')) setFieldValue('useLso', checked);
   };
 
   return (


### PR DESCRIPTION
backport of #2832 