### PR TITLE
MGMT-20351: selecting CNV - not able to deselect it using UI  - new changes

### DIFF
--- a/libs/ui-lib-tests/cypress/integration/ui-behaviour/cluster-updates.cy.ts
+++ b/libs/ui-lib-tests/cypress/integration/ui-behaviour/cluster-updates.cy.ts
@@ -37,7 +37,6 @@ describe('Assisted Installer UI behaviour - cluster updates', () => {
 
       navbar.clickOnNavItem('Operators');
       operatorsPage.singleOperatorsToggle().click();
-      operatorsPage.migrationToolkitForVirtualization().click();
       operatorsPage.openshiftVirtualization().click();
       cy.wait('@update-cluster').then(() => {
         commonActions.getDangerAlert().should('exist');

--- a/libs/ui-lib-tests/cypress/views/operatorsPage.ts
+++ b/libs/ui-lib-tests/cypress/views/operatorsPage.ts
@@ -2,9 +2,6 @@ export const operatorsPage = {
   openshiftVirtualization: () => {
     return cy.get('#form-checkbox-useContainerNativeVirtualization-field');
   },
-  migrationToolkitForVirtualization: () => {
-    return cy.get('#form-checkbox-useMigrationToolkitforVirtualization-field');
-  },
   singleOperatorsToggle: () => {
     return cy.contains('Single Operators ');
   },

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/CnvCheckbox.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/CnvCheckbox.tsx
@@ -79,6 +79,8 @@ const CnvCheckbox = ({
   const fieldId = getFieldId(CNV_FIELD_NAME, 'input');
   const selectOperatorsNeeded = (checked: boolean) => {
     if (featureSupportLevelData.isFeatureSupported('LSO')) setFieldValue('useLso', checked);
+    if (featureSupportLevelData.isFeatureSupported('MTV'))
+      setFieldValue('useMigrationToolkitforVirtualization', checked);
   };
   return (
     <FormGroup isInline fieldId={fieldId}>

--- a/libs/ui-lib/lib/ocm/components/clusterWizard/OperatorsStep.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/OperatorsStep.tsx
@@ -40,7 +40,6 @@ import { useFormikContext } from 'formik';
 import NewFeatureSupportLevelBadge from '../../../common/components/newFeatureSupportLevels/NewFeatureSupportLevelBadge';
 import { useNewFeatureSupportLevel } from '../../../common/components/newFeatureSupportLevels';
 import {
-  getCnvDisabledWithMtvReason,
   getCnvIncompatibleWithLvmReason,
   getLvmIncompatibleWithCnvReason,
   getLvmsIncompatibleWithOdfReason,
@@ -254,11 +253,6 @@ export const OperatorsStep = (props: ClusterOperatorProps) => {
         if (!disabledReason) {
           const lvmSupport = featureSupportLevelData.getFeatureSupportLevel('LVM');
           disabledReason = getCnvIncompatibleWithLvmReason(values, lvmSupport);
-        }
-        if (!disabledReason) {
-          if (featureSupportLevelData.isFeatureSupported('MTV')) {
-            disabledReason = getCnvDisabledWithMtvReason(values);
-          }
         }
       }
       if (operatorKey === 'lvm') {

--- a/libs/ui-lib/lib/ocm/components/featureSupportLevels/featureStateUtils.ts
+++ b/libs/ui-lib/lib/ocm/components/featureSupportLevels/featureStateUtils.ts
@@ -361,7 +361,9 @@ const getOpenShiftAIDisabledReason = (
 };
 
 export const getCnvDisabledWithMtvReason = (operatorValues: OperatorsValues) => {
-  const mustDisableCnv = !operatorValues.useMigrationToolkitforVirtualization;
+  const mustDisableCnv =
+    operatorValues.useContainerNativeVirtualization &&
+    !operatorValues.useMigrationToolkitforVirtualization;
   return mustDisableCnv
     ? `Currently, you need to install ${CNV_OPERATOR_LABEL} operator at the same time as ${MTV_OPERATOR_LABEL} operator.`
     : undefined;


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-20351
After the change the CNV operator is disabled by default until we select the MTV operator because right now the CNV operator can be selected only when selecting the MTV as well.
and then it will be automatically checked but if user wants it can remove the CNV operator and remain only with MTV.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced operator setup: The configuration interface now dynamically supports virtualization migration, offering improved state management during setup.
- **Refactor**
	- Simplified operator enablement logic: The conditions for activating container-native virtualization have been refined to deliver a smoother and more responsive configuration experience.
	- Removed unnecessary checks related to the Migration Toolkit for Virtualization, streamlining the logic in the operator configuration process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->