### PR TITLE
MGMT-20291: Add data-testid to Single Operators section in Operators page

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusterWizard/OperatorsStep.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/OperatorsStep.tsx
@@ -427,6 +427,7 @@ export const OperatorsStep = (props: ClusterOperatorProps) => {
         } selected)`}
         onToggle={() => setIsExpanded(!isExpanded)}
         isExpanded={isExpanded}
+        data-testid="single-operators-section"
       >
         <Stack hasGutter data-testid={'operators-form'}>
           {supportedOperators.map((operatorKey) => {


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-20291

Add  id/data-testid  to the expand button in operators page:

![image](https://github.com/user-attachments/assets/e0054b23-a80a-4a1a-99b1-14f77c2ab59d)
