### PR TITLE
MGMT-20404: Refactor dropdown component import package

### DIFF
--- a/libs/ui-lib-tests/cypress/fixtures/infra-envs/openshift-versions.ts
+++ b/libs/ui-lib-tests/cypress/fixtures/infra-envs/openshift-versions.ts
@@ -9,6 +9,7 @@ export const x86 = 'x86_64';
 export const arm64 = 'arm64';
 export const s390x = 's390x';
 export const ppc64le = 'ppc64le';
+export const arm64Text = 'Arm64';
 
 const versions: Record<string, Version> = {
   '4.9': {

--- a/libs/ui-lib-tests/cypress/integration/create-sno/0-create-cluster.cy.ts
+++ b/libs/ui-lib-tests/cypress/integration/create-sno/0-create-cluster.cy.ts
@@ -33,7 +33,6 @@ describe(`Assisted Installer SNO Cluster Installation`, () => {
       clusterDetailsPage.inputBaseDnsDomain();
       clusterDetailsPage.inputOpenshiftVersion('4.18');
 
-      clusterDetailsPage.openControlPlaneNodesDropdown();
       clusterDetailsPage.selectControlPlaneNodeOption('1');
       clusterDetailsPage.inputPullSecret();
 

--- a/libs/ui-lib-tests/cypress/integration/day-2/2-adding-hosts.cy.ts
+++ b/libs/ui-lib-tests/cypress/integration/day-2/2-adding-hosts.cy.ts
@@ -44,8 +44,7 @@ describe(`Assisted Installer Day2 flow`, () => {
     it('Can select a different CPU architecture and move next', () => {
       cy.findByRole('button', { name: 'Add hosts' }).click();
 
-      clusterDetailsPage.openCpuArchitectureDropdown();
-      clusterDetailsPage.selectCpuArchitecture('arm64');
+      clusterDetailsPage.selectCpuArchitecture('Arm64');
 
       commonActions.toNextDay2StepAfter('Cluster details');
 

--- a/libs/ui-lib-tests/cypress/integration/ui-behaviour/cluster-creation.cy.ts
+++ b/libs/ui-lib-tests/cypress/integration/ui-behaviour/cluster-creation.cy.ts
@@ -31,7 +31,7 @@ describe('Assisted Installer UI behaviour - cluster creation', () => {
         .each((versionItem, index) => {
           //TODO: test adaptations for new feature about custom OCP releases
           if (index < 7) {
-            expect(versionItem.parent()).to.have.id(expectedVersionIds[index]);
+            expect(versionItem).to.have.id(expectedVersionIds[index]);
           }
         });
     });
@@ -52,13 +52,15 @@ describe('Assisted Installer UI behaviour - cluster creation', () => {
       clusterDetailsPage.openCpuArchitectureDropdown();
       clusterDetailsPage.CpuArchitectureNotExists(versionsFixtures.arm64);
       clusterDetailsPage.CpuArchitectureExists(versionsFixtures.x86);
+      clusterDetailsPage.openCpuArchitectureDropdown();
       clusterDetailsPage.selectCpuArchitecture(versionsFixtures.x86);
 
       clusterDetailsPage.inputOpenshiftVersion(versionsFixtures.getVersionWithArmSupport());
       clusterDetailsPage.openCpuArchitectureDropdown();
-      clusterDetailsPage.CpuArchitectureExists(versionsFixtures.arm64);
+      clusterDetailsPage.CpuArchitectureExists(versionsFixtures.arm64Text);
       clusterDetailsPage.CpuArchitectureExists(versionsFixtures.x86);
-      clusterDetailsPage.selectCpuArchitecture(versionsFixtures.arm64);
+      clusterDetailsPage.openCpuArchitectureDropdown();
+      clusterDetailsPage.selectCpuArchitecture(versionsFixtures.arm64Text);
     });
   });
 });

--- a/libs/ui-lib-tests/cypress/integration/use-cases/create-cluster/with-external-partner-integrations.cy.ts
+++ b/libs/ui-lib-tests/cypress/integration/use-cases/create-cluster/with-external-partner-integrations.cy.ts
@@ -25,7 +25,7 @@ describe('Create a new cluster with external partner integrations', () => {
       cy.wait(1000);
       ClusterDetailsForm.externalPartnerIntegrationsField.findDropdownItems().each((item) => {
         // Get the expected values from the externalPlatformTypes object
-        const platformType = item.parent().attr('id');
+        const platformType = item.attr('id');
         const { label, href } = externalPlatformTypes[platformType];
 
         // Assert the label
@@ -88,7 +88,7 @@ describe('Create a new cluster with external partner integrations', () => {
       ClusterDetailsForm.openshiftVersionField.selectVersion('4.14');
       ClusterDetailsForm.cpuArchitectureField.selectCpuArchitecture('s390x');
       ClusterDetailsForm.externalPartnerIntegrationsField
-        .findDropdownToggle()
+        .findExternalPartnerIntegrationsField()
         .should('be.disabled');
     });
 
@@ -96,7 +96,7 @@ describe('Create a new cluster with external partner integrations', () => {
       ClusterDetailsForm.openshiftVersionField.selectVersion('4.10');
       ClusterDetailsForm.externalPartnerIntegrationsField
         .findDropdownItem('Nutanix')
-        .should('have.class', 'pf-m-aria-disabled');
+        .should('have.attr', 'aria-disabled', 'true');
     });
 
     it('Validate that Nutanix option is disabled when we choose SNO option', () => {
@@ -104,24 +104,28 @@ describe('Create a new cluster with external partner integrations', () => {
       ClusterDetailsForm.controlPlaneNodesField.selectControlPlaneNode(1);
       ClusterDetailsForm.externalPartnerIntegrationsField
         .findDropdownItem('Nutanix')
-        .should('have.class', 'pf-m-aria-disabled');
+        .should('have.attr', 'aria-disabled', 'true');
     });
     it('Validate that all dropdown is disabled in case we choose IBM/Z(s390x) architecture + SNO', () => {
       ClusterDetailsForm.openshiftVersionField.selectVersion('4.18');
       ClusterDetailsForm.controlPlaneNodesField.selectControlPlaneNode(1);
       ClusterDetailsForm.cpuArchitectureField.selectCpuArchitecture('s390x');
       ClusterDetailsForm.externalPartnerIntegrationsField
-        .findDropdownToggle()
+        .findExternalPartnerIntegrationsField()
         .should('be.disabled');
     });
     it('Validate that for OCP version 4.15 we show Technology Preview badge in OCI option', () => {
       ClusterDetailsForm.openshiftVersionField.selectVersion('4.15');
-      ClusterDetailsForm.externalPartnerIntegrationsField.findDropdown().click();
+      ClusterDetailsForm.externalPartnerIntegrationsField
+        .findExternalPartnerIntegrationsField()
+        .click();
       ClusterDetailsForm.externalPartnerIntegrationsField.checkPlatformTechSupportLevel();
     });
     it('Validate that for OCP version 4.14 we show Developer Preview badge in OCI option', () => {
       ClusterDetailsForm.openshiftVersionField.selectVersion('4.14');
-      ClusterDetailsForm.externalPartnerIntegrationsField.findDropdown().click();
+      ClusterDetailsForm.externalPartnerIntegrationsField
+        .findExternalPartnerIntegrationsField()
+        .click();
       ClusterDetailsForm.externalPartnerIntegrationsField.checkPlatformDevSupportLevel();
     });
   });

--- a/libs/ui-lib-tests/cypress/views/bareMetalDiscovery.ts
+++ b/libs/ui-lib-tests/cypress/views/bareMetalDiscovery.ts
@@ -70,10 +70,11 @@ export const bareMetalDiscoveryPage = {
     cy.get('li[role][id^=button-delete-host]').should('not.exist');
   },
   massRenameHosts: (prefix) => {
-    cy.get('.table-toolbar .pf-v5-c-toolbar__item:first').click();
-    cy.get('.table-toolbar .pf-v5-c-toolbar__item:last').click();
-    cy.get('ul[role="menu"]').within(() => {
-      cy.get('[role="menuitem"]')
+    cy.get('.table-toolbar .pf-v5-c-menu-toggle__controls:first').click();
+    cy.get('#select-all').click();
+    cy.get('.table-toolbar .pf-v5-c-menu-toggle__controls:last').click();
+    cy.get('.pf-v5-c-menu__content:last').within(() => {
+      cy.get('.pf-v5-c-menu__item-text')
         .contains(Cypress.env('hostRowKebabMenuChangeHostnameText'))
         .click();
     });

--- a/libs/ui-lib-tests/cypress/views/bareMetalDiscoveryIsoModal.ts
+++ b/libs/ui-lib-tests/cypress/views/bareMetalDiscoveryIsoModal.ts
@@ -92,13 +92,13 @@ export const bareMetalDiscoveryIsoModal = {
     return cy.get(Cypress.env('imageTypeFieldId'));
   },
   openImageTypeDropdown: () => {
-    bareMetalDiscoveryIsoModal.getImageTypeField().find('button.pf-v5-c-dropdown__toggle').click();
+    bareMetalDiscoveryIsoModal.getImageTypeField().click();
   },
   getImageTypeDropdown: () => {
-    return bareMetalDiscoveryIsoModal.getImageTypeField().find('.pf-v5-c-dropdown__menu');
+    return cy.get(`${Cypress.env('imageTypeFieldId')}-dropdown`);
   },
   getSelectedImageType: () => {
-    return bareMetalDiscoveryIsoModal.getImageTypeField().find('.pf-v5-c-dropdown__toggle-text');
+    return bareMetalDiscoveryIsoModal.getImageTypeField().find('.pf-v5-c-menu-toggle__text');
   },
   selectImageType: (typeLabel: string) => {
     bareMetalDiscoveryIsoModal.openImageTypeDropdown();

--- a/libs/ui-lib-tests/cypress/views/clusterDetails.ts
+++ b/libs/ui-lib-tests/cypress/views/clusterDetails.ts
@@ -11,13 +11,13 @@ export const clusterDetailsPage = {
     return cy.get(Cypress.env('openshiftVersionFieldId'));
   },
   openOpenshiftVersionDropdown: () => {
-    clusterDetailsPage.getOpenshiftVersionField().find('button.pf-v5-c-dropdown__toggle').click();
+    clusterDetailsPage.getOpenshiftVersionField().click();
   },
   getOpenshiftVersionDropdown: () => {
-    return clusterDetailsPage.getOpenshiftVersionField().find('.pf-v5-c-dropdown__menu');
+    return cy.get(`${Cypress.env('openshiftVersionFieldId')}-dropdown`);
   },
   getSelectedOpenShiftVersion: () => {
-    return clusterDetailsPage.getOpenshiftVersionField().find('.pf-v5-c-dropdown__toggle-text');
+    return clusterDetailsPage.getOpenshiftVersionField().find('.pf-v5-c-menu-toggle__text');
   },
   inputOpenshiftVersion: (version = Cypress.env('OPENSHIFT_VERSION')) => {
     clusterDetailsPage.openOpenshiftVersionDropdown();
@@ -61,20 +61,37 @@ export const clusterDetailsPage = {
   getStaticIpNetworkConfig: () => {
     return cy.get(Cypress.env('staticIpNetworkConfigFieldId'));
   },
+  getCpuArchitectureField: () => {
+    return cy.get(Cypress.env('cpuArchitectureFieldId'));
+  },
   openCpuArchitectureDropdown: () => {
-    cy.get(`${Cypress.env('cpuArchitectureFieldId')} > button.pf-v5-c-dropdown__toggle`).click();
+    clusterDetailsPage.getCpuArchitectureField().click();
+  },
+  getCpuArchitectureDropdown: () => {
+    return cy.get(`${Cypress.env('cpuArchitectureFieldId')}-dropdown`);
+  },
+  getSelectedCpuArchitecture: () => {
+    return clusterDetailsPage.getCpuArchitectureField().find('.pf-v5-c-menu-toggle__text');
   },
   selectCpuArchitecture: (cpuArchitecture) => {
-    cy.get(`ul.pf-v5-c-dropdown__menu li[id=${cpuArchitecture}] a`).click();
-    cy.get(`${Cypress.env('cpuArchitectureFieldId')} .pf-v5-c-dropdown__toggle-text`)
+    clusterDetailsPage.openCpuArchitectureDropdown();
+    clusterDetailsPage.getCpuArchitectureDropdown().within(() => {
+      cy.get('li').contains(cpuArchitecture).click();
+    });
+    clusterDetailsPage
+      .getSelectedCpuArchitecture()
       .invoke('text')
       .should('match', new RegExp(cpuArchitecture, 'i'));
   },
   CpuArchitectureExists: (cpuArchitecture) => {
-    cy.get(`ul.pf-v5-c-dropdown__menu li[id=${cpuArchitecture}] a`).should('exist');
+    clusterDetailsPage.getCpuArchitectureDropdown().within(() => {
+      cy.get('li').contains(cpuArchitecture).should('exist');
+    });
   },
   CpuArchitectureNotExists: (cpuArchitecture) => {
-    cy.get(`ul.pf-v5-c-dropdown__menu li[id=${cpuArchitecture}] a`).should('not.exist');
+    clusterDetailsPage.getCpuArchitectureDropdown().within(() => {
+      cy.get('li').contains(cpuArchitecture).should('not.exist');
+    });
   },
   getSnoDisclaimer: () => {
     return cy.get(Cypress.env('checkboxSNODisclaimerFieldId'));
@@ -136,12 +153,25 @@ export const clusterDetailsPage = {
   validateInputPullSecretFieldHelper: (msg) => {
     cy.get(Cypress.env('pullSecretFieldHelperErrorId')).should('contain', msg);
   },
+  getControlPlaneNodesField: () => {
+    return cy.get(Cypress.env('controlPlaneNodesFieldId'));
+  },
   openControlPlaneNodesDropdown: () => {
-    cy.get(`${Cypress.env('controlPlaneNodesFieldId')} > button.pf-v5-c-dropdown__toggle`).click();
+    clusterDetailsPage.getControlPlaneNodesField().click();
+  },
+  getControlPlaneNodeDropdown: () => {
+    return cy.get(`${Cypress.env('controlPlaneNodesFieldId')}-dropdown`);
+  },
+  getSelectedControlPlaneNode: () => {
+    return clusterDetailsPage.getControlPlaneNodesField().find('.pf-v5-c-menu-toggle__text');
   },
   selectControlPlaneNodeOption: (controlPlaneCount) => {
-    cy.get(`ul.pf-v5-c-dropdown__menu li[id=${controlPlaneCount}] a`).click();
-    cy.get(`${Cypress.env('controlPlaneNodesFieldId')} .pf-v5-c-dropdown__toggle-text`)
+    clusterDetailsPage.openControlPlaneNodesDropdown();
+    clusterDetailsPage.getControlPlaneNodeDropdown().within(() => {
+      cy.get('li').contains(controlPlaneCount).click();
+    });
+    clusterDetailsPage
+      .getSelectedControlPlaneNode()
       .invoke('text')
       .should('match', new RegExp(controlPlaneCount, 'i'));
   },

--- a/libs/ui-lib-tests/cypress/views/common.ts
+++ b/libs/ui-lib-tests/cypress/views/common.ts
@@ -75,7 +75,7 @@ export const commonActions = {
     });
   },
   verifyIsAtStep: (stepTitle: string) => {
-    cy.get('h2', { timeout: 2000 }).should('contain.text', stepTitle);
+    cy.get('h2', { timeout: 3000 }).should('contain.text', stepTitle);
   },
   verifyIsAtSubStep: (subStepTitle: string) => {
     cy.get('h3', { timeout: 2000 }).should('contain.text', subStepTitle);

--- a/libs/ui-lib-tests/cypress/views/forms/ClusterDetails/Fields/ControlPlaneNodesField.ts
+++ b/libs/ui-lib-tests/cypress/views/forms/ClusterDetails/Fields/ControlPlaneNodesField.ts
@@ -14,12 +14,16 @@ export class ControlPlaneNodesField {
     return cy.get(ControlPlaneNodesField.alias).findByText(/number of control plane nodes/i);
   }
 
+  static findControlPlaneNodeField() {
+    return cy.get('#form-input-controlPlaneCount-field');
+  }
+
   static findDropdown() {
-    return cy.get(ControlPlaneNodesField.alias).find('#form-input-controlPlaneCount-field');
+    return cy.get('#form-input-controlPlaneCount-field-dropdown');
   }
 
   static selectControlPlaneNode(controlPlaneCount: number) {
-    ControlPlaneNodesField.findDropdown().click();
+    ControlPlaneNodesField.findControlPlaneNodeField().click();
     ControlPlaneNodesField.findDropdown().within(() => {
       cy.findByRole('menuitem', { name: new RegExp(`${controlPlaneCount}`, 'i') }).click();
     });

--- a/libs/ui-lib-tests/cypress/views/forms/ClusterDetails/Fields/CpuArchitectureField.ts
+++ b/libs/ui-lib-tests/cypress/views/forms/ClusterDetails/Fields/CpuArchitectureField.ts
@@ -12,12 +12,16 @@ export class CpuArchitectureField {
     return cy.get(CpuArchitectureField.alias).findByText(/cpu architecture/i);
   }
 
-  static findDropdown() {
+  static findCpuArchitectureField() {
     return cy.get(CpuArchitectureField.alias).find('#form-input-cpuArchitecture-field');
   }
 
+  static findDropdown() {
+    return cy.get(CpuArchitectureField.alias).find('#form-input-cpuArchitecture-field-dropdown');
+  }
+
   static selectCpuArchitecture(cpuArch: string) {
-    CpuArchitectureField.findDropdown().click();
+    CpuArchitectureField.findCpuArchitectureField().click();
     CpuArchitectureField.findDropdown().within(() => {
       cy.findByRole('menuitem', { name: new RegExp(`${cpuArch}`, 'i') }).click();
     });

--- a/libs/ui-lib-tests/cypress/views/forms/ClusterDetails/Fields/ExternalPartnerIntegrationsField.ts
+++ b/libs/ui-lib-tests/cypress/views/forms/ClusterDetails/Fields/ExternalPartnerIntegrationsField.ts
@@ -15,34 +15,30 @@ export class ExternalPartnerIntegrationsField {
       .findByText(/integrate with external partner platforms/i);
   }
 
-  static findDropdown() {
-    return cy.get(ExternalPartnerIntegrationsField.alias).find('#form-input-platform-field');
+  static findExternalPartnerIntegrationsField() {
+    return cy.get('#form-input-platform-field');
   }
 
-  static findDropdownToggle() {
-    return ExternalPartnerIntegrationsField.findDropdown().find(
-      '[data-ouia-component-type="PF5/DropdownToggle"]',
-    );
+  static findDropdown() {
+    return cy.get('#form-input-platform-field-dropdown');
   }
 
   static findDropdownItemSelected(item: string) {
-    return ExternalPartnerIntegrationsField.findDropdown().findByText(item);
+    return ExternalPartnerIntegrationsField.findExternalPartnerIntegrationsField().findByText(item);
   }
 
   static findDropdownItems() {
-    ExternalPartnerIntegrationsField.findDropdown().click();
-    return ExternalPartnerIntegrationsField.findDropdown().find(
-      '.pf-v5-c-dropdown__menu [role="menuitem"]',
-    );
+    ExternalPartnerIntegrationsField.findExternalPartnerIntegrationsField().click();
+    return ExternalPartnerIntegrationsField.findDropdown().find('.pf-v5-c-menu__item');
   }
 
   static findDropdownItem(platform: string) {
-    ExternalPartnerIntegrationsField.findDropdown().click();
-    return cy.findByRole('menuitem', { name: new RegExp(`${platform}`, 'i') });
+    ExternalPartnerIntegrationsField.findExternalPartnerIntegrationsField().click();
+    return ExternalPartnerIntegrationsField.findDropdown().find(`#${platform.toLowerCase()}`);
   }
 
   static selectPlatform(platform: string) {
-    ExternalPartnerIntegrationsField.findDropdown().click();
+    ExternalPartnerIntegrationsField.findExternalPartnerIntegrationsField().click();
     ExternalPartnerIntegrationsField.findDropdown().within(() => {
       cy.findByRole('menuitem', { name: new RegExp(`${platform}`, 'i') }).click();
     });

--- a/libs/ui-lib-tests/cypress/views/forms/ClusterDetails/Fields/OpenShiftVersionField.ts
+++ b/libs/ui-lib-tests/cypress/views/forms/ClusterDetails/Fields/OpenShiftVersionField.ts
@@ -14,12 +14,16 @@ export class OpenShiftVersionField {
     return cy.get(OpenShiftVersionField.alias).findByText(/openshift version/i);
   }
 
+  static findOpenshiftVersionField() {
+    return cy.get('#form-input-openshiftVersion-field');
+  }
+
   static findDropdown() {
-    return cy.get(OpenShiftVersionField.alias).find('#form-input-openshiftVersion-field');
+    return cy.get('#form-input-openshiftVersion-field-dropdown');
   }
 
   static selectVersion(version: string) {
-    OpenShiftVersionField.findDropdown().click();
+    OpenShiftVersionField.findOpenshiftVersionField().click();
     OpenShiftVersionField.findDropdown().within(() => {
       cy.findByRole('menuitem', { name: new RegExp(`openshift ${version}`, 'i') }).click();
     });

--- a/libs/ui-lib/lib/cim/components/ClusterDeployment/ClusterDeploymentHostsDiscovery.tsx
+++ b/libs/ui-lib/lib/cim/components/ClusterDeployment/ClusterDeploymentHostsDiscovery.tsx
@@ -82,12 +82,14 @@ const ClusterDeploymentHostsDiscovery: React.FC<ClusterDeploymentHostsDiscoveryP
           <DiscoveryInstructions />
         </TextContent>
       </GridItem>
-      <AddHostDropdown
-        infraEnv={infraEnv}
-        agentClusterInstall={agentClusterInstall}
-        usedHostnames={usedHostnames}
-        {...rest}
-      />
+      <GridItem span={5}>
+        <AddHostDropdown
+          infraEnv={infraEnv}
+          agentClusterInstall={agentClusterInstall}
+          usedHostnames={usedHostnames}
+          {...rest}
+        />
+      </GridItem>
       <GridItem>
         <TextContent>
           <Text component="h3">{t('ai:Information and warnings')}</Text>

--- a/libs/ui-lib/lib/cim/components/ClusterDeployment/LabelsSelector.tsx
+++ b/libs/ui-lib/lib/cim/components/ClusterDeployment/LabelsSelector.tsx
@@ -1,7 +1,16 @@
 import React from 'react';
 import flatten from 'lodash-es/flatten.js';
-import { Label, LabelGroup, Split, SplitItem } from '@patternfly/react-core';
-import { Dropdown, DropdownItem, DropdownToggle } from '@patternfly/react-core/deprecated';
+import {
+  Label,
+  LabelGroup,
+  Split,
+  SplitItem,
+  Dropdown,
+  DropdownItem,
+  MenuToggle,
+  MenuToggleElement,
+  DropdownList,
+} from '@patternfly/react-core';
 import { useField } from 'formik';
 
 import { MultiSelectField } from '../../../common';
@@ -122,23 +131,27 @@ export const LabelSelectorGroup: React.FC<LabelsSelectorProps> = ({
       </SplitItem>
       <SplitItem>
         <Dropdown
+          isOpen={addLabelOpen}
           onSelect={() => setAddLabelOpen(false)}
-          toggle={
-            <DropdownToggle
-              toggleIndicator={null}
-              onToggle={(_event, val) => setAddLabelOpen(val)}
-              style={{ padding: 0 }}
+          onOpenChange={() => setAddLabelOpen(!addLabelOpen)}
+          toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+            <MenuToggle
+              variant="plain"
+              className="pf-v5-u-w-100"
+              ref={toggleRef}
+              isFullWidth
+              onClick={() => setAddLabelOpen(!addLabelOpen)}
+              isExpanded={addLabelOpen}
             >
               <Label color="blue" variant="outline" className="pf-m-overflow">
                 {t('ai:Add label')}
               </Label>
-            </DropdownToggle>
-          }
-          isOpen={addLabelOpen}
-          isPlain
-          dropdownItems={children}
-          menuAppendTo={() => document.body}
-        />
+            </MenuToggle>
+          )}
+          shouldFocusToggleOnSelect
+        >
+          <DropdownList>{children}</DropdownList>
+        </Dropdown>
       </SplitItem>
     </Split>
   );

--- a/libs/ui-lib/lib/cim/components/InfraEnv/AddHostDropdown.tsx
+++ b/libs/ui-lib/lib/cim/components/InfraEnv/AddHostDropdown.tsx
@@ -1,20 +1,25 @@
-import { Split, SplitItem, Spinner } from '@patternfly/react-core';
 import {
+  Split,
+  SplitItem,
+  Spinner,
   Dropdown,
-  DropdownGroup,
   DropdownItem,
   DropdownItemProps,
-  DropdownSeparator,
-  DropdownToggle,
-} from '@patternfly/react-core/deprecated';
+  MenuToggle,
+  MenuToggleElement,
+  Divider,
+  DropdownList,
+  Popover,
+  Flex,
+} from '@patternfly/react-core';
 import * as React from 'react';
 import { useTranslation } from '../../../common/hooks/use-translation-wrapper';
 import { AddBmcHostModal, AddBmcHostYamlModal, AddHostModal } from '../modals';
 import { AddHostDropdownProps } from './types';
 import './AddHostDropdown.css';
-import { PopoverIcon } from '../../../common';
 import { Trans } from 'react-i18next';
 import { Link } from 'react-router-dom-v5-compat';
+import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons/dist/js/icons/outlined-question-circle-icon';
 
 type ModalType = 'iso' | 'bmc' | 'yaml' | 'ipxe' | undefined;
 
@@ -50,21 +55,28 @@ const AddHostDropdown = ({
   const [provisioningConfig, provisioningConfigLoaded, provisioningConfigError] =
     provisioningConfigResult;
   const { t } = useTranslation();
+
   return (
     <>
       <Dropdown
         id="infraenv-actions"
-        toggle={
-          <DropdownToggle
+        isOpen={isKebabOpen}
+        onSelect={() => setIsKebabOpen(false)}
+        onOpenChange={() => setIsKebabOpen(!isKebabOpen)}
+        toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+          <MenuToggle
             id="dropdown-basic"
-            onToggle={(_event, value) => setIsKebabOpen(value)}
-            toggleVariant="primary"
+            variant="primary"
+            ref={toggleRef}
+            onClick={() => setIsKebabOpen(!isKebabOpen)}
+            isExpanded={isKebabOpen}
           >
             {t('ai:Add hosts')}
-          </DropdownToggle>
-        }
-        isOpen={isKebabOpen}
-        dropdownItems={[
+          </MenuToggle>
+        )}
+        shouldFocusToggleOnSelect
+      >
+        {[
           <DropdownItem
             key="discovery-iso"
             onClick={() => {
@@ -85,36 +97,37 @@ const AddHostDropdown = ({
           >
             {t('ai:With iPXE')}
           </DropdownItem>,
-          <DropdownSeparator key="separator" />,
-          <DropdownGroup
-            id="discovery-bmc"
-            key="discovery-bmc"
-            className="ai-discovery-bmc__group"
-            label={
-              <Split hasGutter>
-                <SplitItem>{t('ai:Baseboard Management Controller (BMC)')}</SplitItem>
-                <SplitItem>
-                  {!provisioningConfig && (
-                    <>
-                      {' '}
-                      <PopoverIcon
-                        noVerticalAlign
-                        bodyContent={
-                          <Trans t={t}>
-                            ai:To enable the host's baseboard management controller (BMC) on the hub
-                            cluster, you must first{' '}
-                            <Link to="/k8s/cluster/metal3.io~v1alpha1~Provisioning/~new">
-                              create a provisioning configuration.
-                            </Link>
-                          </Trans>
-                        }
-                      />
-                    </>
-                  )}
-                </SplitItem>
-              </Split>
-            }
-          >
+          <Divider component="li" key="separator" />,
+          <DropdownList id="discovery-bmc" key="discovery-bmc" className="ai-discovery-bmc__group">
+            {!provisioningConfig && (
+              <DropdownItem
+                isAriaDisabled
+                className="pf-v5-u-color-200" // visually muted
+                component="div"
+              >
+                <Flex
+                  alignItems={{ default: 'alignItemsCenter' }}
+                  spaceItems={{ default: 'spaceItemsMd' }} // Changed to 'spaceItemsMd' for larger spacing
+                >
+                  <span>{t('ai:Baseboard Management Controller (BMC)')}</span>
+                  <Popover
+                    triggerAction="hover"
+                    position="top"
+                    bodyContent={
+                      <Trans t={t}>
+                        ai:To enable the host's baseboard management controller (BMC) on the hub
+                        cluster, you must first{' '}
+                        <Link to="/k8s/cluster/metal3.io~v1alpha1~Provisioning/~new">
+                          create a provisioning configuration.
+                        </Link>
+                      </Trans>
+                    }
+                  >
+                    <OutlinedQuestionCircleIcon />
+                  </Popover>
+                </Flex>
+              </DropdownItem>
+            )}
             <DropdownItemWithLoading
               key="with-credentials"
               onClick={() => {
@@ -139,10 +152,9 @@ const AddHostDropdown = ({
               isLoading={!provisioningConfigLoaded}
               isDisabled={!provisioningConfig && !provisioningConfigError}
             />
-          </DropdownGroup>,
+          </DropdownList>,
         ]}
-        position={'right'}
-      />
+      </Dropdown>
       {addModalType === 'iso' && (
         <AddHostModal
           infraEnv={infraEnv}

--- a/libs/ui-lib/lib/cim/components/InfraEnv/InfraEnvAgentTable.tsx
+++ b/libs/ui-lib/lib/cim/components/InfraEnv/InfraEnvAgentTable.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Button, Stack, StackItem } from '@patternfly/react-core';
-import { DropdownItem } from '@patternfly/react-core/deprecated';
+import { DropdownItem } from '@patternfly/react-core';
 
 import { Host } from '@openshift-assisted/types/assisted-installer-service';
 import {

--- a/libs/ui-lib/lib/cim/components/InfraEnv/InfraEnvOpenShiftVersionDropdown.tsx
+++ b/libs/ui-lib/lib/cim/components/InfraEnv/InfraEnvOpenShiftVersionDropdown.tsx
@@ -1,6 +1,13 @@
 import * as React from 'react';
-import { Dropdown, DropdownItem, DropdownToggle } from '@patternfly/react-core/deprecated';
-import { FormGroup, Tooltip } from '@patternfly/react-core';
+import {
+  FormGroup,
+  Tooltip,
+  Dropdown,
+  DropdownItem,
+  MenuToggle,
+  MenuToggleElement,
+  DropdownList,
+} from '@patternfly/react-core';
 import { useField } from 'formik';
 import { useTranslation } from '../../../common/hooks/use-translation-wrapper';
 import { architectureData, getFieldId, SupportedCpuArchitecture } from '../../../common';
@@ -13,9 +20,11 @@ const InfraEnvOpenShiftVersionDropdown = ({ osImages }: { osImages: OsImage[] })
   const [osImageOpen, setOsImageOpen] = React.useState(false);
   const fieldId = getFieldId(name, 'input');
 
-  const onOsImageSelect = (e?: React.SyntheticEvent<HTMLDivElement>) => {
-    const val = e?.currentTarget.id || '';
-    setValue(val);
+  const onOsImageSelect = (
+    event?: React.MouseEvent<Element, MouseEvent>,
+    val?: string | number,
+  ) => {
+    setValue(val ? String(val) : '');
     setOsImageOpen(false);
   };
 
@@ -40,30 +49,33 @@ const InfraEnvOpenShiftVersionDropdown = ({ osImages }: { osImages: OsImage[] })
         hidden={!!filteredImages.length}
       >
         <Dropdown
-          toggle={
-            <DropdownToggle
-              onToggle={() => setOsImageOpen(!osImageOpen)}
-              className="pf-u-w-100"
+          toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+            <MenuToggle
+              ref={toggleRef}
+              isFullWidth
+              onClick={() => setOsImageOpen(!osImageOpen)}
+              isExpanded={osImageOpen}
               isDisabled={!filteredImages.length}
             >
               {value ? `OpenShift ${value}` : t('ai:No version selected')}
-            </DropdownToggle>
-          }
-          name="osImageVersion"
+            </MenuToggle>
+          )}
           isOpen={osImageOpen}
           onSelect={onOsImageSelect}
-          dropdownItems={[
-            <DropdownItem key={'NO_VALUE'} value={''}>
-              {t('ai:No version selected')}
-            </DropdownItem>,
-            ...filteredImages.map((image) => (
-              <DropdownItem key={image.openshiftVersion} id={image.openshiftVersion}>
+          onOpenChange={() => setOsImageOpen(!osImageOpen)}
+        >
+          <DropdownList>
+            {filteredImages.map((image) => (
+              <DropdownItem
+                key={image.openshiftVersion}
+                id={image.openshiftVersion}
+                value={image.openshiftVersion}
+              >
                 {`OpenShift ${image.openshiftVersion}`}
               </DropdownItem>
-            )),
-          ]}
-          className="pf-u-w-100"
-        />
+            ))}
+          </DropdownList>
+        </Dropdown>
       </Tooltip>
     </FormGroup>
   );

--- a/libs/ui-lib/lib/cim/components/common/CpuArchitectureDropdown.tsx
+++ b/libs/ui-lib/lib/cim/components/common/CpuArchitectureDropdown.tsx
@@ -74,23 +74,26 @@ const CpuArchitectureDropdown = ({
   return !isDisabled ? (
     <FormGroup
       isInline
-      fieldId={fieldId}
+      id={`form-control__${fieldId}`}
       label={t('ai:CPU architecture')}
       isRequired
       name={'cpuArchiteture'}
     >
       <Dropdown
+        id={`${fieldId}-dropdown`}
         toggle={(toggleRef) => (
           <MenuToggle
+            id={fieldId}
             ref={toggleRef}
             onClick={() => setCpuArchOpen(!cpuArchOpen)}
-            className="pf-u-w-100"
+            className="pf-v5-u-w-100"
           >
             {value ? architectureData[value].label : t('ai:CPU architecture')}
           </MenuToggle>
         )}
         isOpen={cpuArchOpen}
         onSelect={onCpuArchSelect}
+        onOpenChange={() => setCpuArchOpen(!cpuArchOpen)}
       >
         {dropdownItems}
       </Dropdown>

--- a/libs/ui-lib/lib/cim/components/modals/MassApproveAction.tsx
+++ b/libs/ui-lib/lib/cim/components/modals/MassApproveAction.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { DropdownItem } from '@patternfly/react-core/deprecated';
+import { DropdownItem } from '@patternfly/react-core';
 import { AgentK8sResource } from '../../types';
 import { useTranslation } from '../../../common/hooks/use-translation-wrapper';
 

--- a/libs/ui-lib/lib/common/components/clusterConfiguration/ControlPlaneNodesDropdown.tsx
+++ b/libs/ui-lib/lib/common/components/clusterConfiguration/ControlPlaneNodesDropdown.tsx
@@ -1,6 +1,13 @@
 import * as React from 'react';
-import { Dropdown, DropdownItem, DropdownToggle } from '@patternfly/react-core/deprecated';
-import { FormGroup, Tooltip } from '@patternfly/react-core';
+import {
+  FormGroup,
+  Tooltip,
+  Dropdown,
+  DropdownItem,
+  MenuToggle,
+  MenuToggleElement,
+  DropdownList,
+} from '@patternfly/react-core';
 import { useTranslation } from '../../hooks/use-translation-wrapper';
 import { getFieldId, StaticField } from '../..';
 import { useField } from 'formik';
@@ -55,29 +62,35 @@ const ControlPlaneNodesDropdown = ({
     );
   });
 
-  const onControlPlaneSelect = (e?: React.SyntheticEvent<HTMLDivElement>) => {
-    const val = e?.currentTarget.id as string;
-    setValue(toNumber(val));
+  const onControlPlaneSelect = (
+    e?: React.MouseEvent<Element, MouseEvent>,
+    value?: string | number,
+  ) => {
+    setValue(toNumber(value));
     setControlPlanelOpen(false);
   };
 
   return !isDisabled ? (
     <FormGroup isInline fieldId={fieldId} label={t('ai:Number of control plane nodes')} isRequired>
       <Dropdown
-        toggle={
-          <DropdownToggle
-            onToggle={() => setControlPlanelOpen(!controlPlanelOpen)}
-            className="pf-u-w-100"
-          >
-            {selectedValue ? selectedValue : '3'}
-          </DropdownToggle>
-        }
-        name="controlPlaneCount"
         isOpen={controlPlanelOpen}
         onSelect={onControlPlaneSelect}
-        dropdownItems={dropdownItems}
-        className="pf-u-w-100"
-      />
+        onOpenChange={() => setControlPlanelOpen(!controlPlanelOpen)}
+        toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+          <MenuToggle
+            className="pf-v5-u-w-100"
+            ref={toggleRef}
+            isFullWidth
+            onClick={() => setControlPlanelOpen(!controlPlanelOpen)}
+            isExpanded={controlPlanelOpen}
+          >
+            {selectedValue ? selectedValue : '3'}
+          </MenuToggle>
+        )}
+        shouldFocusToggleOnSelect
+      >
+        <DropdownList>{dropdownItems}</DropdownList>
+      </Dropdown>
     </FormGroup>
   ) : (
     <StaticField

--- a/libs/ui-lib/lib/common/components/hosts/DiskRole.tsx
+++ b/libs/ui-lib/lib/common/components/hosts/DiskRole.tsx
@@ -1,6 +1,11 @@
 import React from 'react';
-import { Dropdown, DropdownItem, DropdownToggle } from '@patternfly/react-core/deprecated';
-import { CaretDownIcon } from '@patternfly/react-icons/dist/js/icons/caret-down-icon';
+import {
+  Dropdown,
+  DropdownItem,
+  DropdownList,
+  MenuToggle,
+  MenuToggleElement,
+} from '@patternfly/react-core';
 import {
   Disk,
   DiskRole as DiskRoleValue,
@@ -83,7 +88,7 @@ const DiskRoleDropdown: React.FC<DiskRoleDropdownProps> = ({
   ];
 
   const onSelect = React.useCallback(
-    (event?: React.SyntheticEvent<HTMLDivElement>) => {
+    (event?: React.MouseEvent<Element, MouseEvent>) => {
       const asyncFunc = async () => {
         if (event?.currentTarget.id) {
           setDisabled(true);
@@ -98,28 +103,29 @@ const DiskRoleDropdown: React.FC<DiskRoleDropdownProps> = ({
   );
 
   const currentRoleLabel = getCurrentDiskRoleLabel(disk, installationDiskId, t);
-  const toggle = React.useMemo(
-    () => (
-      <DropdownToggle
-        onToggle={(_event, val) => setOpen(val)}
-        toggleIndicator={CaretDownIcon}
-        isDisabled={isDisabled}
-        className="pf-v5-c-button pf-m-link pf-m-inline"
-      >
-        {currentRoleLabel}
-      </DropdownToggle>
-    ),
-    [setOpen, currentRoleLabel, isDisabled],
+  const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
+    <MenuToggle
+      variant="plainText"
+      ref={toggleRef}
+      isFullWidth
+      onClick={() => setOpen(!isOpen)}
+      isExpanded={isOpen}
+      isDisabled={isDisabled}
+    >
+      {currentRoleLabel}
+    </MenuToggle>
   );
 
   return (
     <Dropdown
+      onOpenChange={() => setOpen(!isOpen)}
       onSelect={onSelect}
-      dropdownItems={dropdownItems}
       toggle={toggle}
       isOpen={isOpen}
       isPlain
-    />
+    >
+      <DropdownList>{dropdownItems}</DropdownList>
+    </Dropdown>
   );
 };
 

--- a/libs/ui-lib/lib/common/components/hosts/HostToolbarActions.tsx
+++ b/libs/ui-lib/lib/common/components/hosts/HostToolbarActions.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { DropdownItem } from '@patternfly/react-core/deprecated';
+import { DropdownItem } from '@patternfly/react-core';
 import { useTranslation } from '../../hooks/use-translation-wrapper';
 
 type ChangeHostnameActionProps = {

--- a/libs/ui-lib/lib/common/components/ui/OpenShiftVersionDropdown.css
+++ b/libs/ui-lib/lib/common/components/ui/OpenShiftVersionDropdown.css
@@ -1,9 +1,0 @@
-#form-input-openshiftVersion-field .pf-v5-c-dropdown__menu {
-  max-height: 22vh;
-  overflow: auto;
-}
-
-#form-input-openshiftVersion-field .pf-v5-c-dropdown__menu ul {
-  list-style: none;
-  padding-left: 0;
-}

--- a/libs/ui-lib/lib/common/components/ui/SimpleDropdown.tsx
+++ b/libs/ui-lib/lib/common/components/ui/SimpleDropdown.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import {
   DropdownItem,
-  DropdownToggle,
+  MenuToggle,
+  MenuToggleElement,
   Dropdown,
-  DropdownProps,
-} from '@patternfly/react-core/deprecated';
-import { CaretDownIcon } from '@patternfly/react-icons/dist/js/icons/caret-down-icon';
+  DropdownPopperProps,
+} from '@patternfly/react-core';
 import { HostRole } from '../../../common/types/hosts';
 import './SimpleDropdown.css';
 
@@ -16,7 +16,7 @@ type SimpleDropdownProps = {
   setValue: (value?: string) => void;
   isDisabled: boolean;
   idPrefix?: string;
-  menuAppendTo?: DropdownProps['menuAppendTo'];
+  menuAppendTo?: DropdownPopperProps['appendTo'];
 };
 
 export const SimpleDropdown = ({
@@ -36,37 +36,38 @@ export const SimpleDropdown = ({
   ));
 
   const onSelect = React.useCallback(
-    (event?: React.SyntheticEvent<HTMLDivElement>) => {
+    (event?: React.MouseEvent<Element, MouseEvent>) => {
       setValue(event?.currentTarget.id);
       setOpen(false);
     },
     [setValue, setOpen],
   );
 
-  const toggle = React.useMemo(
-    () => (
-      <DropdownToggle
-        onToggle={(_event, val) => setOpen(!isDisabled && val)}
-        toggleIndicator={CaretDownIcon}
-        isDisabled={isDisabled}
-        id={idPrefix ? `${idPrefix}-dropdown-toggle-items` : undefined}
-        className="role-dropdown"
-      >
-        {current || defaultValue}
-      </DropdownToggle>
-    ),
-    [setOpen, current, isDisabled, defaultValue, idPrefix],
+  const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
+    <MenuToggle
+      id={idPrefix ? `${idPrefix}-dropdown-toggle-items` : undefined}
+      className="role-dropdown"
+      ref={toggleRef}
+      variant="plainText"
+      onClick={() => setOpen(!isOpen)}
+      isDisabled={isDisabled}
+      isExpanded={isOpen}
+    >
+      {current || defaultValue}
+    </MenuToggle>
   );
 
   return (
     <Dropdown
       onSelect={onSelect}
-      dropdownItems={dropdownItems}
+      onOpenChange={() => setOpen(!isOpen)}
       toggle={toggle}
       isOpen={isOpen}
       isPlain
       id={idPrefix ? `${idPrefix}-dropdown-toggle` : undefined}
-      menuAppendTo={menuAppendTo}
-    />
+      popperProps={{ appendTo: menuAppendTo }}
+    >
+      {dropdownItems}
+    </Dropdown>
   );
 };

--- a/libs/ui-lib/lib/common/index.ts
+++ b/libs/ui-lib/lib/common/index.ts
@@ -6,4 +6,5 @@ export * from './features';
 export * from './reducers';
 export * from './selectors';
 export * from './hooks';
+export * from './utils';
 export { ResourceUIState } from './types/resource-ui-state';

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/ControlPlaneNodesDropdown.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/ControlPlaneNodesDropdown.tsx
@@ -1,6 +1,13 @@
 import React from 'react';
-import { FormGroup, Tooltip } from '@patternfly/react-core';
-import { Dropdown, DropdownItem, DropdownToggle } from '@patternfly/react-core/deprecated';
+import {
+  FormGroup,
+  Tooltip,
+  Dropdown,
+  DropdownItem,
+  MenuToggle,
+  MenuToggleElement,
+  DropdownList,
+} from '@patternfly/react-core';
 import { useField } from 'formik';
 import { getFieldId, PopoverIcon } from '../../../common';
 import {
@@ -91,7 +98,7 @@ const ControlPlaneNodesDropdown: React.FC<ControlPlaneNodesDropdownProps> = ({
     }
   }, [field.value, setValue]);
 
-  const onSelect = (event?: React.SyntheticEvent<HTMLDivElement>): void => {
+  const onSelect = (event?: React.MouseEvent<Element, MouseEvent>): void => {
     const selectedValue = event?.currentTarget.id as string;
     setValue(toNumber(selectedValue));
     setOpen(false);
@@ -108,10 +115,16 @@ const ControlPlaneNodesDropdown: React.FC<ControlPlaneNodesDropdownProps> = ({
     );
   });
 
-  const toggle = (
-    <DropdownToggle onToggle={(_, val) => setOpen(val)}>
+  const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
+    <MenuToggle
+      id={fieldId}
+      ref={toggleRef}
+      onClick={() => setOpen(!isOpen)}
+      isExpanded={isOpen}
+      className="pf-v5-u-w-100"
+    >
       {options.find((opt) => opt.value === field.value)?.label || 'Select'}
-    </DropdownToggle>
+    </MenuToggle>
   );
 
   return (
@@ -122,12 +135,14 @@ const ControlPlaneNodesDropdown: React.FC<ControlPlaneNodesDropdownProps> = ({
         fieldId={fieldId}
       >
         <Dropdown
-          id={fieldId}
+          id={`${fieldId}-dropdown`}
           isOpen={isOpen}
           toggle={toggle}
-          dropdownItems={dropdownItems}
+          onOpenChange={() => setOpen(!isOpen)}
           onSelect={onSelect}
-        />
+        >
+          <DropdownList>{dropdownItems}</DropdownList>
+        </Dropdown>
       </FormGroup>
       {field.value === 1 && (
         <OcmSNODisclaimer

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/CpuArchitectureDropdown.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/CpuArchitectureDropdown.tsx
@@ -1,7 +1,14 @@
 import React from 'react';
-import { FormGroup, Split, SplitItem, Tooltip } from '@patternfly/react-core';
-import { Dropdown, DropdownItem, DropdownToggle } from '@patternfly/react-core/deprecated';
-import { CaretDownIcon } from '@patternfly/react-icons/dist/js/icons/caret-down-icon';
+import {
+  FormGroup,
+  Split,
+  SplitItem,
+  Tooltip,
+  Dropdown,
+  DropdownItem,
+  MenuToggle,
+  MenuToggleElement,
+} from '@patternfly/react-core';
 import { useField } from 'formik';
 import {
   architectureData,
@@ -119,7 +126,7 @@ const CpuArchitectureDropdown = ({
   ]);
 
   const onSelect = React.useCallback(
-    (event?: React.SyntheticEvent<HTMLDivElement>) => {
+    (event?: React.MouseEvent<Element, MouseEvent>): void => {
       const selectedCpuArch = event?.currentTarget.id as SupportedCpuArchitecture;
       setValue(selectedCpuArch);
       setOpen(false);
@@ -146,31 +153,30 @@ const CpuArchitectureDropdown = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [cpuArchitectures, openshiftVersion, selectedCpuArchitecture]);
 
-  const toggle = React.useMemo(
-    () => (
-      <DropdownToggle
-        onToggle={(_event, val: boolean) => setOpen(val)}
-        toggleIndicator={CaretDownIcon}
-        isText
-        className="pf-v5-u-w-100"
-      >
-        {currentCpuArch}
-      </DropdownToggle>
-    ),
-    [setOpen, currentCpuArch],
+  const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
+    <MenuToggle
+      id={fieldId}
+      ref={toggleRef}
+      onClick={() => setOpen(!isOpen)}
+      isExpanded={isOpen}
+      className="pf-v5-u-w-100"
+    >
+      {currentCpuArch}
+    </MenuToggle>
   );
 
   return (
     <FormGroup id={`form-control__${fieldId}`} fieldId={fieldId} label={'CPU architecture'}>
       <Dropdown
         {...field}
-        id={fieldId}
-        dropdownItems={enabledItems}
+        id={`${fieldId}-dropdown`}
         toggle={toggle}
         isOpen={isOpen}
-        className="pf-v5-u-w-100"
         onSelect={onSelect}
-      />
+        onOpenChange={() => setOpen(!isOpen)}
+      >
+        {enabledItems}
+      </Dropdown>
     </FormGroup>
   );
 };

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/DiscoveryImageTypeDropdown.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/DiscoveryImageTypeDropdown.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
-import { FormGroup } from '@patternfly/react-core';
+import { FormGroup, Tooltip } from '@patternfly/react-core';
 import {
   DropdownItem,
-  DropdownToggle,
+  Divider,
   Dropdown,
-  DropdownSeparator,
-} from '@patternfly/react-core/deprecated';
-import { CaretDownIcon } from '@patternfly/react-icons/dist/js/icons/caret-down-icon';
+  MenuToggle,
+  MenuToggleElement,
+  DropdownList,
+} from '@patternfly/react-core';
 import { useField } from 'formik';
 import {
   CpuArchitecture,
@@ -47,74 +48,74 @@ export const DiscoveryImageTypeDropdown = ({
       key="full-iso"
       id="full-iso"
       description={'Use when configuring custom networking for easier debugging'}
+      value={discoveryImageTypes['full-iso']}
     >
       {discoveryImageTypes['full-iso']}
     </DropdownItem>,
-    <DropdownSeparator key="separator1" />,
-    <DropdownItem
-      key="minimal-iso"
-      id="minimal-iso"
-      description={'Use when provisioning with default networking options'}
-      tooltip={
+    <Divider component="li" key="separator1" />,
+    <Tooltip
+      key="minimal-iso-tooltip"
+      content={
         isMinimalISODisabled ? (
           <p>{'This provisioning type is not supported when using s390x architecture'}</p>
         ) : undefined
       }
-      isAriaDisabled={!!isMinimalISODisabled}
     >
-      {discoveryImageTypes['minimal-iso']}
-    </DropdownItem>,
-    <DropdownSeparator key="separator2" />,
+      <DropdownItem
+        key="minimal-iso"
+        id="minimal-iso"
+        description={'Use when provisioning with default networking options'}
+        isAriaDisabled={!!isMinimalISODisabled}
+        value={discoveryImageTypes['minimal-iso']}
+      >
+        {discoveryImageTypes['minimal-iso']}
+      </DropdownItem>
+    </Tooltip>,
+    <Divider component="li" key="separator2" />,
     <DropdownItem
       key="discovery-image-ipxe"
       id="discovery-image-ipxe"
       description={'Use when your platform does not support booting from ISO'}
+      value={discoveryImageTypes['discovery-image-ipxe']}
     >
       {discoveryImageTypes['discovery-image-ipxe']}
     </DropdownItem>,
   ];
 
-  const onSelect = React.useCallback(
-    (event?: React.SyntheticEvent<HTMLDivElement>) => {
-      const imageTypeSelection = event?.currentTarget.id as DiscoveryImageType;
-      const currentValue = imageTypeSelection
-        ? discoveryImageTypes[imageTypeSelection]
-        : defaultValue;
-      setCurrent(currentValue ? currentValue : '');
-      setValue(imageTypeSelection);
-      setOpen(false);
-      onChange(imageTypeSelection === 'discovery-image-ipxe');
-    },
-    [setCurrent, setOpen, defaultValue, setValue, onChange],
-  );
+  const onSelect = (event?: React.MouseEvent<Element, MouseEvent>, value?: string | number) => {
+    const imageTypeSelection = value as string;
+    setCurrent(imageTypeSelection ? imageTypeSelection : '');
+    setValue(event?.currentTarget.id as DiscoveryImageType);
+    setOpen(false);
+    onChange(imageTypeSelection === 'discovery-image-ipxe');
+  };
 
-  const toggle = React.useMemo(
-    () => (
-      <DropdownToggle
-        onToggle={(_event, val) => setOpen(val)}
-        toggleIndicator={CaretDownIcon}
-        isText
-        className="pf-v5-u-w-100"
-        isDisabled={isDisabled}
-      >
-        {current || value}
-      </DropdownToggle>
-    ),
-    [setOpen, current, value, isDisabled],
+  const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
+    <MenuToggle
+      id={fieldId}
+      className="pf-v5-u-w-100"
+      ref={toggleRef}
+      isFullWidth
+      onClick={() => setOpen(!isOpen)}
+      isExpanded={isOpen}
+      isDisabled={isDisabled}
+    >
+      {current || value}
+    </MenuToggle>
   );
 
   return (
     <FormGroup fieldId={fieldId} label={'Provisioning type'}>
       <Dropdown
         {...field}
-        name={name}
-        id={fieldId}
-        dropdownItems={dropdownItems}
+        id={`${fieldId}-dropdown`}
         toggle={toggle}
         isOpen={isOpen}
-        className="pf-v5-u-w-100"
         onSelect={onSelect}
-      />
+        onOpenChange={() => setOpen(!isOpen)}
+      >
+        <DropdownList>{dropdownItems}</DropdownList>
+      </Dropdown>
     </FormGroup>
   );
 };

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/OcmBaseDomainField.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/OcmBaseDomainField.tsx
@@ -5,11 +5,13 @@ import {
   HelperText,
   HelperTextItem,
   Tooltip,
+  Dropdown,
+  DropdownItem,
+  MenuToggle,
+  MenuToggleElement,
 } from '@patternfly/react-core';
-import { Dropdown, DropdownItem, DropdownToggle } from '@patternfly/react-core/deprecated';
 import { useField, useFormikContext } from 'formik';
 import { ClusterDetailsValues, getFieldId } from '../../../common';
-import { CaretDownIcon } from '@patternfly/react-icons/dist/js/icons/caret-down-icon';
 import { OcmCheckboxField, OcmInputField } from '../ui/OcmFormFields';
 import { ManagedDomain } from '@openshift-assisted/types/assisted-installer-service';
 import { clusterExistsReason } from '../featureSupportLevels/featureStateUtils';
@@ -62,25 +64,25 @@ export const OcmBaseDomainField = ({
     ));
   }, [managedDomains]);
 
-  const dropdownToggle = React.useMemo(() => {
+  const dropdownToggle = (toggleRef: React.Ref<MenuToggleElement>) => {
     const selectedDomain = managedDomains.find((d) => d.domain === value);
     return (
-      <DropdownToggle
-        onToggle={(_event, val) => setOpen(val)}
-        toggleIndicator={CaretDownIcon}
-        isText
+      <MenuToggle
+        ref={toggleRef}
+        onClick={() => setOpen(!isOpen)}
+        isExpanded={isOpen}
         className="pf-v5-u-w-100"
       >
         {selectedDomain ? getManagedDomainLabel(selectedDomain) : 'Base domain'}
-      </DropdownToggle>
+      </MenuToggle>
     );
-  }, [managedDomains, value]);
+  };
 
   const toggleRedHatDnsService = (checked: boolean) =>
     setValue((checked && managedDomains.map((d) => d.domain)[0]) || '');
 
   const onSelect = React.useCallback(
-    (event?: React.SyntheticEvent<HTMLDivElement>) => {
+    (event?: React.MouseEvent<Element, MouseEvent>): void => {
       const selectedDomain = event?.currentTarget.id || '';
       setValue(selectedDomain);
       setOpen(false);
@@ -111,11 +113,12 @@ export const OcmBaseDomainField = ({
         {useRedHatDnsService ? (
           <Dropdown
             toggle={dropdownToggle}
-            dropdownItems={dropdownItems}
             isOpen={isOpen}
             onSelect={onSelect}
-            className="pf-v5-u-w-100"
-          />
+            onOpenChange={() => setOpen(!isOpen)}
+          >
+            {dropdownItems}
+          </Dropdown>
         ) : (
           <OcmInputField
             name={INPUT_NAME}

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/manifestsConfiguration/components/FolderDropdown.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/manifestsConfiguration/components/FolderDropdown.tsx
@@ -1,7 +1,12 @@
 import React from 'react';
-import { HelperText, FormGroup } from '@patternfly/react-core';
-import { DropdownItem, DropdownToggle, Dropdown } from '@patternfly/react-core/deprecated';
-import { CaretDownIcon } from '@patternfly/react-icons/dist/js/icons/caret-down-icon';
+import {
+  HelperText,
+  FormGroup,
+  Dropdown,
+  DropdownItem,
+  MenuToggle,
+  MenuToggleElement,
+} from '@patternfly/react-core';
 import { useField } from 'formik';
 import { getFieldId } from '../../../../../common/components/ui/formik';
 import { PopoverIcon } from '../../../../../common';
@@ -40,40 +45,34 @@ export const FolderDropdown = ({ name }: FolderDropdownProps) => {
   const [isOpen, setOpen] = React.useState(false);
   const fieldId = getFieldId(name, 'input');
 
-  const onSelect = React.useCallback(
-    (event?: React.SyntheticEvent<HTMLDivElement>) => {
-      setValue(event?.currentTarget.id as string);
-      setOpen(false);
-    },
-    [setOpen, setValue],
-  );
+  const onSelect = (event?: React.MouseEvent<Element, MouseEvent>): void => {
+    setValue(event?.currentTarget.id as string);
+    setOpen(false);
+  };
 
-  const toggle = React.useMemo(
-    () => (
-      <DropdownToggle
-        onToggle={(_event, val) => setOpen(val)}
-        toggleIndicator={CaretDownIcon}
-        isText
-        className="pf-v5-u-w-100"
-      >
-        {value || 'manifests'}
-      </DropdownToggle>
-    ),
-    [setOpen, value],
+  const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
+    <MenuToggle
+      ref={toggleRef}
+      onClick={() => setOpen(!isOpen)}
+      isExpanded={isOpen}
+      className="pf-v5-u-w-100"
+    >
+      {value || 'manifests'}
+    </MenuToggle>
   );
 
   return (
     <FormGroup fieldId={fieldId} label={<FolderLabel />} isRequired>
       <Dropdown
         {...field}
-        name={name}
         id={fieldId}
+        onOpenChange={() => setOpen(!isOpen)}
         onSelect={onSelect}
-        dropdownItems={dropdownItems}
         toggle={toggle}
         isOpen={isOpen}
-        className="pf-v5-u-w-100"
-      />
+      >
+        {dropdownItems}
+      </Dropdown>
       <HelperText style={{ display: 'inherit' }}>
         {'Manifests can be placed in "manifests" or "openshift" directories.'}
       </HelperText>

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/networkConfiguration/SubnetsDropdown.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/networkConfiguration/SubnetsDropdown.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { DropdownItem, DropdownToggle, Dropdown } from '@patternfly/react-core/deprecated';
-import { CaretDownIcon } from '@patternfly/react-icons/dist/js/icons/caret-down-icon';
+import { Dropdown, DropdownItem, MenuToggle, MenuToggleElement } from '@patternfly/react-core';
 import { useField } from 'formik';
 import { getFieldId, HostSubnet, NO_SUBNET_SET } from '../../../../common';
 
@@ -64,46 +63,42 @@ export const SubnetsDropdown = ({ name, machineSubnets, isDisabled }: SubnetsDro
   }, []);
 
   const dropdownItems = itemsSubnets.map(({ value, label, isDisabled }) => (
-    <DropdownItem key={value} id={value} isDisabled={isDisabled}>
+    <DropdownItem key={value} id={value} isDisabled={isDisabled} value={value}>
       {label}
     </DropdownItem>
   ));
 
-  const onSelect = React.useCallback(
-    (event?: React.SyntheticEvent<HTMLDivElement>) => {
-      const currentValue = event?.currentTarget.innerText ?? currentDisplayValue;
-      setCurrentDisplayValue(currentValue);
-      setValue(event?.currentTarget.id);
-      setOpen(false);
-    },
-    [currentDisplayValue, setValue],
-  );
+  const onSelect = (
+    event?: React.MouseEvent<Element, MouseEvent>,
+    value?: string | number,
+  ): void => {
+    setCurrentDisplayValue(value as string);
+    setValue(event?.currentTarget.id);
+    setOpen(false);
+  };
 
-  const toggle = React.useMemo(
-    () => (
-      <DropdownToggle
-        onToggle={(_event, val) => setOpen(!isDisabled && val)}
-        toggleIndicator={CaretDownIcon}
-        isDisabled={isDisabled}
-        isText
-        className="pf-v5-u-w-100"
-      >
-        {currentDisplayValue}
-      </DropdownToggle>
-    ),
-    [setOpen, currentDisplayValue, isDisabled],
+  const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
+    <MenuToggle
+      ref={toggleRef}
+      onClick={() => setOpen(!isOpen)}
+      isExpanded={isOpen}
+      isDisabled={isDisabled}
+      className="pf-v5-u-w-100"
+    >
+      {currentDisplayValue}
+    </MenuToggle>
   );
 
   return (
     <Dropdown
       {...field}
-      name={name}
       id={fieldId}
+      onOpenChange={() => setOpen(!isOpen)}
       onSelect={onSelect}
-      dropdownItems={dropdownItems}
       toggle={toggle}
       isOpen={isOpen}
-      className="pf-v5-u-w-100"
-    />
+    >
+      {dropdownItems}
+    </Dropdown>
   );
 };

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/platformIntegration/ExternalPlatformDropdown.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/platformIntegration/ExternalPlatformDropdown.tsx
@@ -6,9 +6,12 @@ import {
   Split,
   SplitItem,
   Tooltip,
+  Dropdown,
+  DropdownItem,
+  MenuToggle,
+  MenuToggleElement,
+  DropdownList,
 } from '@patternfly/react-core';
-import { Dropdown, DropdownItem, DropdownToggle } from '@patternfly/react-core/deprecated';
-import { CaretDownIcon } from '@patternfly/react-icons/dist/js/icons/caret-down-icon';
 import { useField } from 'formik';
 import {
   CpuArchitecture,
@@ -199,7 +202,12 @@ export const ExternalPlatformDropdown = ({
     ] as ExternalPlatformInfo;
 
     return (
-      <DropdownItem key={platform} id={platform} isAriaDisabled={disabledReason !== undefined}>
+      <DropdownItem
+        value={platform}
+        key={platform}
+        id={platform}
+        isAriaDisabled={disabledReason !== undefined}
+      >
         <Split>
           <SplitItem>
             <Tooltip hidden={!disabledReason} content={disabledReason} position="top">
@@ -234,29 +242,17 @@ export const ExternalPlatformDropdown = ({
     );
   });
 
-  const onSelect = React.useCallback(
-    (event?: React.SyntheticEvent<HTMLDivElement>) => {
-      const selectedPlatform = event?.currentTarget.id as PlatformType;
-      setValue(selectedPlatform);
-      setOpen(false);
-      onChange(selectedPlatform);
-    },
-    [setOpen, setValue, onChange],
-  );
-
-  const toggle = React.useMemo(
-    () => (
-      <DropdownToggle
-        onToggle={(_event, val) => setOpen(val)}
-        toggleIndicator={CaretDownIcon}
-        isText
-        className="pf-v5-u-w-100"
-        isDisabled={dropdownIsDisabled}
-      >
-        {externalPlatformTypes[field.value as PlatformType]?.label}
-      </DropdownToggle>
-    ),
-    [externalPlatformTypes, field, dropdownIsDisabled],
+  const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
+    <MenuToggle
+      id={fieldId}
+      className="pf-v5-u-w-100"
+      ref={toggleRef}
+      onClick={() => setOpen(!isOpen)}
+      isDisabled={dropdownIsDisabled}
+      isExpanded={isOpen}
+    >
+      {externalPlatformTypes[field.value as PlatformType]?.label}
+    </MenuToggle>
   );
 
   return (
@@ -272,15 +268,20 @@ export const ExternalPlatformDropdown = ({
         distance={7}
       >
         <Dropdown
-          {...field}
-          id={fieldId}
-          dropdownItems={enabledItems}
+          id={`${fieldId}-dropdown`}
           toggle={toggle}
           isOpen={isOpen}
-          className="pf-v5-u-w-100"
-          onSelect={onSelect}
-          disabled={dropdownIsDisabled}
-        />
+          onOpenChange={() => setOpen(!isOpen)}
+          onSelect={(event) => {
+            const selectedPlatform = event?.currentTarget.id as PlatformType;
+            setValue(selectedPlatform);
+            setOpen(false);
+            onChange(selectedPlatform);
+          }}
+          shouldFocusToggleOnSelect
+        >
+          <DropdownList>{enabledItems}</DropdownList>
+        </Dropdown>
       </Tooltip>
     </FormGroup>
   );


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-20404

changed all the dropdown component usages to use the patternfly v5 component and not hte deprecated one

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Utilities from the common library are now available for import, expanding the public API.
- **Refactor**
	- All dropdown components have been updated to use the latest PatternFly UI elements, providing a more consistent and modern user experience.
	- Dropdown toggles and menus now use explicit open state controls and improved event handling.
	- Informational tooltips and dropdown groupings have been enhanced for clarity and usability.
	- Dropdown interaction patterns in tests have been standardized and selectors updated to match UI changes.
	- Test selectors and interaction methods for dropdown fields have been refined for more precise and reliable UI testing.
- **Style**
	- Layout and spacing of dropdowns have been refined for better alignment and appearance.
	- Removed obsolete CSS styling for OpenShift version dropdown to streamline UI presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->