### PR TITLE
MGMT-20939: Refresh cluster-level validations on host role update

### DIFF
--- a/libs/ui-lib/lib/ocm/components/hosts/use-hosts-table.tsx
+++ b/libs/ui-lib/lib/ocm/components/hosts/use-hosts-table.tsx
@@ -326,7 +326,14 @@ export const useHostsTable = (cluster: Cluster) => {
           throw new Error(`Failed to edit role in host: ${host.id}.\nMissing cluster_id`);
         }
         const { data } = await HostsService.updateRole(host, role);
-        resetCluster ? void resetCluster() : dispatch(updateHost(data));
+
+        if (resetCluster) {
+          void resetCluster();
+        } else {
+          dispatch(updateHost(data));
+          // Reload to obtain cluster-level validations that may be affected by role change
+          dispatch(forceReload());
+        }
       } catch (e) {
         handleApiError(e, () =>
           addAlert({ title: 'Failed to set role', message: getApiErrorMessage(e) }),


### PR DESCRIPTION
After the host role changes, we refetch the cluster details to get the updated cluster validations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of host role updates to ensure cluster-level validations are refreshed after changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->