### PR TITLE
MGMT-20351: selecting CNV - not able to deselect it using UI

### DIFF
--- a/libs/ui-lib-tests/cypress/integration/ui-behaviour/cluster-updates.cy.ts
+++ b/libs/ui-lib-tests/cypress/integration/ui-behaviour/cluster-updates.cy.ts
@@ -37,6 +37,7 @@ describe('Assisted Installer UI behaviour - cluster updates', () => {
 
       navbar.clickOnNavItem('Operators');
       operatorsPage.singleOperatorsToggle().click();
+      operatorsPage.migrationToolkitForVirtualization().click();
       operatorsPage.openshiftVirtualization().click();
       cy.wait('@update-cluster').then(() => {
         commonActions.getDangerAlert().should('exist');

--- a/libs/ui-lib-tests/cypress/views/operatorsPage.ts
+++ b/libs/ui-lib-tests/cypress/views/operatorsPage.ts
@@ -2,6 +2,9 @@ export const operatorsPage = {
   openshiftVirtualization: () => {
     return cy.get('#form-checkbox-useContainerNativeVirtualization-field');
   },
+  migrationToolkitForVirtualization: () => {
+    return cy.get('#form-checkbox-useMigrationToolkitforVirtualization-field');
+  },
   singleOperatorsToggle: () => {
     return cy.contains('Single Operators ');
   },

--- a/libs/ui-lib/lib/ocm/components/featureSupportLevels/featureStateUtils.ts
+++ b/libs/ui-lib/lib/ocm/components/featureSupportLevels/featureStateUtils.ts
@@ -354,9 +354,7 @@ const getOpenShiftAIDisabledReason = (
 };
 
 export const getCnvDisabledWithMtvReason = (operatorValues: OperatorsValues) => {
-  const mustDisableCnv =
-    operatorValues.useContainerNativeVirtualization &&
-    !operatorValues.useMigrationToolkitforVirtualization;
+  const mustDisableCnv = !operatorValues.useMigrationToolkitforVirtualization;
   return mustDisableCnv
     ? `Currently, you need to install ${CNV_OPERATOR_LABEL} operator at the same time as ${MTV_OPERATOR_LABEL} operator.`
     : undefined;


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-20351
after the change the CNV operator is disabled by default until we select the MTV operator because right now the CNV operator can be selected only when selecting the MTV as well.
and then it will be automatically checked but if user wants it can remove the CNV operator and remain only with MTV.


https://www.loom.com/share/3f15f5622457465da194b51c56f3d3d9?sid=1fb93a91-fb97-4db8-9408-1239766b9b7e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined the logic for determining CNV availability based solely on the Migration Toolkit for Virtualization.

- **New Features**
  - Added a method to the operators page for interacting with the Migration Toolkit for Virtualization checkbox.

- **Tests**
  - Updated test sequences to include interaction with the Migration Toolkit for Virtualization during cluster update checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->