### PR TITLE
MGMT-20520: Change learn more link for Kube Descheduler operator

### DIFF
--- a/libs/ui-lib/lib/common/components/operators/operatorSpecs.tsx
+++ b/libs/ui-lib/lib/common/components/operators/operatorSpecs.tsx
@@ -30,6 +30,7 @@ import {
   AUTHORINO_OPERATOR_LINK,
   CNV_LINK,
   FENCE_AGENTS_REMEDIATION_LINK,
+  getKubeDeschedulerLink,
   getLsoLink,
   getLvmsDocsLink,
   getMceDocsLink,
@@ -154,10 +155,10 @@ export const getOperatorSpecs = (useLVMS?: boolean): { [key: string]: OperatorSp
     [OPERATOR_NAME_KUBE_DESCHEDULER]: {
       title: 'Kube Descheduler',
       featureId: 'KUBE_DESCHEDULER',
-      Description: () => (
+      Description: ({ openshiftVersion }) => (
         <>
           Evicts pods to reschedule them onto more suitable nodes.{' '}
-          <ExternalLink href={NODE_HEALTHCHECK_LINK}>Learn more</ExternalLink>
+          <ExternalLink href={getKubeDeschedulerLink(openshiftVersion)}>Learn more</ExternalLink>
         </>
       ),
       notStandalone: true,


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-20520

The Learn more link for the Kube Descheduler Operator is incorrect. Needs to point to `https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/nodes/controlling-pod-placement-onto-nodes-scheduling#additional-resources-3`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The Kube Descheduler operator's description now provides a version-specific documentation link based on your OpenShift version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->