### PR TITLE
MGMT-20872: Change min OCP version in TNA disabled reason

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/ControlPlaneNodesDropdown.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/ControlPlaneNodesDropdown.tsx
@@ -83,7 +83,7 @@ const ControlPlaneNodesDropdown: React.FC<ControlPlaneNodesDropdownProps> = ({
   );
 
   const disabledReason =
-    'This option is not available with the current configurations. Make sure that OpenShift version is 4.18 or newer, CPU architecture is x86_64 and no external platform integration is selected.';
+    'This option is not available with the current configurations. Make sure that OpenShift version is 4.19 or newer, CPU architecture is x86_64 and no external platform integration is selected.';
 
   const isNonStandardControlPlaneEnabled = newFeatureSupportLevelContext.isFeatureSupported(
     'NON_STANDARD_HA_CONTROL_PLANE',


### PR DESCRIPTION
Two-node arbiter clusters are only available for OCP 4.19 or newer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated displayed text to reference OpenShift version 4.19 instead of 4.18 in the control plane nodes dropdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->