### PR TITLE
MGMT-20303: Do not allow renaming host after install startedOC

### DIFF
--- a/libs/ui-lib/lib/cim/components/Agent/tableUtils.tsx
+++ b/libs/ui-lib/lib/cim/components/Agent/tableUtils.tsx
@@ -40,7 +40,7 @@ export const agentHostnameColumn = (
   agents: AgentK8sResource[],
   bareMetalHosts: BareMetalHostK8sResource[],
   onEditHostname?: HostsTableActions['onEditHost'],
-  canEditHostname?: HostsTableActions['canEditHost'],
+  canEditHostname?: HostsTableActions['canEditHostname'],
   canEditBMH?: HostsTableActions['canEditBMH'],
 ): TableRow<Host> => ({
   header: {

--- a/libs/ui-lib/lib/common/components/hosts/tableUtils.tsx
+++ b/libs/ui-lib/lib/common/components/hosts/tableUtils.tsx
@@ -80,7 +80,7 @@ export const hostnameColumn = (
             inventory={inventory}
             onEditHostname={editHostname}
             hosts={hosts}
-            readonly={canEditHostname ? !canEditHostname() : false}
+            readonly={canEditHostname ? !canEditHostname(host) : false}
           />
         ),
         props: { 'data-testid': 'host-name' },

--- a/libs/ui-lib/lib/common/components/hosts/types.ts
+++ b/libs/ui-lib/lib/common/components/hosts/types.ts
@@ -47,7 +47,7 @@ export type HostsTableActions = {
   onEditBMH?: (host: Host) => void;
   canEditBMH?: (host: Host) => ActionCheck;
   onSelect?: (host: Host, selected: boolean) => void;
-  canEditHostname?: () => boolean;
+  canEditHostname?: (host?: Host) => boolean;
   canUnbindHost?: (host: Host) => ActionCheck;
   onUnbindHost?: (host: Host) => void;
   onExcludedODF?: (

--- a/libs/ui-lib/lib/common/components/hosts/utils.ts
+++ b/libs/ui-lib/lib/common/components/hosts/utils.ts
@@ -80,8 +80,19 @@ export const canEditRole = (
   isSNO?: boolean,
 ) => canEditHost(clusterStatus, status) && !isSNO;
 
-export const canEditHostname = (clusterStatus: Cluster['status']) =>
-  ['insufficient', 'adding-hosts', 'ready', 'pending-for-input'].includes(clusterStatus);
+export const canEditHostname = (clusterStatus: Cluster['status'], host?: Host) => {
+  // First check if the cluster status allows hostname editing
+  if (!['insufficient', 'adding-hosts', 'ready', 'pending-for-input'].includes(clusterStatus)) {
+    return false;
+  }
+
+  // For Day2 hosts, also check the host status
+  if (host && host.kind === 'AddToExistingClusterHost') {
+    return canHostnameBeChanged(host.status);
+  }
+
+  return true;
+};
 
 export const canEditDisks = canEditHost;
 

--- a/libs/ui-lib/lib/ocm/components/hosts/use-hosts-table.tsx
+++ b/libs/ui-lib/lib/ocm/components/hosts/use-hosts-table.tsx
@@ -263,7 +263,7 @@ export const useHostsTable = (cluster: Cluster) => {
       canDelete: (host: Host) => !isViewerMode && canDeleteUtil(cluster.status, host.status),
       canEditHost: (host: Host) => !isViewerMode && canEditHostUtil(cluster.status, host.status),
       canReset: (host: Host) => !isViewerMode && canResetUtil(cluster.status, host.status),
-      canEditHostname: () => !isViewerMode && canEditHostnameUtil(cluster.status),
+      canEditHostname: (host?: Host) => !isViewerMode && canEditHostnameUtil(cluster.status, host),
     }),
     [cluster, isViewerMode, isSingleClusterFeatureEnabled],
   );


### PR DESCRIPTION
Prevents being able to rename a Day2 host after it started installing.

Note: I couldn't test the part after the Day2 host started installing, as my host was not getting Ready for installation.
From the documentation, it seems like it should behave correctly.