### PR TITLE
MGMT-20931: Always show the box-shadow in the floating Dropdown menus

### DIFF
--- a/libs/ui-lib/lib/common/components/hosts/DiskRole.tsx
+++ b/libs/ui-lib/lib/common/components/hosts/DiskRole.tsx
@@ -122,7 +122,6 @@ const DiskRoleDropdown: React.FC<DiskRoleDropdownProps> = ({
       onSelect={onSelect}
       toggle={toggle}
       isOpen={isOpen}
-      isPlain
     >
       <DropdownList>{dropdownItems}</DropdownList>
     </Dropdown>

--- a/libs/ui-lib/lib/common/components/ui/SimpleDropdown.tsx
+++ b/libs/ui-lib/lib/common/components/ui/SimpleDropdown.tsx
@@ -63,7 +63,6 @@ export const SimpleDropdown = ({
       onOpenChange={() => setOpen(!isOpen)}
       toggle={toggle}
       isOpen={isOpen}
-      isPlain
       id={idPrefix ? `${idPrefix}-dropdown-toggle` : undefined}
       popperProps={{ appendTo: menuAppendTo }}
     >


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/MGMT-20931
Stop using the `isPlain` variants for Host and Disk roles, so there's a box-shadow to highlight the menu better.

Before:
![disks-plain](https://github.com/user-attachments/assets/f68da9ee-4af4-4de4-a1e4-a788b4579d90)
![host-role-plain](https://github.com/user-attachments/assets/10b93ff2-a1d2-4343-b43b-48f371a37bb9)

After:
![disks-with-border](https://github.com/user-attachments/assets/86e66225-bafb-467c-b37b-ec043af96640)
![host-role-with-border](https://github.com/user-attachments/assets/cda64f71-f004-4c9f-bd50-d72b19fce923)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated dropdown components by removing the "plain" style variant, resulting in a modified appearance for dropdown menus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->