### PR TITLE
MGMT-19415: Static IP form - Error test of default GW is incorrect for the case d…

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/staticIp/commonValidationSchemas.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/staticIp/commonValidationSchemas.tsx
@@ -234,7 +234,7 @@ export const getIpIsNotNetworkOrBroadcastAddressSchema = (
     (value) => {
       const subnetAddr = getAddressObject(subnet, protocolVersion);
       if (!subnetAddr) {
-        return false;
+        return true;
       } else {
         const subnetStart = subnetAddr?.startAddress().correctForm();
         const subnetEnd = subnetAddr?.endAddress().correctForm();


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-19415

before the fix:
the wrong error was shown when adding valid default GW indicates a wrong msg for the error, when there is not error that needs to be shown.
![image](https://github.com/user-attachments/assets/05a92d17-1973-4993-9d79-4bb10bf009b1)

after the fix: 
no error.
![image](https://github.com/user-attachments/assets/3be47d08-64b1-4999-b87f-fe680eb09a5a)
