### PR TITLE
MGMT-20237: Change tooltip for Openshift AI bundle

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/bundleSpecs.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/bundleSpecs.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { List, ListItem } from '@patternfly/react-core';
-import { OPENSHIFT_AI_REQUIREMENTS_LINK } from '../../../../common';
 
 export type BundleSpec = {
   noSNO?: boolean;
@@ -27,36 +26,16 @@ export const bundleSpecs: { [key: string]: BundleSpec } = {
       </List>
     ),
   },
-  'openshift-ai-nvidia': {
+  'openshift-ai': {
     noSNO: true,
-    incompatibleBundles: ['openshift-ai-amd'],
+    incompatibleBundles: [],
     Description: () => (
       <List>
-        <ListItem>At least two worker nodes.</ListItem>
         <ListItem>
-          Each worker node requires 32 additional GiB of memory and 8 additional CPUs.
-        </ListItem>
-        <ListItem>At least one supported NVIDIA GPU.</ListItem>
-        <ListItem>
-          Nodes that have NVIDIA GPUs installed need to have secure boot disabled.
+          NVIDIA GPU, AMD GPU and Kernel Module Management may or may not be installed based on the
+          GPU discovered on your hosts.
         </ListItem>
       </List>
     ),
-    docsLink: OPENSHIFT_AI_REQUIREMENTS_LINK,
-  },
-  'openshift-ai-amd': {
-    noSNO: true,
-    incompatibleBundles: ['openshift-ai-nvidia'],
-    Description: () => (
-      <List>
-        <ListItem>At least two worker nodes.</ListItem>
-        <ListItem>
-          Each worker node requires 32 additional GiB of memory and 8 additional CPUs.
-        </ListItem>
-        <ListItem>At least one supported AMD GPU.</ListItem>
-        <ListItem>Nodes that have AMD GPUs installed need to have secure boot disabled.</ListItem>
-      </List>
-    ),
-    docsLink: OPENSHIFT_AI_REQUIREMENTS_LINK,
   },
 };


### PR DESCRIPTION
Related with https://issues.redhat.com/browse/MGMT-20237

![Captura desde 2025-04-30 11-45-53](https://github.com/user-attachments/assets/0890ce9d-c6eb-4029-b855-cf73e6db4b2d)
![Captura desde 2025-04-30 11-45-42](https://github.com/user-attachments/assets/4eafc9d6-a075-4196-9a04-8bd825a1786a)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a unified 'openshift-ai' bundle that supports both NVIDIA and AMD GPUs, with automatic component installation based on detected hardware.

- **Improvements**
  - Simplified the description for the 'openshift-ai' bundle, making requirements and compatibility clearer for users.
  - Removed separate 'openshift-ai-nvidia' and 'openshift-ai-amd' bundles for a more streamlined experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->