### PR TITLE
Remove CODEOWNERS, replaced by OWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,0 @@
-# These owners will be the default owners for everything in
-# the repo. Unless a later match takes precedence,
-# @global-owner1 and @global-owner2 will be requested for
-# review when someone opens a pull request.
-* @openshift-assisted/ui-dev
-/libs/ui-lib/cim/ @openshift-assisted/ui-dev-cim
-/libs/ui-lib/ocm/ @openshift-assisted/ui-dev-ocm


### PR DESCRIPTION
since we are using OpenShift bot, the people responsible for reviews are driven by OWNERS file, not CODEOWNERS