### PR TITLE
MGMT-20867: Replace "Machine network" label with "Subnet" in Static network Configuration Form View

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/staticIp/commonValidationSchemas.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/staticIp/commonValidationSchemas.tsx
@@ -201,7 +201,7 @@ export const getIpAddressInSubnetValidationSchema = (
 ) => {
   return Yup.string().test(
     'is-in-subnet',
-    `IP Address is outside of the machine network ${subnet}`,
+    `IP Address is outside of the subnet ${subnet}`,
     (value, testContext: Yup.TestContext) => {
       if (!value) {
         return true;

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/staticIp/components/FormViewNetworkWide/FormViewNetworkWideFields.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/staticIp/components/FormViewNetworkWide/FormViewNetworkWideFields.tsx
@@ -82,10 +82,10 @@ const MachineNetwork: React.FC<{ fieldName: string; protocolVersion: ProtocolVer
       labelIcon={
         <PopoverIcon noVerticalAlign bodyContent="The range of IP addresses of the hosts." />
       }
-      label="Machine network"
+      label="Subnet"
       fieldId={fieldId}
       isRequired
-      className="machine-network"
+      className="subnet"
     >
       <Flex>
         <FlexItem spacer={{ default: 'spacerSm' }}>

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/staticIp/components/staticIp.css
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/staticIp/components/staticIp.css
@@ -16,14 +16,14 @@
   font-weight: unset;
 }
 
-.machine-network .pf-l-flex > div:nth-child(1) {
+.subnet .pf-l-flex > div:nth-child(1) {
   flex: 0 0 24rem;
 }
 
-.machine-network .pf-l-flex > div:nth-child(3) {
+.subnet .pf-l-flex > div:nth-child(3) {
   flex: 0 0 6rem;
 }
 
-.machine-network .pf-v5-c-form__helper-text.pf-m-error {
+.subnet .pf-v5-c-form__helper-text.pf-m-error {
   margin-top: unset;
 }

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/staticIp/data/formDataToInfraEnvField.ts
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/staticIp/data/formDataToInfraEnvField.ts
@@ -44,7 +44,7 @@ const getPrefixLength = (
 ): number => {
   const machineNetwork = networkWide.ipConfigs[protocolVersion].machineNetwork;
   if (machineNetwork.prefixLength === '') {
-    throw 'Machine network prefix length not configured';
+    throw 'Subnet prefix length not configured';
   }
   return machineNetwork.prefixLength;
 };


### PR DESCRIPTION
"Machine network" is a cluster-wide attribute, but in this form users are actually entering a subnet. To avoid confusion, the label has been changed to "Subnet".

Changes made:
* Updated the field label and its corresponding error message from "Machine network" to "Subnet" in the static network configuration Form View.