### PR TITLE
Fix bundle cards popover in firefox

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusterWizard/OperatorsBundle.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/OperatorsBundle.tsx
@@ -164,6 +164,7 @@ const BundleCard = ({
       <Card
         isDisabled={!!disabledReason}
         isFullHeight
+        isClickable
         isSelectable
         isSelected={isSelected}
         className="ai-bundle-card"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Made cards within the bundle selection interface clickable for improved user interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->