### PR TITLE
MGMT-20611: Make KMM operator URL dynamic

### DIFF
--- a/libs/ui-lib/lib/common/components/operators/operatorSpecs.tsx
+++ b/libs/ui-lib/lib/common/components/operators/operatorSpecs.tsx
@@ -30,6 +30,7 @@ import {
   AUTHORINO_OPERATOR_LINK,
   CNV_LINK,
   FENCE_AGENTS_REMEDIATION_LINK,
+  getKmmDocsLink,
   getKubeDeschedulerLink,
   getLsoLink,
   getLvmsDocsLink,
@@ -38,7 +39,6 @@ import {
   getNodeFeatureDiscoveryLink,
   getNvidiaGpuLink,
   getServiceMeshLink,
-  KMM_LINK,
   MTV_LINK,
   NODE_HEALTHCHECK_LINK,
   NODE_MAINTENANCE_LINK,
@@ -147,9 +147,10 @@ export const getOperatorSpecs = (useLVMS?: boolean): { [key: string]: OperatorSp
     [OPERATOR_NAME_KMM]: {
       title: 'Kernel Module Management',
       featureId: 'KMM',
-      Description: () => (
+      Description: ({ openshiftVersion }) => (
         <>
-          Management of kernel modules. <ExternalLink href={KMM_LINK}>Learn more</ExternalLink>
+          Management of kernel modules.{' '}
+          <ExternalLink href={getKmmDocsLink(openshiftVersion)}>Learn more</ExternalLink>
         </>
       ),
     },

--- a/libs/ui-lib/lib/common/config/docs_links.ts
+++ b/libs/ui-lib/lib/common/config/docs_links.ts
@@ -90,8 +90,10 @@ export const OSC_REQUIREMENTS_LINK =
 
 export const CNV_LINK = 'https://cloud.redhat.com/learn/topics/virtualization/';
 
-export const KMM_LINK =
-  'https://docs.redhat.com/en/documentation/openshift_container_platform/4.12/html/specialized_hardware_and_driver_enablement/kernel-module-management-operator';
+export const getKmmDocsLink = (ocpVersion?: string) =>
+  `https://docs.redhat.com/en/documentation/openshift_container_platform/${getShortOpenshiftVersion(
+    ocpVersion,
+  )}/html/specialized_hardware_and_driver_enablement/kernel-module-management-operator`;
 
 export const ODF_LINK = 'https://www.redhat.com/en/resources/openshift-data-foundation-datasheet';
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Documentation links for the Kernel Module Management (KMM) operator are now dynamically generated based on the selected OpenShift version, ensuring users are directed to the correct version-specific documentation.
- **Improvements**
  - Operator descriptions now better align with other operators by supporting version-aware documentation links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->