### PR TITLE
MGMT-20082: Deploying 4/5 nodes control plane is blocked

### DIFF
--- a/libs/locales/lib/en/translation.json
+++ b/libs/locales/lib/en/translation.json
@@ -840,7 +840,7 @@
   "ai:This IP is being allocated by the DHCP server": "This IP is being allocated by the DHCP server",
   "ai:This IP was allocated by the DHCP server.": "This IP was allocated by the DHCP server.",
   "ai:This name will replace the original discovered hostname.": "This name will replace the original discovered hostname.",
-  "ai:This option is not available for Nutanix platform": "This option is not available for Nutanix platform",
+  "ai:This option is not available with the selected OpenShift version": "This option is not available with the selected OpenShift version",
   "ai:This option is not editable after the draft cluster is created": "This option is not editable after the draft cluster is created",
   "ai:this script.": "this script.",
   "ai:This stage may take a while to finish. To view detailed information, click the events log link below.": "This stage might take a while to finish. To view detailed information, click the events log link.",

--- a/libs/ui-lib/lib/cim/components/ClusterDeployment/ClusterDetailsFormFields.tsx
+++ b/libs/ui-lib/lib/cim/components/ClusterDeployment/ClusterDetailsFormFields.tsx
@@ -24,6 +24,7 @@ export type ClusterDetailsFormFieldsProps = {
   allVersions: OpenshiftVersionOptionType[];
   isNutanix?: boolean;
   cpuArchitectures?: string[];
+  allowHighlyAvailable?: boolean;
 };
 
 export const BaseDnsHelperText: React.FC<{ name?: string; baseDnsDomain?: string }> = ({
@@ -52,6 +53,7 @@ export const ClusterDetailsFormFields: React.FC<ClusterDetailsFormFieldsProps> =
   extensionAfter,
   isNutanix,
   cpuArchitectures,
+  allowHighlyAvailable,
 }) => {
   const { values } = useFormikContext<ClusterDetailsValues>();
   const { name, baseDnsDomain } = values;
@@ -146,7 +148,10 @@ export const ClusterDetailsFormFields: React.FC<ClusterDetailsFormFieldsProps> =
           )}
         </>
       )}
-      <ControlPlaneNodesDropdown isNutanix={isNutanix} isDisabled={isEditFlow} />
+      <ControlPlaneNodesDropdown
+        isDisabled={isEditFlow}
+        allowHighlyAvailable={allowHighlyAvailable}
+      />
       {!isNutanix && (
         <CpuArchitectureDropdown cpuArchitectures={cpuArchitectures} isDisabled={isEditFlow} />
       )}

--- a/libs/ui-lib/lib/cim/components/helpers/versions.ts
+++ b/libs/ui-lib/lib/cim/components/helpers/versions.ts
@@ -113,7 +113,7 @@ export const getSelectedVersion = (
   );
 
   return selectedClusterImage
-    ? getOCPVersions([selectedClusterImage])?.[0]?.version
+    ? getOCPVersions([selectedClusterImage], undefined, undefined, true)?.[0]?.version
     : agentClusterInstall?.spec?.imageSetRef?.name;
 };
 


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-20082
https://issues.redhat.com/browse/MGMT-20083

4 and 5 control planes nodes should not be allowed for OpenShift versions older than `4.18` and those that are `-multi`.