### PR TITLE
MGMT-20483: Adding new categories for operators

### DIFF
--- a/libs/ui-lib/lib/common/components/operators/operatorSpecs.tsx
+++ b/libs/ui-lib/lib/common/components/operators/operatorSpecs.tsx
@@ -91,7 +91,6 @@ export type OperatorSpec = {
   Description?: React.ComponentType<{ openshiftVersion?: string }>;
   notStandalone?: boolean;
   Requirements?: React.ComponentType<{ cluster: Cluster }>;
-  category: string;
   supportLevel?: SupportLevel | undefined;
 };
 
@@ -113,7 +112,6 @@ export const getOperatorSpecs = (
           </>
         ),
         notStandalone: true,
-        category: categories[Category.STORAGE],
         supportLevel: getFeatureSupportLevel('LSO'),
       },
       {
@@ -130,7 +128,6 @@ export const getOperatorSpecs = (
           ) : (
             <>{DESCRIPTION_LVM}</>
           ),
-        category: categories[Category.STORAGE],
         supportLevel: getFeatureSupportLevel('LVM'),
       },
       {
@@ -148,7 +145,6 @@ export const getOperatorSpecs = (
             {DESCRIPTION_ODF} <ExternalLink href={ODF_LINK}>Learn more</ExternalLink>
           </>
         ),
-        category: categories[Category.STORAGE],
         supportLevel: getFeatureSupportLevel('ODF'),
       },
     ],
@@ -166,7 +162,6 @@ export const getOperatorSpecs = (
             {DESCRIPTION_CNV} <ExternalLink href={CNV_LINK}>Learn more</ExternalLink>
           </>
         ),
-        category: categories[Category.VIRT],
         supportLevel: getFeatureSupportLevel('CNV'),
       },
       {
@@ -179,7 +174,6 @@ export const getOperatorSpecs = (
             {DESCRIPTION_MTV} <ExternalLink href={MTV_LINK}>Learn more</ExternalLink>
           </>
         ),
-        category: categories[Category.VIRT],
         supportLevel: getFeatureSupportLevel('MTV'),
       },
       {
@@ -197,7 +191,6 @@ export const getOperatorSpecs = (
             {DESCRIPTION_OSC} <ExternalLink href={OSC_LINK}>Learn more</ExternalLink>
           </>
         ),
-        category: categories[Category.VIRT],
         supportLevel: getFeatureSupportLevel('OSC'),
       },
     ],
@@ -216,7 +209,6 @@ export const getOperatorSpecs = (
             <ExternalLink href={OPENSHIFT_AI_LINK}>Learn more</ExternalLink>
           </>
         ),
-        category: categories[Category.AI],
         supportLevel: getFeatureSupportLevel('OPENSHIFT_AI'),
       },
       {
@@ -226,7 +218,6 @@ export const getOperatorSpecs = (
         descriptionText: DESCRIPTION_AMD_GPU,
         Requirements: () => <>Requires at least one supported AMD GPU</>,
         Description: () => <>{DESCRIPTION_AMD_GPU}</>,
-        category: categories[Category.AI],
         supportLevel: getFeatureSupportLevel('AMD_GPU'),
       },
       {
@@ -241,7 +232,6 @@ export const getOperatorSpecs = (
             <ExternalLink href={getNvidiaGpuLink(openshiftVersion)}>Learn more</ExternalLink>
           </>
         ),
-        category: categories[Category.AI],
         supportLevel: getFeatureSupportLevel('NVIDIA_GPU'),
       },
     ],
@@ -257,7 +247,6 @@ export const getOperatorSpecs = (
             <ExternalLink href={getNmstateLink(openshiftVersion)}>Learn more</ExternalLink>
           </>
         ),
-        category: categories[Category.NETWORK],
         supportLevel: getFeatureSupportLevel('NMSTATE'),
       },
       {
@@ -272,7 +261,6 @@ export const getOperatorSpecs = (
           </>
         ),
         notStandalone: true,
-        category: categories[Category.NETWORK],
         supportLevel: getFeatureSupportLevel('SERVICEMESH'),
       },
     ],
@@ -289,7 +277,6 @@ export const getOperatorSpecs = (
           </>
         ),
         notStandalone: true,
-        category: categories[Category.SECURITY],
         supportLevel: getFeatureSupportLevel('AUTHORINO'),
       },
       {
@@ -303,7 +290,6 @@ export const getOperatorSpecs = (
             <ExternalLink href={getKmmDocsLink(openshiftVersion)}>Learn more</ExternalLink>
           </>
         ),
-        category: categories[Category.SECURITY],
         supportLevel: getFeatureSupportLevel('KMM'),
       },
     ],
@@ -320,7 +306,6 @@ export const getOperatorSpecs = (
           </>
         ),
         notStandalone: true,
-        category: categories[Category.CI_CD],
         supportLevel: getFeatureSupportLevel('PIPELINES'),
       },
       {
@@ -335,7 +320,6 @@ export const getOperatorSpecs = (
           </>
         ),
         notStandalone: true,
-        category: categories[Category.CI_CD],
         supportLevel: getFeatureSupportLevel('SERVERLESS'),
       },
     ],
@@ -351,7 +335,6 @@ export const getOperatorSpecs = (
             <ExternalLink href={getMceDocsLink(openshiftVersion)}>Learn more</ExternalLink>
           </>
         ),
-        category: categories[Category.PLATFORM],
         supportLevel: getFeatureSupportLevel('MCE'),
       },
       {
@@ -366,7 +349,6 @@ export const getOperatorSpecs = (
           </>
         ),
         notStandalone: true,
-        category: categories[Category.PLATFORM],
         supportLevel: getFeatureSupportLevel('NODE_MAINTENANCE'),
       },
     ],
@@ -384,7 +366,6 @@ export const getOperatorSpecs = (
             </ExternalLink>
           </>
         ),
-        category: categories[Category.SCHEDULING],
         supportLevel: getFeatureSupportLevel('NODE_FEATURE_DISCOVERY'),
       },
       {
@@ -399,7 +380,6 @@ export const getOperatorSpecs = (
           </>
         ),
         notStandalone: true,
-        category: categories[Category.SCHEDULING],
         supportLevel: getFeatureSupportLevel('KUBE_DESCHEDULER'),
       },
     ],

--- a/libs/ui-lib/lib/common/components/operators/operatorSpecs.tsx
+++ b/libs/ui-lib/lib/common/components/operators/operatorSpecs.tsx
@@ -182,6 +182,24 @@ export const getOperatorSpecs = (
         category: categories[Category.VIRT],
         supportLevel: getFeatureSupportLevel('MTV'),
       },
+      {
+        operatorKey: OPERATOR_NAME_OSC,
+        title: 'OpenShift sandboxed containers',
+        featureId: 'OSC',
+        descriptionText: DESCRIPTION_OSC,
+        Requirements: () => (
+          <ExternalLink href={OSC_REQUIREMENTS_LINK}>
+            Learn more about the requirements for OpenShift sandboxed containers
+          </ExternalLink>
+        ),
+        Description: () => (
+          <>
+            {DESCRIPTION_OSC} <ExternalLink href={OSC_LINK}>Learn more</ExternalLink>
+          </>
+        ),
+        category: categories[Category.VIRT],
+        supportLevel: getFeatureSupportLevel('OSC'),
+      },
     ],
     [categories[Category.AI]]: [
       {
@@ -258,7 +276,7 @@ export const getOperatorSpecs = (
         supportLevel: getFeatureSupportLevel('SERVICEMESH'),
       },
     ],
-    [categories[Category.OTHER]]: [
+    [categories[Category.SECURITY]]: [
       {
         operatorKey: OPERATOR_NAME_AUTHORINO,
         title: 'Authorino',
@@ -271,25 +289,25 @@ export const getOperatorSpecs = (
           </>
         ),
         notStandalone: true,
-        category: categories[Category.OTHER],
+        category: categories[Category.SECURITY],
         supportLevel: getFeatureSupportLevel('AUTHORINO'),
       },
       {
-        operatorKey: OPERATOR_NAME_NODE_FEATURE_DISCOVERY,
-        title: 'Node Feature Discovery',
-        featureId: 'NODE_FEATURE_DISCOVERY',
-        descriptionText: DESCRIPTION_NODE_FEATURE_DISCOVERY,
+        operatorKey: OPERATOR_NAME_KMM,
+        title: 'Kernel Module Management',
+        featureId: 'KMM',
+        descriptionText: DESCRIPTION_KMM,
         Description: ({ openshiftVersion }) => (
           <>
-            {DESCRIPTION_NODE_FEATURE_DISCOVERY}{' '}
-            <ExternalLink href={getNodeFeatureDiscoveryLink(openshiftVersion)}>
-              Learn more
-            </ExternalLink>
+            {DESCRIPTION_KMM}{' '}
+            <ExternalLink href={getKmmDocsLink(openshiftVersion)}>Learn more</ExternalLink>
           </>
         ),
-        category: categories[Category.OTHER],
-        supportLevel: getFeatureSupportLevel('NODE_FEATURE_DISCOVERY'),
+        category: categories[Category.SECURITY],
+        supportLevel: getFeatureSupportLevel('KMM'),
       },
+    ],
+    [categories[Category.CI_CD]]: [
       {
         operatorKey: OPERATOR_NAME_PIPELINES,
         title: 'Pipelines',
@@ -302,7 +320,7 @@ export const getOperatorSpecs = (
           </>
         ),
         notStandalone: true,
-        category: categories[Category.OTHER],
+        category: categories[Category.CI_CD],
         supportLevel: getFeatureSupportLevel('PIPELINES'),
       },
       {
@@ -317,23 +335,11 @@ export const getOperatorSpecs = (
           </>
         ),
         notStandalone: true,
-        category: categories[Category.OTHER],
+        category: categories[Category.CI_CD],
         supportLevel: getFeatureSupportLevel('SERVERLESS'),
       },
-      {
-        operatorKey: OPERATOR_NAME_KMM,
-        title: 'Kernel Module Management',
-        featureId: 'KMM',
-        descriptionText: DESCRIPTION_KMM,
-        Description: ({ openshiftVersion }) => (
-          <>
-            {DESCRIPTION_KMM}{' '}
-            <ExternalLink href={getKmmDocsLink(openshiftVersion)}>Learn more</ExternalLink>
-          </>
-        ),
-        category: categories[Category.OTHER],
-        supportLevel: getFeatureSupportLevel('KMM'),
-      },
+    ],
+    [categories[Category.PLATFORM]]: [
       {
         operatorKey: OPERATOR_NAME_MCE,
         title: 'Multicluster engine',
@@ -345,26 +351,41 @@ export const getOperatorSpecs = (
             <ExternalLink href={getMceDocsLink(openshiftVersion)}>Learn more</ExternalLink>
           </>
         ),
-        category: categories[Category.OTHER],
+        category: categories[Category.PLATFORM],
         supportLevel: getFeatureSupportLevel('MCE'),
       },
       {
-        operatorKey: OPERATOR_NAME_OSC,
-        title: 'OpenShift sandboxed containers',
-        featureId: 'OSC',
-        descriptionText: DESCRIPTION_OSC,
-        Requirements: () => (
-          <ExternalLink href={OSC_REQUIREMENTS_LINK}>
-            Learn more about the requirements for OpenShift sandboxed containers
-          </ExternalLink>
-        ),
+        operatorKey: OPERATOR_NAME_NODE_MAINTENANCE,
+        title: 'Node Maintenance',
+        featureId: 'NODE_MAINTENANCE',
+        descriptionText: DESCRIPTION_NODE_MAINTENANCE,
         Description: () => (
           <>
-            {DESCRIPTION_OSC} <ExternalLink href={OSC_LINK}>Learn more</ExternalLink>
+            {DESCRIPTION_NODE_MAINTENANCE}{' '}
+            <ExternalLink href={NODE_MAINTENANCE_LINK}>Learn more</ExternalLink>
           </>
         ),
-        category: categories[Category.OTHER],
-        supportLevel: getFeatureSupportLevel('OSC'),
+        notStandalone: true,
+        category: categories[Category.PLATFORM],
+        supportLevel: getFeatureSupportLevel('NODE_MAINTENANCE'),
+      },
+    ],
+    [categories[Category.SCHEDULING]]: [
+      {
+        operatorKey: OPERATOR_NAME_NODE_FEATURE_DISCOVERY,
+        title: 'Node Feature Discovery',
+        featureId: 'NODE_FEATURE_DISCOVERY',
+        descriptionText: DESCRIPTION_NODE_FEATURE_DISCOVERY,
+        Description: ({ openshiftVersion }) => (
+          <>
+            {DESCRIPTION_NODE_FEATURE_DISCOVERY}{' '}
+            <ExternalLink href={getNodeFeatureDiscoveryLink(openshiftVersion)}>
+              Learn more
+            </ExternalLink>
+          </>
+        ),
+        category: categories[Category.SCHEDULING],
+        supportLevel: getFeatureSupportLevel('NODE_FEATURE_DISCOVERY'),
       },
       {
         operatorKey: OPERATOR_NAME_KUBE_DESCHEDULER,
@@ -378,24 +399,8 @@ export const getOperatorSpecs = (
           </>
         ),
         notStandalone: true,
-        category: categories[Category.OTHER],
+        category: categories[Category.SCHEDULING],
         supportLevel: getFeatureSupportLevel('KUBE_DESCHEDULER'),
-      },
-
-      {
-        operatorKey: OPERATOR_NAME_NODE_MAINTENANCE,
-        title: 'Node Maintenance',
-        featureId: 'NODE_MAINTENANCE',
-        descriptionText: DESCRIPTION_NODE_MAINTENANCE,
-        Description: () => (
-          <>
-            {DESCRIPTION_NODE_MAINTENANCE}{' '}
-            <ExternalLink href={NODE_MAINTENANCE_LINK}>Learn more</ExternalLink>
-          </>
-        ),
-        notStandalone: true,
-        category: categories[Category.OTHER],
-        supportLevel: getFeatureSupportLevel('NODE_MAINTENANCE'),
       },
     ],
   };
@@ -442,7 +447,10 @@ enum Category {
   VIRT,
   AI,
   NETWORK,
-  OTHER,
+  CI_CD,
+  PLATFORM,
+  SECURITY,
+  SCHEDULING,
 }
 
 export const categories: { [key in Category]: string } = {
@@ -450,5 +458,8 @@ export const categories: { [key in Category]: string } = {
   [Category.VIRT]: 'Virtualization',
   [Category.AI]: 'AI',
   [Category.NETWORK]: 'Network',
-  [Category.OTHER]: 'Other',
+  [Category.SECURITY]: 'Security & Access Control',
+  [Category.CI_CD]: 'CI/CD & Dev Productivity',
+  [Category.PLATFORM]: 'Platform Operations & Lifecycle',
+  [Category.SCHEDULING]: 'Scheduling',
 };


### PR DESCRIPTION
Related with https://issues.redhat.com/browse/MGMT-20483

Adding new categories for operators and removing 'Other' categories:
![Captura desde 2025-06-26 12-18-57](https://github.com/user-attachments/assets/257da3c4-0a96-4f6a-81e0-99ecca513f8c)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new operator for OpenShift sandboxed containers under the Virtualization category.

* **Improvements**
  * Introduced more specific categories for operators: Security, CI/CD, Platform, and Scheduling.
  * Updated operator categories for improved organization and clarity.
  * Removed the generic "Other" category and redistributed operators into the new categories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->