### PR TITLE
MGMT-20086: Change Broadcast to Broadcase in the Bond Type field

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/staticIp/components/FormViewHosts/BondsSelect.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/staticIp/components/FormViewHosts/BondsSelect.tsx
@@ -11,7 +11,7 @@ const bondsList = [
   { value: 'balance-rr', label: 'Balance-rr (0)', default: false },
   { value: 'active-backup', label: 'Active-Backup (1)', default: true },
   { value: 'balance-xor', label: 'Balance-xor (2)', default: false },
-  { value: 'broadcast', label: 'Broadcast (3)', default: false },
+  { value: 'broadcase', label: 'Broadcase (3)', default: false },
   { value: '802.3ad', label: '802.3ad (4)', default: false },
   { value: 'balance-tlb', label: 'Balance-tlb (5)', default: false },
   { value: 'balance-alb', label: 'Balance-alb (6)', default: false },


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-20086

changed Broadcast to Broadcase:

![image](https://github.com/user-attachments/assets/7c037995-9ce5-4cbb-bae7-39b5059ab996)
