### PR TITLE
MGMT-20576: Make hosts list scrollable inside Events table

### DIFF
--- a/libs/ui-lib/lib/common/components/ui/ClusterEventsToolbar.tsx
+++ b/libs/ui-lib/lib/common/components/ui/ClusterEventsToolbar.tsx
@@ -235,6 +235,7 @@ const ClusterEventsToolbar = ({
               isOpen={isHostExpanded}
               onSelect={(e, value) => onHostSelect(value as string, isSelectEventChecked(e))}
               onOpenChange={onHostToggle}
+              isScrollable
               toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
                 <MenuToggle
                   id="cluster-events-hosts-dropdown-button"


### PR DESCRIPTION
Allow the host list to be scrollable when necessary.

With few hosts:
![few-hosts](https://github.com/user-attachments/assets/cf484fef-f726-404f-b40b-c4c9e01bb6e6)


With many hosts (showing the beginning and end of the list):
![many-hosts-up](https://github.com/user-attachments/assets/22e50bce-b094-4b6b-9b11-5fa950983c60)

![many-hosts-down](https://github.com/user-attachments/assets/b1b31d15-ec04-43ab-811f-177e19063275)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added scrollable functionality to the "Hosts" filter dropdown in the events toolbar for improved usability when there are many options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->