### PR TITLE
MGMT-20253: Virtualization operator doesn't require MTV

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/CnvCheckbox.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/CnvCheckbox.tsx
@@ -79,8 +79,6 @@ const CnvCheckbox = ({
   const fieldId = getFieldId(CNV_FIELD_NAME, 'input');
   const selectOperatorsNeeded = (checked: boolean) => {
     if (featureSupportLevelData.isFeatureSupported('LSO')) setFieldValue('useLso', checked);
-    if (featureSupportLevelData.isFeatureSupported('MTV'))
-      setFieldValue('useMigrationToolkitforVirtualization', checked);
   };
   return (
     <FormGroup isInline fieldId={fieldId}>


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-20253

While "Migration Toolkit for Virtualization" operator required virtualization operator, virtualization operator doesn't require MTV.

