### PR TITLE
OpenShift docs for 4.19 are already available

### DIFF
--- a/libs/ui-lib/lib/common/components/operators/operatorSpecs.tsx
+++ b/libs/ui-lib/lib/common/components/operators/operatorSpecs.tsx
@@ -34,7 +34,6 @@ import {
   getNmstateLink,
   getNodeFeatureDiscoveryLink,
   getNvidiaGpuLink,
-  getServiceMeshLink,
   MTV_LINK,
   NODE_MAINTENANCE_LINK,
   ODF_LINK,
@@ -45,6 +44,7 @@ import {
   OSC_REQUIREMENTS_LINK,
   PIPELINES_OPERATOR_LINK,
   SERVERLESS_OPERATOR_LINK,
+  SERVICE_MESH_OPERATOR_LINK,
 } from '../../config';
 import { getMajorMinorVersion } from '../../utils';
 import { GetFeatureSupportLevel, useNewFeatureSupportLevel } from '../newFeatureSupportLevels';
@@ -285,10 +285,10 @@ export const getOperatorSpecs = (
         title: 'Service Mesh',
         featureId: 'SERVICEMESH',
         descriptionText: DESCRIPTION_SERVICEMESH,
-        Description: ({ openshiftVersion, searchTerm }) => (
+        Description: ({ searchTerm }) => (
           <>
             <HighlightedText text={DESCRIPTION_SERVICEMESH} searchTerm={searchTerm} />{' '}
-            <ExternalLink href={getServiceMeshLink(openshiftVersion)}>Learn more</ExternalLink>
+            <ExternalLink href={SERVICE_MESH_OPERATOR_LINK}>Learn more</ExternalLink>
           </>
         ),
         notStandalone: true,

--- a/libs/ui-lib/lib/common/config/docs_links.ts
+++ b/libs/ui-lib/lib/common/config/docs_links.ts
@@ -1,6 +1,6 @@
 import { isMajorMinorVersionEqualOrGreater } from '../utils';
 
-const LATEST_OPENSHIFT_DOCS_VERSION = '4.18';
+const LATEST_OPENSHIFT_DOCS_VERSION = '4.19';
 const MIN_OPENSHIFT_DOCS_VERSION = '4.14';
 
 const getDocsOpenshiftVersion = (ocpVersion?: string): string => {
@@ -164,20 +164,22 @@ export const getMtuLink = (ocpVersion?: string) =>
 
 export const AUTHORINO_OPERATOR_LINK = 'https://github.com/Kuadrant/authorino-operator';
 
-export const getLsoLink = (ocpVersion?: string) =>
-  `https://docs.openshift.com/container-platform/${getDocsOpenshiftVersion(
-    ocpVersion,
-  )}/storage/persistent_storage/persistent_storage_local/ways-to-provision-local-storage.html`;
+export const getLsoLink = (ocpVersion?: string) => {
+  const version = getDocsOpenshiftVersion(ocpVersion);
+  return isMajorMinorVersionEqualOrGreater(ocpVersion, '4.19')
+    ? `https://docs.redhat.com/en/documentation/openshift_container_platform/${version}/html/storage/configuring-persistent-storage#persistent-storage-using-local-storage`
+    : `https://docs.openshift.com/container-platform/${version}/storage/persistent_storage/persistent_storage_local/ways-to-provision-local-storage.html`;
+};
 
 export const getNmstateLink = (ocpVersion?: string) =>
-  `https://docs.openshift.com/container-platform/${getDocsOpenshiftVersion(
+  `https://docs.redhat.com/en/documentation/openshift_container_platform/${getDocsOpenshiftVersion(
     ocpVersion,
-  )}/networking/networking_operators/k8s-nmstate-about-the-k8s-nmstate-operator.html`;
+  )}/html/networking/networking-operators#k8s-nmstate-about-the-k8s-nmstate-operator`;
 
 export const getNodeFeatureDiscoveryLink = (ocpVersion?: string) =>
-  `https://docs.openshift.com/container-platform/${getDocsOpenshiftVersion(
+  `https://docs.redhat.com/en/documentation/openshift_container_platform/${getDocsOpenshiftVersion(
     ocpVersion,
-  )}/hardware_enablement/psap-node-feature-discovery-operator.html`;
+  )}/html/specialized_hardware_and_driver_enablement/psap-node-feature-discovery-operator`;
 
 export const getNvidiaGpuLink = (ocpVersion?: string) => {
   const version = getDocsOpenshiftVersion(ocpVersion);
@@ -187,15 +189,13 @@ export const getNvidiaGpuLink = (ocpVersion?: string) => {
 };
 
 export const PIPELINES_OPERATOR_LINK =
-  'https://docs.openshift.com/pipelines/1.17/install_config/installing-pipelines.html';
+  'https://docs.redhat.com/en/documentation/red_hat_openshift_pipelines/1.18/html/installing_and_configuring/installing-pipelines';
 
-export const getServiceMeshLink = (ocpVersion?: string) =>
-  `https://docs.openshift.com/container-platform/${getDocsOpenshiftVersion(
-    ocpVersion,
-  )}/service_mesh/v1x/preparing-ossm-installation.html`;
+export const SERVICE_MESH_OPERATOR_LINK =
+  'https://docs.redhat.com/en/documentation/red_hat_openshift_service_mesh/3.0/html/installing/ossm-installing-service-mesh';
 
 export const SERVERLESS_OPERATOR_LINK =
-  'https://docs.openshift.com/serverless/1.28/install/install-serverless-operator.html#serverless-install-web-console_install-serverless-operator';
+  'https://docs.redhat.com/en/documentation/red_hat_openshift_serverless/1.36/html/installing_openshift_serverless/install-serverless-operator#serverless-install-web-console_install-serverless-operator';
 
 export const KUBECONFIG_INFO_LINK =
   'https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/cli_tools/openshift-cli-oc#about-switches-between-cli-profiles_managing-cli-profiles';


### PR DESCRIPTION
Made some changes to doc links since OpenShift 4.19 is now Generally Available:

1. When users choose OpenShift 4.19, the documentation links are for that version instead of 4.18

2. Service mesh operator: 
 The previous link was for the documentation of Service Mesh 1.x which is now unsupported, plus Service Mesh has now official docs separate from OpenShift docs. I modified the link to the documentation for the standalone docs of Service Mesh 3.x

3. Local Storage Operator:
 There are no docs in docs.openshift.com for LSO for OpenShift 4.19. Modified to the correct documentation in docs.redhat.com
 
4. Nmstate operator: The old docs in docs.openshift.com don't have the equivalent for 4.19. The new link seems to work with quite old OCP versions.

5.  Pipelines and Serverless operators: The versions we linked for these operators were pretty outdated. I updated the links to docs.redhat.com links and to their latest versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated documentation links throughout the application to point to the latest Red Hat documentation, including new versions and revised URL structures for various operators and features.

* **Bug Fixes**
  * Simplified and improved the reliability of documentation links for Service Mesh and other operators by removing version-dependent logic and using fixed URLs where appropriate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->