### PR TITLE
MGMT-20976: Disable table actions when no hosts have been selected

### DIFF
--- a/libs/locales/lib/en/translation.json
+++ b/libs/locales/lib/en/translation.json
@@ -726,7 +726,6 @@
   "ai:Select all": "Select all",
   "ai:Select how you'd like to add hosts (Discovery ISO, iPXE, or BMC form) and follow the instructions that appear.": "Select the method of adding hosts (Discovery ISO, iPXE, or BMC form) and follow the instructions.",
   "ai:Select none": "Select none",
-  "ai:Select one or more hosts": "Select one or more hosts",
   "ai:Select one or more locations to view hosts": "Select one or more locations to view hosts",
   "ai:Select one or multiple locations to choose the hosts from.": "Select one or multiple locations of the hosts.",
   "ai:selected": "selected",

--- a/libs/ui-lib/lib/common/components/hosts/TableToolbar.tsx
+++ b/libs/ui-lib/lib/common/components/hosts/TableToolbar.tsx
@@ -10,7 +10,6 @@ import {
   ToolbarContent,
   ToolbarItem,
   ToolbarProps,
-  Tooltip,
   Dropdown,
   DropdownItem,
   MenuToggle,
@@ -68,14 +67,20 @@ const TableToolbar: React.FC<TableToolbarProps> = ({
         : null;
   }
 
-  const isDisabled = isChecked === false;
+  const isActionsDisabled = isChecked === false;
 
   const actionsDropdown = (
     <Dropdown
       onSelect={onActionsToggle}
       onOpenChange={onActionsToggle}
       toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
-        <MenuToggle ref={toggleRef} isFullWidth onClick={onActionsToggle} isExpanded={actionsOpen}>
+        <MenuToggle
+          ref={toggleRef}
+          isFullWidth
+          onClick={onActionsToggle}
+          isExpanded={actionsOpen}
+          isDisabled={isActionsDisabled}
+        >
           {t('ai:Actions')}
         </MenuToggle>
       )}
@@ -130,13 +135,7 @@ const TableToolbar: React.FC<TableToolbarProps> = ({
           <ToolbarContent className="table-toolbar__content">
             <ToolbarItem>{SelectDropdown}</ToolbarItem>
             {children}
-            <ToolbarItem>
-              {isDisabled ? (
-                <Tooltip content={t('ai:Select one or more hosts')}>{actionsDropdown}</Tooltip>
-              ) : (
-                actionsDropdown
-              )}
-            </ToolbarItem>
+            <ToolbarItem>{actionsDropdown}</ToolbarItem>
           </ToolbarContent>
         </Toolbar>
       </SplitItem>


### PR DESCRIPTION
Disable the "actions" button of `TableToolbar` when no items have been selected.
Modified for all tables:

1. OCM, host discovery

2. CIM, host discovery
![cim-hosts-disabled](https://github.com/user-attachments/assets/cc883c8c-c564-431b-98a4-490c8e9268b6)
 ![cim-hosts-enabled](https://github.com/user-attachments/assets/efad58da-4953-4472-aab7-91fe1c8decf1)

3. CIM, infraenv hosts (<clusterURL>/multicloud/infrastructure/environments/details/celia-test/celia-test/hosts)
![infraenv-table-disabled](https://github.com/user-attachments/assets/14770239-939a-424c-9215-cbc3a43fa8dd)
![infraenv-table-enabled](https://github.com/user-attachments/assets/ab62ab5b-020c-4121-b809-103ba46277e2)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated the "Actions" dropdown in the hosts table toolbar to be directly disabled when no hosts are selected, removing the tooltip that previously appeared in this state.

* **Chores**
  * Removed an unused translation key from the English language file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->