### PR TITLE
MGMT-20809: Add hosts menu is not fully seen on infraenv page

### DIFF
--- a/libs/ui-lib/lib/cim/components/InfraEnv/AddHostDropdown.tsx
+++ b/libs/ui-lib/lib/cim/components/InfraEnv/AddHostDropdown.tsx
@@ -75,6 +75,7 @@ const AddHostDropdown = ({
           </MenuToggle>
         )}
         shouldFocusToggleOnSelect
+        popperProps={{ preventOverflow: true }}
       >
         {[
           <DropdownItem


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-20809

**Before:**
![image](https://github.com/user-attachments/assets/88b5f736-ffd1-45a8-bc4f-164d9548170f)


**After:**
![image](https://github.com/user-attachments/assets/a82542c3-d649-4dcb-9b1d-a5d01e0bcb8f)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved dropdown positioning to prevent it from overflowing outside the viewport or container.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->