### PR TITLE
ECOPROJECT-2933: Disable virtualization bundle when cluster come from Migration Assessment

### DIFF
--- a/libs/ui-lib/lib/common/types/ui-settings.ts
+++ b/libs/ui-lib/lib/common/types/ui-settings.ts
@@ -3,4 +3,5 @@ export type UISettingsValues = {
   customManifestsAdded?: boolean;
   customManifestsUpdated?: boolean;
   bundlesSelected?: string[];
+  isAssistedMigration?: boolean;
 };

--- a/libs/ui-lib/lib/ocm/components/clusterWizard/OperatorsBundle.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/OperatorsBundle.tsx
@@ -36,6 +36,7 @@ import { bundleSpecs } from '../clusterConfiguration/operators/bundleSpecs';
 import { useOperatorSpecs } from '../../../common/components/operators/operatorSpecs';
 
 import './OperatorsBundle.css';
+import { useClusterWizardContext } from './ClusterWizardContext';
 
 const BundleLabel = ({ bundle }: { bundle: Bundle }) => {
   const opSpecs = useOperatorSpecs();
@@ -114,6 +115,7 @@ const BundleCard = ({
   const isSNO = useSelector(selectIsCurrentClusterSNO);
   const { isFeatureSupported, getFeatureSupportLevel } = useNewFeatureSupportLevel();
   const opSpecs = useOperatorSpecs();
+  const { uiSettings } = useClusterWizardContext();
 
   const supportLevel = getBundleSupportLevel(bundle, opSpecs, getFeatureSupportLevel);
 
@@ -130,7 +132,7 @@ const BundleCard = ({
   const incompatibleBundle = bundleSpec?.incompatibleBundles?.find((b) =>
     values.selectedBundles.includes(b),
   );
-
+  const isAssistedMigration = uiSettings?.isAssistedMigration;
   const disabledReason = hasUnsupportedOperators
     ? 'Some operators in this bundle are not supported with the current configuration.'
     : isSNO && bundleSpec?.noSNO
@@ -139,6 +141,8 @@ const BundleCard = ({
     ? `Bundle cannot be installed together with ${
         bundles.find(({ id }) => id === incompatibleBundle)?.title || incompatibleBundle
       }`
+    : isAssistedMigration
+    ? 'This bundle needs to be selected for clusters created from Migration Assessment'
     : undefined;
 
   const onSelect = (checked: boolean) => {


### PR DESCRIPTION
Related with https://issues.redhat.com/browse/ECOPROJECT-2933

When cluster is created from the Migration Assessment app we need to select the virtualization bundle and disable it.

![image](https://github.com/user-attachments/assets/5283d875-0f5e-453c-a2ca-84349e1c841b)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for identifying and handling clusters created through Assisted Migration in the UI.
  - Bundle selection cards now display a specific message when a bundle must be selected due to Assisted Migration.

- **Enhancements**
  - UI settings now include an option to mark clusters as Assisted Migration, improving clarity and workflow for migration scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->