### PR TITLE
MGMT-20399: Allow to add in day2 hosts with other CPU architectures in s390x clusters

### DIFF
--- a/libs/ui-lib/lib/common/types/cpuArchitecture.ts
+++ b/libs/ui-lib/lib/common/types/cpuArchitecture.ts
@@ -76,18 +76,12 @@ export const getSupportedCpuArchitectures = (
   day1CpuArchitecture?: SupportedCpuArchitecture,
 ): SupportedCpuArchitecture[] => {
   const newSupportedCpuArchs: SupportedCpuArchitecture[] = [];
-  //Power/Z clusters can be only homogeneous clusters
-  if (
-    day1CpuArchitecture === CpuArchitecture.ppc64le ||
-    day1CpuArchitecture === CpuArchitecture.s390x
-  ) {
+  //Power clusters can be only homogeneous clusters
+  if (day1CpuArchitecture === CpuArchitecture.ppc64le) {
     newSupportedCpuArchs.push(day1CpuArchitecture);
   } else {
     cpuArchitectures.forEach((cpuArch) => {
-      if (
-        day1CpuArchitecture === undefined &&
-        (cpuArch === CpuArchitecture.ppc64le || cpuArch === CpuArchitecture.s390x)
-      ) {
+      if (day1CpuArchitecture === undefined && cpuArch === CpuArchitecture.ppc64le) {
         newSupportedCpuArchs.push(cpuArch);
       } else if (
         cpuArch !== CpuArchitecture.MULTI &&


### PR DESCRIPTION
Related with https://issues.redhat.com/browse/MGMT-20399

For s390x clusters created by AI, its only possible to add s390x nodes in a day2 operation.

This differs from "normal OpenShift installer" where its possible to start with e.g. three s390x master nodes and add additional worker nodes using different architecture.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted CPU architecture handling to ensure only the "ppc64le" architecture is included in certain scenarios, no longer including "s390x".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->