### PR TITLE
Fix badge for bundles with no feature ID

### DIFF
--- a/libs/ui-lib/lib/common/components/newFeatureSupportLevels/NewFeatureSupportLevelBadge.tsx
+++ b/libs/ui-lib/lib/common/components/newFeatureSupportLevels/NewFeatureSupportLevelBadge.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { SupportLevel } from '@openshift-assisted/types/assisted-installer-service';
-import { FeatureId, isPreviewSupportLevel } from '../../types';
+import { isPreviewSupportLevel } from '../../types';
 import { TechnologyPreview } from '../ui/TechnologyPreview';
 import { DeveloperPreview } from '../ui/DeveloperPreview';
 
 export type NewSupportLevelBadgeProps = {
-  featureId: FeatureId;
+  featureId: string;
   supportLevel: SupportLevel | undefined;
 };
 

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/bundleSpecs.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/bundleSpecs.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react';
 import { List, ListItem } from '@patternfly/react-core';
-import { FeatureId, OPENSHIFT_AI_REQUIREMENTS_LINK } from '../../../../common';
+import { OPENSHIFT_AI_REQUIREMENTS_LINK } from '../../../../common';
 
 export type BundleSpec = {
-  featureId?: FeatureId;
   noSNO?: boolean;
   incompatibleBundles?: string[];
   Description: React.ComponentType;
@@ -28,7 +27,6 @@ export const bundleSpecs: { [key: string]: BundleSpec } = {
     ),
   },
   'openshift-ai-nvidia': {
-    featureId: 'OPENSHIFT_AI',
     noSNO: true,
     incompatibleBundles: ['openshift-ai-amd'],
     Description: () => (
@@ -46,7 +44,6 @@ export const bundleSpecs: { [key: string]: BundleSpec } = {
     docsLink: OPENSHIFT_AI_REQUIREMENTS_LINK,
   },
   'openshift-ai-amd': {
-    featureId: 'OPENSHIFT_AI',
     noSNO: true,
     incompatibleBundles: ['openshift-ai-nvidia'],
     Description: () => (

--- a/libs/ui-lib/lib/ocm/components/clusterWizard/OperatorsBundle.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/OperatorsBundle.tsx
@@ -186,19 +186,17 @@ const BundleCard = ({
             <StackItem isFilled>
               <div>{bundle.description}</div>
             </StackItem>
-            {bundleSpec.featureId && (
-              <StackItem>
-                <Split>
-                  <SplitItem isFilled />
-                  <SplitItem>
-                    <NewFeatureSupportLevelBadge
-                      featureId={bundleSpec.featureId}
-                      supportLevel={supportLevel}
-                    />
-                  </SplitItem>
-                </Split>
-              </StackItem>
-            )}
+            <StackItem>
+              <Split>
+                <SplitItem isFilled />
+                <SplitItem>
+                  <NewFeatureSupportLevelBadge
+                    featureId={bundle.id || ''}
+                    supportLevel={supportLevel}
+                  />
+                </SplitItem>
+              </Split>
+            </StackItem>
           </Stack>
         </CardBody>
       </Card>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated how support level badges are displayed for operator bundles, ensuring they are always shown and now use the bundle ID.
  - Simplified internal types by removing specific feature ID properties and using more general types.

No visible changes to app behavior are expected, but the display of support level badges is now more consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->