### PR TITLE
MGMT-20742: Shorten operators debounce for responsiveness

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusterWizard/Operators.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/Operators.tsx
@@ -21,6 +21,10 @@ import { setServerUpdateError, updateCluster } from '../../store/slices/current-
 import { getApiErrorMessage, handleApiError, isUnknownServerError } from '../../../common/api';
 import { canNextOperators } from './wizardTransition';
 
+// Balance debounce time: fast clicks should trigger a single API call,
+// but making it shorter will allow us to disable navigation buttons while changes are pending
+const operatorsAutoSaveDebounce = 500;
+
 const getOperatorsInitialValues = (
   uiSettings: UISettingsValues | undefined,
   cluster: Cluster,
@@ -34,7 +38,7 @@ const getOperatorsInitialValues = (
 const OperatorsForm = ({ cluster }: { cluster: Cluster }) => {
   const { alerts } = useAlerts();
   const clusterWizardContext = useClusterWizardContext();
-  const isAutoSaveRunning = useFormikAutoSave();
+  const isAutoSaveRunning = useFormikAutoSave(operatorsAutoSaveDebounce);
   const { errors, touched, isSubmitting, isValid } = useFormikContext<OperatorsValues>();
   const navigate = useNavigate();
   const { pathname } = useLocation();


### PR DESCRIPTION
With the default debounce time of 1s, it gives the user too much time to select an operator and attempting to navigate outside of the Operators step.

The reduced time should capture repeated and fast clicks, and prevent navigation while changes are pending.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Adjusted the auto-save timing in the Operators form to improve responsiveness and reduce unnecessary API calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->