### PR TITLE
MGMT-21123: Add option to start a new chat from scratch

### DIFF
--- a/libs/chatbot/lib/components/ChatBot/ChatBot.tsx
+++ b/libs/chatbot/lib/components/ChatBot/ChatBot.tsx
@@ -24,6 +24,11 @@ const ChatBot = ({ onApiCall, username }: ChatBotProps) => {
           messages={messages}
           conversationId={conversationId}
           setConversationId={setConversationId}
+          onClose={() => {
+            setChatbotVisible(false);
+            setMessages([]);
+            setConversationId(undefined);
+          }}
           onApiCall={onApiCall}
           username={username}
         />

--- a/libs/chatbot/lib/components/ChatBot/ChatBotWindow.tsx
+++ b/libs/chatbot/lib/components/ChatBot/ChatBotWindow.tsx
@@ -7,13 +7,23 @@ import {
   ChatbotDisplayMode,
   ChatbotFooter,
   ChatbotFootnote,
+  ChatbotHeader,
+  ChatbotHeaderTitle,
   ChatbotWelcomePrompt,
   Message,
   MessageBar,
   MessageBox,
 } from '@patternfly-6/chatbot';
-import { Alert, AlertActionCloseButton, Button } from '@patternfly-6/react-core';
+import {
+  Alert,
+  AlertActionCloseButton,
+  Button,
+  Flex,
+  FlexItem,
+  Tooltip,
+} from '@patternfly-6/react-core';
 import { ExternalLinkAltIcon } from '@patternfly-6/react-icons/dist/js/icons/external-link-alt-icon';
+import { PlusIcon, TimesIcon } from '@patternfly-6/react-icons';
 
 import AIAvatar from '../../assets/rh-logo.svg';
 import UserAvatar from '../../assets/avatarimg.svg';
@@ -39,11 +49,12 @@ type MsgProps = React.ComponentProps<typeof Message>;
 
 export type ChatBotWindowProps = {
   conversationId: string | undefined;
-  setConversationId: (id: string) => void;
+  setConversationId: (id: string | undefined) => void;
   setMessages: React.Dispatch<React.SetStateAction<MsgProps[]>>;
   messages: MsgProps[];
   onApiCall: typeof fetch;
   username: string;
+  onClose: () => void;
 };
 
 const ChatBotWindow = ({
@@ -52,6 +63,7 @@ const ChatBotWindow = ({
   messages,
   setMessages,
   onApiCall,
+  onClose,
   username,
 }: ChatBotWindowProps) => {
   const [error, setError] = React.useState<string>();
@@ -62,6 +74,10 @@ const ChatBotWindow = ({
     localStorage.getItem(CHAT_ALERT_LOCAL_STORAGE_KEY) !== 'true',
   );
   const scrollToBottomRef = React.useRef<HTMLDivElement>(null);
+  const handleNewChat = () => {
+    setConversationId(undefined);
+    setMessages([]);
+  };
 
   const handleSend = async (message: string | number) => {
     setError(undefined);
@@ -172,6 +188,37 @@ const ChatBotWindow = ({
 
   return (
     <Chatbot displayMode={ChatbotDisplayMode.default}>
+      <ChatbotHeader>
+        <ChatbotHeaderTitle>
+          <Flex
+            justifyContent={{ default: 'justifyContentSpaceBetween' }}
+            className="pf-v6-u-w-100"
+          >
+            <FlexItem>
+              <Tooltip content="New chat">
+                <Button
+                  variant="plain"
+                  aria-label="New chat"
+                  id="new-chat-button"
+                  icon={<PlusIcon size={40} />}
+                  onClick={handleNewChat}
+                />
+              </Tooltip>
+            </FlexItem>
+            <FlexItem>
+              <Tooltip content="Close chat">
+                <Button
+                  variant="plain"
+                  aria-label="Close chat"
+                  id="close-chat-button"
+                  icon={<TimesIcon size={40} />}
+                  onClick={onClose}
+                />
+              </Tooltip>
+            </FlexItem>
+          </Flex>
+        </ChatbotHeaderTitle>
+      </ChatbotHeader>
       <ChatbotContent>
         <MessageBox announcement={announcement} position={'top'}>
           {isAlertVisible && (


### PR DESCRIPTION
Adds the ChatbotHeader with two actions:

- New chat: clears the existing conversation, and displays the greeting to start a new conversation.
- Close: closes the Chatbot. It deletes the current conversation, contrary to the icon to collapse the Chatbot.

https://github.com/user-attachments/assets/a2399b4e-a341-43a0-8735-a51d6c29b118

