### PR TITLE
MGMT-20507: Static IP configure via should appear only in the first page

### DIFF
--- a/libs/ui-lib-tests/cypress/integration/static-ip/2-configure-static-ip-host-specific.cy.ts
+++ b/libs/ui-lib-tests/cypress/integration/static-ip/2-configure-static-ip-host-specific.cy.ts
@@ -20,7 +20,6 @@ describe(`Assisted Installer Static IP Host specific Configuration`, () => {
   it('Can be entered using Form View', () => {
     commonActions.toNextStaticIpStepAfter('Network-wide configurations');
 
-    staticIpPage.getFormViewSelect().should('be.checked');
     staticIpPage.getAddMoreHosts().should('be.disabled');
     staticIpPage.hostSpecificMacAddress(0).type('00:00:5e:00:53:af');
     staticIpPage.hostSpecificIpv4Address(0).type('192.168.2.38');
@@ -43,7 +42,6 @@ describe(`Assisted Installer Static IP Host specific Configuration`, () => {
 
     it('Can show the existing static IP configuration', () => {
       commonActions.getWizardStepNav('Host specific configurations').click();
-      staticIpPage.getFormViewSelect().should('be.checked');
 
       staticIpPage.hostMappingBlockToggle(0).click();
       staticIpPage.hostMappingIpv4Address(0).should('have.value', '192.168.3.28');

--- a/libs/ui-lib-tests/cypress/integration/static-ip/3-configure-static-ip-yaml.cy.ts
+++ b/libs/ui-lib-tests/cypress/integration/static-ip/3-configure-static-ip-yaml.cy.ts
@@ -70,7 +70,6 @@ describe(`Assisted Installer Static IP YAML configuration`, () => {
 
     it('Can show the correct type view', () => {
       commonActions.verifyIsAtStep('Static network configurations');
-      staticIpPage.getYamlViewSelect().should('be.enabled');
     });
 
     it('Can show the existing static IP configuration', () => {

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/staticIp/components/StaticIpPage.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/staticIp/components/StaticIpPage.tsx
@@ -62,10 +62,10 @@ export const StaticIpPage: React.FC<StaticIpPageProps> = ({
     switch (clusterWizardContext.currentStepId) {
       case 'static-ip-yaml-view':
         return <YamlView {...viewProps} />;
-      case 'static-ip-host-configurations':
-        return <FormViewHosts {...viewProps} />;
       case 'static-ip-network-wide-configurations':
         return <FormViewNetworkWide {...viewProps} />;
+      case 'static-ip-host-configurations':
+        return <FormViewHosts {...viewProps} />;
       default:
         throw `Unexpected wizard step id ${clusterWizardContext.currentStepId} when entering static ip page`;
     }
@@ -85,11 +85,13 @@ export const StaticIpPage: React.FC<StaticIpPageProps> = ({
         </Text>
       </TextContent>
 
-      <StaticIpViewRadioGroup
-        initialView={initialStaticIpInfo.view}
-        confirmOnChangeView={confirmOnChangeView}
-        onChangeView={onChangeView}
-      />
+      {clusterWizardContext.currentStepId === 'static-ip-network-wide-configurations' && (
+        <StaticIpViewRadioGroup
+          initialView={initialStaticIpInfo.view}
+          confirmOnChangeView={confirmOnChangeView}
+          onChangeView={onChangeView}
+        />
+      )}
       {initialStaticIpInfo.isDataComplete && isoRegenerationAlert}
       {content}
     </Grid>


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-20507

after fix:

![Screenshot From 2025-05-07 15-35-14](https://github.com/user-attachments/assets/e74a9e37-4077-4769-b947-bafd2a56a61b)


![image](https://github.com/user-attachments/assets/edcf5eee-d763-4ef9-be46-7e71a372d125)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Adjusted the display of the radio group UI to show only during the network-wide configurations step in the static IP setup process, improving step-specific clarity for users.  
- **Tests**
  - Updated test cases by removing assertions related to form and YAML view toggles, while preserving other validations for static IP configuration steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->