### PR TITLE
MGMT-20116: fix bug: UMN documentation link returns 404

### DIFF
--- a/libs/ui-lib/lib/common/config/docs_links.ts
+++ b/libs/ui-lib/lib/common/config/docs_links.ts
@@ -1,11 +1,14 @@
-const DEFAULT_OPENSHIFT_DOCS_VERSION = '4.15';
+const DEFAULT_OPENSHIFT_DOCS_VERSION = 4.15;
 
 export const getShortOpenshiftVersion = (ocpVersion?: string) => {
-  let shortOcpVersion = ocpVersion
-    ? ocpVersion.split('.').slice(0, 2).join('.')
-    : DEFAULT_OPENSHIFT_DOCS_VERSION;
-  if (shortOcpVersion < '4.14') shortOcpVersion = '4.14';
-  return shortOcpVersion;
+  if (!ocpVersion) {
+    return DEFAULT_OPENSHIFT_DOCS_VERSION;
+  }
+  const versionXY = Number(ocpVersion.split('.').slice(0, 2).join('.'));
+  if (!Number.isFinite(versionXY)) {
+    return DEFAULT_OPENSHIFT_DOCS_VERSION;
+  }
+  return versionXY < 4.14 ? 4.14 : versionXY;
 };
 
 export const getYearForAssistedInstallerDocumentationLink = () => {
@@ -36,7 +39,11 @@ export const getEncryptingDiskDuringInstallationDocsLink = (ocpVersion?: string)
 export const getOpenShiftNetworkingDocsLink = (ocpVersion?: string) =>
   `https://docs.redhat.com/en/documentation/openshift_container_platform/${getShortOpenshiftVersion(
     ocpVersion,
-  )}/html/installing_on_bare_metal/installing-bare-metal#installation-network-user-infra_installing-bare-metal`;
+  )}/html/installing_on_bare_metal/${
+    getShortOpenshiftVersion(ocpVersion) > 4.17
+      ? 'user-provisioned-infrastructure'
+      : 'installing-bare-metal'
+  }#installation-network-user-infra_installing-bare-metal`;
 
 export const SSH_GENERATION_DOC_LINK = 'https://www.redhat.com/sysadmin/configure-ssh-keygen';
 


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-20116

we still dont have this doc file for OCP version more than 4.17 in the same url.
so if the cluster uses version 4.17 or more this link will direct to the url of the doc for > 4.18.