### PR TITLE
NO-ISSUE: Export common/utils from CIM

### DIFF
--- a/libs/ui-lib/lib/cim/index.ts
+++ b/libs/ui-lib/lib/cim/index.ts
@@ -5,6 +5,7 @@ export * from './components';
 // re-export selected from common
 export * as Reducers from '../common/reducers';
 export * from '../common/api';
+export * from '../common/utils';
 export * from '../common/types';
 export * from '../common/features';
 


### PR DESCRIPTION
The `getMajorMinorVersion` function was moved from `/cim` to `/common` is used in Console. Re-exporting from `/cim`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added new utilities to the UI library, making additional functions available for use in your projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->