### PR TITLE
MGMT-20999: Fix background color in readonly form controls in PF5

### DIFF
--- a/libs/ui-lib/lib/cim/global.css
+++ b/libs/ui-lib/lib/cim/global.css
@@ -1,0 +1,12 @@
+/*
+ In readonly form controls in PF5, text is unreadable in dark theme due to its background color.
+ Original color is disabled-color-300, see effect at https://v5-archive.patternfly.org/utility-classes/background-color
+
+ Applied to:
+ - Add hosts modal
+ - AI cluster installation progress card
+ */
+.pf-v5-theme-dark #add-host-modal .pf-v5-c-form-control.pf-m-readonly,
+.pf-v5-theme-dark #aiprogress .pf-v5-c-form-control.pf-m-readonly {
+  --pf-v5-c-form-control--m-readonly--BackgroundColor: var(--pf-v5-global--disabled-color--200);
+}

--- a/libs/ui-lib/lib/cim/index.ts
+++ b/libs/ui-lib/lib/cim/index.ts
@@ -1,3 +1,6 @@
+// Import global CIM styles
+import './global.css';
+
 // without namespace
 export * from './types';
 export * from './components';


### PR DESCRIPTION
Depending on the environment, some CSS rules for read-only form controls have a very hard to read background color.
See "Disabled color 300" in dark mode in [PF5](https://v5-archive.patternfly.org/utility-classes/background-color in dark mode)
![pf5-disabled-backgrounds](https://github.com/user-attachments/assets/aac65efd-0d08-4708-9758-91cb7028ecf1)

Since this affects several PF5 components (at least read-only `ClipboardCopy`, `FileUploadField` ), I added a new CSS file that will load always in CIM. But I used IDs belonging to Assisted Installer UI components in order to scope the rule to only apply to our components.

Before:
![original-background](https://github.com/user-attachments/assets/10a3a0cf-d012-4340-bfd2-14271f798fac)

After:
![fixed-background](https://github.com/user-attachments/assets/7b722d90-3091-40d0-98ac-f2c3c87d1c4c)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved readability of readonly form controls in dark mode by adjusting background colors in specific modals and cards.
  * Updated global styles to enhance visual consistency for users in the dark theme.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->