### PR TITLE
AGENT-1141: Disable arch and ocp version fields

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/OcmClusterDetailsFormFields.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/OcmClusterDetailsFormFields.tsx
@@ -144,7 +144,7 @@ export const OcmClusterDetailsFormFields = ({
       ) : (
         <OcmOpenShiftVersionSelect versions={versions} />
       )}
-      {clusterExists ? (
+      {clusterExists || isSingleClusterFeatureEnabled ? (
         <StaticTextField name="cpuArchitecture" label="CPU architecture" isRequired>
           {cpuArchitecture}
         </StaticTextField>

--- a/libs/ui-lib/lib/ocm/components/clusterWizard/ClusterDetailsForm.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/ClusterDetailsForm.tsx
@@ -31,6 +31,7 @@ import {
   InfraEnv,
   ManagedDomain,
 } from '@openshift-assisted/types/assisted-installer-service';
+import { useFeature } from '../../hooks/use-feature';
 
 type ClusterDetailsFormProps = {
   cluster?: Cluster;
@@ -67,6 +68,7 @@ const ClusterDetailsForm = (props: ClusterDetailsFormProps) => {
   const { search } = useLocation();
   const { isViewerMode } = useSelector(selectCurrentClusterPermissionsState);
   const { clearAlerts } = useAlerts();
+  const isSingleClusterFeatureEnabled = useFeature('ASSISTED_INSTALLER_SINGLE_CLUSTER_FEATURE');
 
   const handleSubmit = React.useCallback(
     async (values: OcmClusterDetailsValues) => {
@@ -175,7 +177,11 @@ const ClusterDetailsForm = (props: ClusterDetailsFormProps) => {
               <GridItem span={12} lg={10} xl={9} xl2={7}>
                 <OcmClusterDetailsFormFields
                   versions={ocpVersions}
-                  forceOpenshiftVersion={cluster?.openshiftVersion}
+                  forceOpenshiftVersion={
+                    isSingleClusterFeatureEnabled
+                      ? ocpVersions[0].version
+                      : cluster?.openshiftVersion
+                  }
                   isPullSecretSet={!!cluster?.pullSecretSet}
                   defaultPullSecret={pullSecret}
                   isOcm={isInOcm}


### PR DESCRIPTION
https://issues.redhat.com/browse/AGENT-1141

when on disconnected env, the OCP version and arch are selected by default and are not changeable.

![image](https://github.com/user-attachments/assets/8108933a-b70f-458b-8a94-4bebe24e4a85)
