### PR TITLE
MGMT-21111: Refresh clusters automatically every minute

### DIFF
--- a/libs/ui-lib/lib/common/components/fetching/EventListFetch.tsx
+++ b/libs/ui-lib/lib/common/components/fetching/EventListFetch.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import omit from 'lodash-es/omit.js';
 import { Pagination, PaginationVariant } from '@patternfly/react-core';
 import { EventList } from '@openshift-assisted/types/assisted-installer-service';
-import { EVENTS_POLLING_INTERVAL } from '../../config';
+import { REDUCED_POLLING_INTERVAL } from '../../config';
 import { ClusterEventsFiltersType, EventListFetchProps } from '../../types';
 import { useStateSafely } from '../../hooks';
 import { ErrorState, LoadingState } from '../ui/uiState';
@@ -72,7 +72,7 @@ export const EventListFetch = ({
         setLoading(false);
         setTotalEvents(totalEvents);
         setSeverityCount(severities);
-        timer = setTimeout(() => setLastPolling(Date.now()), EVENTS_POLLING_INTERVAL);
+        timer = setTimeout(() => setLastPolling(Date.now()), REDUCED_POLLING_INTERVAL);
       },
       (err: string) => {
         setError(err);

--- a/libs/ui-lib/lib/common/config/constants.ts
+++ b/libs/ui-lib/lib/common/config/constants.ts
@@ -12,8 +12,8 @@ import { ValidationGroup as ClusterValidationGroup } from '../types/clusters';
 import buildManifest from '@openshift-assisted/ui-lib/package.json';
 import { isInOcm } from '../api/axiosClient';
 
-export const POLLING_INTERVAL = 10 * 1000;
-export const EVENTS_POLLING_INTERVAL = 10 * 1000 * 6;
+export const DEFAULT_POLLING_INTERVAL = 10 * 1000;
+export const REDUCED_POLLING_INTERVAL = 10 * 1000 * 6;
 
 export const hostRoles = (t: TFunction): HostRole[] => [
   {

--- a/libs/ui-lib/lib/ocm/components/HostsClusterDetailTab/HostsClusterDetailTabContent.tsx
+++ b/libs/ui-lib/lib/ocm/components/HostsClusterDetailTab/HostsClusterDetailTabContent.tsx
@@ -5,7 +5,7 @@ import {
   CpuArchitecture,
   ErrorState,
   LoadingState,
-  POLLING_INTERVAL,
+  DEFAULT_POLLING_INTERVAL,
 } from '../../../common';
 import { usePullSecret } from '../../hooks';
 import { Button, EmptyStateVariant } from '@patternfly/react-core';
@@ -134,7 +134,7 @@ export const HostsClusterDetailTabContent = ({
   React.useEffect(() => {
     const id = setInterval(() => {
       void refreshCluster();
-    }, POLLING_INTERVAL);
+    }, DEFAULT_POLLING_INTERVAL);
     return () => clearInterval(id);
   }, [refreshCluster]);
 

--- a/libs/ui-lib/lib/ocm/components/clusters/Clusters.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusters/Clusters.tsx
@@ -17,6 +17,7 @@ import {
   EmptyState,
   useAlerts,
   AlertsContextProvider,
+  REDUCED_POLLING_INTERVAL,
 } from '../../../common';
 import ClustersTable from './ClustersTable';
 import { fetchClustersAsync, deleteCluster } from '../../store/slices/clusters/slice';
@@ -62,8 +63,17 @@ const Clusters = () => {
   );
 
   const fetchClusters = React.useCallback(() => void dispatch(fetchClustersAsync()), [dispatch]);
+
   React.useEffect(() => {
+    // Fetch immediately on mount
     fetchClusters();
+
+    // Set up polling for subsequent updates
+    const timer = setInterval(() => {
+      fetchClusters();
+    }, REDUCED_POLLING_INTERVAL);
+
+    return () => clearInterval(timer);
   }, [fetchClusters]);
 
   switch (uiState.current) {

--- a/libs/ui-lib/lib/ocm/components/clusters/clusterPolling.ts
+++ b/libs/ui-lib/lib/ocm/components/clusters/clusterPolling.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ResourceUIState, POLLING_INTERVAL } from '../../../common';
+import { ResourceUIState, DEFAULT_POLLING_INTERVAL } from '../../../common';
 import {
   fetchClusterAsync,
   cleanCluster,
@@ -53,7 +53,7 @@ export const useClusterPolling = (
 
   React.useEffect(() => {
     fetchCluster();
-    const timer = window.setInterval(() => dispatch(forceReload()), POLLING_INTERVAL);
+    const timer = window.setInterval(() => dispatch(forceReload()), DEFAULT_POLLING_INTERVAL);
     return () => {
       clearInterval(timer);
       dispatch(cancelForceReload());


### PR DESCRIPTION
Adds polling to the list of clusters so users don't need to manually refresh the page if they create clusters via a method other than the UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced automatic periodic refreshing of cluster data in the clusters view.

* **Refactor**
  * Updated polling intervals throughout the application to use newly named constants for consistency.
  * Adjusted polling frequencies for event and cluster data fetching to align with the updated intervals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->