### PR TITLE
NO-ISSUE: Change 'CPUs' to 'CPU cores'

### DIFF
--- a/libs/locales/lib/en/translation.json
+++ b/libs/locales/lib/en/translation.json
@@ -23,7 +23,7 @@
   "ai:{{count}} worker failed_plural": "{{count}} workers failed",
   "ai:{{count}} worker installed": "{{count}} worker installed",
   "ai:{{count}} worker installed_plural": "{{count}} workers installed",
-  "ai:{{cpus}} CPUs | {{memory}} Memory": "{{cpus}} CPUs | {{memory}} Memory",
+  "ai:{{cpus}} CPU cores | {{memory}} Memory": "{{cpus}} CPU cores | {{memory}} Memory",
   "ai:{{operatorsCountString}} installed": "{{operatorsCountString}} installed",
   "ai:{{selectedAgentsCount}} host selected out of {{matchingAgentsCount}} matching.": "{{selectedAgentsCount}} host selected out of {{matchingAgentsCount}} identified.",
   "ai:{{selectedAgentsCount}} host selected out of {{matchingAgentsCount}} matching._plural": "{{selectedAgentsCount}} hosts selected out of {{matchingAgentsCount}} identified.",

--- a/libs/ui-lib/lib/cim/components/ClusterDeployment/ShortCapacitySummary.tsx
+++ b/libs/ui-lib/lib/cim/components/ClusterDeployment/ShortCapacitySummary.tsx
@@ -17,7 +17,7 @@ export const getTotalCompute = (selectedAgents: AgentK8sResource[], t: TFunction
     },
   );
 
-  return t('ai:{{cpus}} CPUs | {{memory}} Memory', {
+  return t('ai:{{cpus}} CPU cores | {{memory}} Memory', {
     cpus: totals.cpus,
     memory: fileSize(totals.memory, 2, 'iec'),
   });

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/OperatorCheckbox.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/OperatorCheckbox.tsx
@@ -83,7 +83,7 @@ const OperatorRequirements = ({
                 <ListItem>
                   Each worker node requires an additional {workerRequirements?.ramMib || 360} MiB of
                   memory {workerRequirements?.diskSizeGb ? ',' : ' and'}{' '}
-                  {workerRequirements?.cpuCores || 2} CPUs
+                  {workerRequirements?.cpuCores || 2} CPU cores
                   {workerRequirements?.diskSizeGb
                     ? ` and ${workerRequirements?.diskSizeGb} storage space`
                     : ''}
@@ -93,7 +93,7 @@ const OperatorRequirements = ({
                 <ListItem>
                   Each control plane node requires an additional {masterRequirements?.ramMib || 150}{' '}
                   MiB of memory {masterRequirements?.diskSizeGb ? ',' : ' and'}{' '}
-                  {masterRequirements?.cpuCores || 4} CPUs
+                  {masterRequirements?.cpuCores || 4} CPU cores
                   {masterRequirements?.diskSizeGb
                     ? ` and ${masterRequirements?.diskSizeGb} storage space`
                     : ''}

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/bundleSpecs.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/bundleSpecs.tsx
@@ -17,9 +17,11 @@ export const bundleSpecs: { [key: string]: BundleSpec } = {
           Enabled CPU virtualization support in BIOS (Intel-VT / AMD-V) on all nodes.
         </ListItem>
         <ListItem>
-          Each control plane node requires an additional 1024 MiB of memory and 3 CPUs.
+          Each control plane node requires an additional 1024 MiB of memory and 3 CPU cores.
         </ListItem>
-        <ListItem>Each worker node requires an additional 1024 MiB of memory and 5 CPUs.</ListItem>
+        <ListItem>
+          Each worker node requires an additional 1024 MiB of memory and 5 CPU cores.
+        </ListItem>
         <ListItem>
           Additional resources may be required to support the selected storage operator.
         </ListItem>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
	- Updated all user-facing references from "CPUs" to "CPU cores" for improved clarity in resource descriptions and requirements.
- **Documentation**
	- Revised descriptions and labels to consistently use "CPU cores" instead of "CPUs" in cluster configuration and virtualization requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->