### PR TITLE
MGMT-20842: Not highlighted text in OSC and Node Feature Discovery operators when  we found results

### DIFF
--- a/libs/ui-lib/lib/common/components/operators/operatorSpecs.tsx
+++ b/libs/ui-lib/lib/common/components/operators/operatorSpecs.tsx
@@ -211,9 +211,10 @@ export const getOperatorSpecs = (
             Learn more about the requirements for OpenShift sandboxed containers
           </ExternalLink>
         ),
-        Description: () => (
+        Description: ({ searchTerm }) => (
           <>
-            {DESCRIPTION_OSC} <ExternalLink href={OSC_LINK}>Learn more</ExternalLink>
+            <HighlightedText text={DESCRIPTION_OSC} searchTerm={searchTerm} />{' '}
+            <ExternalLink href={OSC_LINK}>Learn more</ExternalLink>
           </>
         ),
         supportLevel: getFeatureSupportLevel('OSC'),
@@ -388,9 +389,9 @@ export const getOperatorSpecs = (
         title: 'Node Feature Discovery',
         featureId: 'NODE_FEATURE_DISCOVERY',
         descriptionText: DESCRIPTION_NODE_FEATURE_DISCOVERY,
-        Description: ({ openshiftVersion }) => (
+        Description: ({ openshiftVersion, searchTerm }) => (
           <>
-            {DESCRIPTION_NODE_FEATURE_DISCOVERY}{' '}
+            <HighlightedText text={DESCRIPTION_NODE_FEATURE_DISCOVERY} searchTerm={searchTerm} />{' '}
             <ExternalLink href={getNodeFeatureDiscoveryLink(openshiftVersion)}>
               Learn more
             </ExternalLink>


### PR DESCRIPTION
Related with https://issues.redhat.com/browse/MGMT-20482

It's not highlighting the text only for OSC and Node Feature Discovery operators when some results are found.