### PR TITLE
ACM-17500: Fix HostedCluster status CustomKubeconfig name

### DIFF
--- a/libs/ui-lib/lib/cim/components/Hypershift/DetailsPage/HypershiftKubeconfigDownload.tsx
+++ b/libs/ui-lib/lib/cim/components/Hypershift/DetailsPage/HypershiftKubeconfigDownload.tsx
@@ -15,8 +15,8 @@ const HypershiftKubeconfigDownload = ({
   fetchSecret,
 }: HypershiftKubeconfigDownloadProps) => {
   const { t } = useTranslation();
-  const kubeconfigSecretName = hostedCluster.status?.customkubeconfig
-    ? hostedCluster.status.customkubeconfig?.name
+  const kubeconfigSecretName = hostedCluster.status?.customKubeconfig
+    ? hostedCluster.status.customKubeconfig?.name
     : hostedCluster.status?.kubeconfig?.name;
   const handleKubeconfigDownload = async () => {
     const kubeconfigSecretNamespace = hostedCluster.metadata?.namespace;

--- a/libs/ui-lib/lib/cim/components/Hypershift/types.ts
+++ b/libs/ui-lib/lib/cim/components/Hypershift/types.ts
@@ -157,7 +157,7 @@ export type HostedClusterK8sResource = K8sResourceCommon & {
     kubeconfig?: {
       name: string;
     };
-    customkubeconfig?: {
+    customKubeconfig?: {
       name: string;
     };
     kubeadminPassword?: {


### PR DESCRIPTION
Changes required in the HC API to fix the resource name for the custom kubeconfig status field

#Fixes [ACM-17500](https://issues.redhat.com/browse/ACM-17500)