### PR TITLE
MGMT-20508: Not correct number of CPs on cluster details page when trying to cont…

### DIFF
--- a/libs/ui-lib/lib/cim/components/ClusterDeployment/ClusterDeploymentDetailsForm.tsx
+++ b/libs/ui-lib/lib/cim/components/ClusterDeployment/ClusterDeploymentDetailsForm.tsx
@@ -112,7 +112,9 @@ const ClusterDeploymentDetailsForm: React.FC<ClusterDeploymentDetailsFormProps> 
 
   const [cpuArchitectures, allowHighlyAvailable] = React.useMemo(() => {
     const cpuArchitectures = [CpuArchitecture.x86, CpuArchitecture.ARM, CpuArchitecture.s390x];
-    const version = allVersions.find((ver) => ver.value === values.openshiftVersion);
+    const version = allVersions.find(
+      (ver) => ver.value === values.openshiftVersion || ver.version === forceOpenshiftVersion,
+    );
     const isMulti = version?.cpuArchitectures?.[0] === CpuArchitecture.MULTI;
 
     const highlyAvailableSupported = toNumber(version?.version?.split('.')?.[1]) >= 18;
@@ -120,7 +122,7 @@ const ClusterDeploymentDetailsForm: React.FC<ClusterDeploymentDetailsFormProps> 
       (isMulti ? cpuArchitectures : version?.cpuArchitectures) as SupportedCpuArchitecture[],
       highlyAvailableSupported && !isMulti,
     ];
-  }, [allVersions, values.openshiftVersion]);
+  }, [allVersions, forceOpenshiftVersion, values.openshiftVersion]);
 
   return (
     <>


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-20508

fixed the issue, now shows the correct number of control planes in the UI and in the yaml and able to click the next button and proceed.
![image](https://github.com/user-attachments/assets/8ccb58e6-edc5-4427-9029-0768b0e6a516)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved selection of the OpenShift version to better handle scenarios where a forced version is specified, ensuring accurate display of supported CPU architectures and high availability options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->