### PR TITLE
MGMT-20699: Change data-testid for disk row adding host id

### DIFF
--- a/libs/ui-lib-tests/cypress/integration/storage/storage-step.cy.ts
+++ b/libs/ui-lib-tests/cypress/integration/storage/storage-step.cy.ts
@@ -7,13 +7,13 @@ const masterDisks = [
     id: '/dev/sda-10',
     size: '17.80 GB',
     type: 'HDD',
-    row: '0',
+    hostId: 'bb566d48-9b73-4047-9d4c-ae08618a5ed1',
   },
   {
     id: '/dev/sr-11',
     size: '1.05 GB',
     type: 'ODD',
-    row: '2',
+    hostId: 'bb566d48-9b73-4047-9d4c-ae08618a5ed1',
   },
 ];
 
@@ -22,13 +22,13 @@ const workerDisks = [
     id: '/dev/sda-40',
     size: '10.48 GB',
     type: 'HDD',
-    row: '0',
+    hostId: 'cf2f3477-896f-40be-876a-b2ac3f2a838c',
   },
   {
     id: '/dev/sr-41',
     size: '1.05 GB',
     type: 'ODD',
-    row: '2',
+    hostId: 'cf2f3477-896f-40be-876a-b2ac3f2a838c',
   },
 ];
 
@@ -93,7 +93,7 @@ describe(`Assisted Installer Storage Step`, () => {
         hostsTableSection.getHostDisksExpander(host.hostId).click();
         storagePage.validateSkipFormattingDisks(host.realHostId, 3);
         storagePage.validateSkipFormattingWarning();
-        storagePage.validateSkipFormattingIcon(workerDisks[0].id, workerDisks[0].row);
+        storagePage.validateSkipFormattingIcon(workerDisks[0].id, workerDisks[0].hostId);
         hostsTableSection.getHostDisksExpander(host.hostId).click();
       });
     });

--- a/libs/ui-lib-tests/cypress/views/hostsTableSection.ts
+++ b/libs/ui-lib-tests/cypress/views/hostsTableSection.ts
@@ -78,12 +78,11 @@ export const hostsTableSection = {
   validateHostDisksDetails: (disks) => {
     disks.forEach((disk) => {
       cy.get(
-        `[data-testid="disk-row-${disk.id}-row${disk.row}"] [data-testid="drive-type"]`,
+        `[data-testid="disk-row-${disk.id}-host-${disk.hostId}"] [data-testid="drive-type"]`,
       ).should('contain', disk.type);
-      cy.get(`[data-testid="disk-row-${disk.id}-row${disk.row}"] [data-testid="disk-size"]`).should(
-        'contain',
-        disk.size,
-      );
+      cy.get(
+        `[data-testid="disk-row-${disk.id}-host-${disk.hostId}"] [data-testid="disk-size"]`,
+      ).should('contain', disk.size);
     });
   },
   validateGroupingByDiskHolders: (disks: ValidateDiskHoldersParams, message?: string) => {

--- a/libs/ui-lib-tests/cypress/views/storagePage.ts
+++ b/libs/ui-lib-tests/cypress/views/storagePage.ts
@@ -48,9 +48,9 @@ export const storagePage = {
       'You have opted out of formatting bootable disks on some hosts. To ensure the hosts reboot into the expected installation disk, manual user intervention might be required during OpenShift installation.',
     );
   },
-  validateSkipFormattingIcon: (diskId: string, diskRow: string) => {
+  validateSkipFormattingIcon: (diskId: string, diskHost: string) => {
     //If a disk is skip formatting validate that warning icon is shown
-    cy.get(`[data-testid="disk-row-${diskId}-row${diskRow}"] [data-testid="disk-name"]`).within(
+    cy.get(`[data-testid="disk-row-${diskId}-host-${diskHost}"] [data-testid="disk-name"]`).within(
       (/* $diskRow */) => {
         cy.get('[role="img"]')
           .parent()

--- a/libs/ui-lib/lib/common/components/storage/DisksTable.tsx
+++ b/libs/ui-lib/lib/common/components/storage/DisksTable.tsx
@@ -217,7 +217,7 @@ const DisksTable = ({
       <Tbody>
         {rows.map((row, i) => (
           // eslint-disable-next-line no-console
-          <Tr key={`disk-row-${row.key}`} data-testid={`disk-row-${row.key}-row${i}`}>
+          <Tr key={`disk-row-${row.key}`} data-testid={`disk-row-${row.key}-host-${host.id}`}>
             {row.cells.map((cell, j) => (
               <Td key={`cell-${i}-${j}`} {...cell.props}>
                 {cell.title}


### PR DESCRIPTION
Related with https://issues.redhat.com/browse/MGMT-20699

![Captura desde 2025-05-27 15-48-34](https://github.com/user-attachments/assets/b26b3455-31af-41f6-8f0d-590b0d374afb)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated disk-related identifiers and selectors to use host ID instead of row number.
  - Adjusted parameter names in test utilities to align with the new identifier scheme.
  - No changes to user-facing functionality or workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->