### PR TITLE
MGMT-20897: Add new Openshift AI - no GPU validation

### DIFF
--- a/libs/types/assisted-installer-service.d.ts
+++ b/libs/types/assisted-installer-service.d.ts
@@ -673,6 +673,7 @@ export type ClusterValidationId =
   | 'servicemesh-requirements-satisfied'
   | 'serverless-requirements-satisfied'
   | 'openshift-ai-requirements-satisfied'
+  | 'openshift-ai-gpu-requirements-satisfied'
   | 'authorino-requirements-satisfied'
   | 'nmstate-requirements-satisfied'
   | 'amd-gpu-requirements-satisfied'
@@ -1071,7 +1072,6 @@ export type FeatureSupportLevelId =
   | 'EXTERNAL_PLATFORM_OCI'
   | 'DUAL_STACK'
   | 'PLATFORM_MANAGED_NETWORKING'
-  | 'SKIP_MCO_REBOOT'
   | 'EXTERNAL_PLATFORM'
   | 'OVN_NETWORK_TYPE'
   | 'SDN_NETWORK_TYPE'
@@ -2928,6 +2928,10 @@ export interface VersionedHostRequirements {
    * Master node requirements
    */
   master?: ClusterHostRequirementsDetails;
+  /**
+   * Arbiter node requirements
+   */
+  arbiter?: ClusterHostRequirementsDetails;
   /**
    * Worker node requirements
    */

--- a/libs/ui-lib/lib/ocm/components/clusterWizard/wizardTransition.ts
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/wizardTransition.ts
@@ -191,7 +191,12 @@ const hostDiscoveryStepValidationsMap: WizardStepValidationMap = {
       'amd-gpu-requirements-satisfied',
     ],
   },
-  softValidationIds: ['no-skip-installation-disk', 'no-skip-missing-disk', 'compatible-agent'],
+  softValidationIds: [
+    'no-skip-installation-disk',
+    'no-skip-missing-disk',
+    'compatible-agent',
+    'openshift-ai-gpu-requirements-satisfied',
+  ],
 };
 
 const storageStepValidationsMap: WizardStepValidationMap = {


### PR DESCRIPTION
Related with https://issues.redhat.com/browse/MGMT-20897

Add a cluster validation for openshift-ai.

If the cluster has no GPU, a warning in the front should be displayed.
This validation appears in "Host Discovery" step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for GPU requirements validation in the cluster wizard.

* **Improvements**
  * Introduced arbiter node requirements to cluster host requirements details.

* **Other Changes**
  * Removed an outdated feature support level related to skipping MCO reboot.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->