### PR TITLE
MGMT-20699: Change data-testid for disk row adding row index

### DIFF
--- a/libs/ui-lib/lib/common/components/storage/DisksTable.tsx
+++ b/libs/ui-lib/lib/common/components/storage/DisksTable.tsx
@@ -217,7 +217,7 @@ const DisksTable = ({
       <Tbody>
         {rows.map((row, i) => (
           // eslint-disable-next-line no-console
-          <Tr key={`disk-row-${row.key}`} data-testid={`disk-row-${row.key}`}>
+          <Tr key={`disk-row-${row.key}`} data-testid={`disk-row-${row.key}-row${i}`}>
             {row.cells.map((cell, j) => (
               <Td key={`cell-${i}-${j}`} {...cell.props}>
                 {cell.title}


### PR DESCRIPTION
Related with https://issues.redhat.com/browse/MGMT-20699

Change data-testid="disk-row-/dev/sda" to data-testid="disk-row-/dev/sda-row{index}"  in storage table rows to find the correct disk for tests coverage.

![Captura desde 2025-05-27 07-28-09](https://github.com/user-attachments/assets/483622f5-be8b-42b8-a282-cd6b35dbf276)
