### PR TITLE
MGMT-20402: Control bundle selection to avoid problems

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusterWizard/OperatorsBundle.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/OperatorsBundle.tsx
@@ -86,6 +86,7 @@ const BundleCard = ({
   const isSNO = useSelector(selectIsCurrentClusterSNO);
   const { isFeatureSupported } = useNewFeatureSupportLevel();
   const opSpecs = useOperatorSpecs();
+  const [isProcessing, setIsProcessing] = React.useState(false);
 
   const hasUnsupportedOperators = !!bundle.operators?.some((op) => {
     const operatorSpec = opSpecs[op];
@@ -112,19 +113,27 @@ const BundleCard = ({
     : undefined;
 
   const onSelect = (checked: boolean) => {
-    const newBundles = checked
-      ? [...values.selectedBundles, bundle.id || '']
-      : values.selectedBundles.filter((sb) => sb !== bundle.id);
-    setFieldValue('selectedBundles', newBundles);
-    const newOperators = getNewBundleOperators(
-      values.selectedOperators,
-      newBundles,
-      bundles,
-      bundle,
-      preflightRequirements,
-      checked,
-    );
-    setFieldValue('selectedOperators', newOperators);
+    setIsProcessing(true);
+    try {
+      const newBundles = checked
+        ? [...values.selectedBundles, bundle.id || '']
+        : values.selectedBundles.filter((sb) => sb !== bundle.id);
+
+      setFieldValue('selectedBundles', newBundles);
+
+      const newOperators = getNewBundleOperators(
+        values.selectedOperators,
+        newBundles,
+        bundles,
+        bundle,
+        preflightRequirements,
+        checked,
+      );
+
+      setFieldValue('selectedOperators', newOperators);
+    } finally {
+      setIsProcessing(false);
+    }
   };
 
   const isSelected = values.selectedBundles.includes(bundle.id || '');
@@ -132,7 +141,7 @@ const BundleCard = ({
   return (
     <Tooltip content={disabledReason} hidden={!disabledReason}>
       <Card
-        isDisabled={!!disabledReason}
+        isDisabled={!!disabledReason || isProcessing}
         isFullHeight
         isSelectable
         isSelected={isSelected}


### PR DESCRIPTION
Related with https://issues.redhat.com/browse/MGMT-20402

 We lock the UI when a bundle is selected or deselected—just until the correct status is reflected—so users don't trigger conflicting actions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved user experience by disabling the card during processing, preventing further interaction while updates are in progress.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->