### PR TITLE
MGMT-20616: Refactor Header component to use not deprecated components of patternfly

### DIFF
--- a/apps/assisted-ui/src/components/Header.tsx
+++ b/apps/assisted-ui/src/components/Header.tsx
@@ -1,12 +1,11 @@
 import type React from 'react';
-import { Brand } from '@patternfly/react-core';
-import { PageHeader, PageHeaderTools } from '@patternfly/react-core/deprecated';
+import { Brand, Masthead, MastheadBrand, MastheadMain } from '@patternfly/react-core';
 import { AboutButton } from './AboutButton';
 import { FeedbackButton } from './FeedbackButton';
 
 export const Header: React.FC = () => (
-  <PageHeader
-    logo={
+  <Masthead style={{ display: 'flex', justifyContent: 'space-between' }}>
+    <MastheadBrand>
       <Brand
         src="/logo.svg"
         alt="OpenShift Container Platform Assisted Installer"
@@ -14,13 +13,10 @@ export const Header: React.FC = () => (
       >
         <source src="/logo.svg" />
       </Brand>
-    }
-    logoProps={{ href: '/' }}
-    headerTools={
-      <PageHeaderTools>
-        <FeedbackButton />
-        <AboutButton />
-      </PageHeaderTools>
-    }
-  />
+    </MastheadBrand>
+    <MastheadMain>
+      <FeedbackButton />
+      <AboutButton />
+    </MastheadMain>
+  </Masthead>
 );


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-20616


used Patternfly's Masthead components instead of PageHeader

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the header layout to use newer design components for improved consistency and appearance.
  - The logo is now displayed without a direct link to the homepage.
  - Feedback and about buttons remain accessible in the header with an updated layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->