### PR TITLE
MGMT-20352: selecting Openshift AI - LVMS should be blocked

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusterWizard/OperatorsStep.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/OperatorsStep.tsx
@@ -44,6 +44,7 @@ import {
   getCnvIncompatibleWithLvmReason,
   getLvmIncompatibleWithCnvReason,
   getLvmsIncompatibleWithOdfReason,
+  getLvmsIncompatibleWithOpenShiftAIReason,
   getOdfIncompatibleWithLvmsReason,
   getOpenShiftAIIncompatibleWithLvmsReason,
 } from '../featureSupportLevels/featureStateUtils';
@@ -260,9 +261,12 @@ export const OperatorsStep = (props: ClusterOperatorProps) => {
         if (!disabledReason) {
           const lvmSupport = featureSupportLevelData.getFeatureSupportLevel('LVM');
           disabledReason = getLvmIncompatibleWithCnvReason(values, lvmSupport);
-          if (!disabledReason) {
-            disabledReason = getLvmsIncompatibleWithOdfReason(values);
-          }
+        }
+        if (!disabledReason) {
+          disabledReason = getLvmsIncompatibleWithOdfReason(values);
+        }
+        if (!disabledReason) {
+          disabledReason = getLvmsIncompatibleWithOpenShiftAIReason(values);
         }
       }
       if (operatorKey === 'odf') {

--- a/libs/ui-lib/lib/ocm/components/featureSupportLevels/featureStateUtils.ts
+++ b/libs/ui-lib/lib/ocm/components/featureSupportLevels/featureStateUtils.ts
@@ -331,6 +331,13 @@ export const getLvmsIncompatibleWithOdfReason = (operatorValues: OperatorsValues
     : undefined;
 };
 
+export const getLvmsIncompatibleWithOpenShiftAIReason = (operatorValues: OperatorsValues) => {
+  const mustDisableLvms = operatorValues.useOpenShiftAI;
+  return mustDisableLvms
+    ? `Currently, you cannot install ${LVMS_OPERATOR_LABEL} operator at the same time as ${OPENSHIFT_AI_OPERATOR_LABEL} operator.`
+    : undefined;
+};
+
 const getOpenShiftAIDisabledReason = (
   cluster: Cluster | undefined,
   activeFeatureConfiguration: ActiveFeatureConfiguration | undefined,


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-20352

https://www.loom.com/share/846dae6f91824102b6c646b9e4950ce3?sid=af58085c-e512-422f-b9da-fb8a3734cd05

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced operator compatibility checks: Users will now receive clear feedback when the Logical Volume Manager Storage operator is disabled due to the OpenShift AI operator being active. This update improves system responsiveness by providing a more detailed reason when an operator is not available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->