### PR TITLE
MGMT-21223 change buttons behaviour

### DIFF
--- a/libs/chatbot/lib/components/ChatBot/ChatBot.tsx
+++ b/libs/chatbot/lib/components/ChatBot/ChatBot.tsx
@@ -26,8 +26,6 @@ const ChatBot = ({ onApiCall, username }: ChatBotProps) => {
           setConversationId={setConversationId}
           onClose={() => {
             setChatbotVisible(false);
-            setMessages([]);
-            setConversationId(undefined);
           }}
           onApiCall={onApiCall}
           username={username}

--- a/libs/chatbot/lib/components/ChatBot/ChatBotWindow.tsx
+++ b/libs/chatbot/lib/components/ChatBot/ChatBotWindow.tsx
@@ -26,6 +26,7 @@ import { ExternalLinkAltIcon } from '@patternfly-6/react-icons/dist/js/icons/ext
 import { PlusIcon, TimesIcon } from '@patternfly-6/react-icons';
 
 import BotMessage, { FeedbackRequest } from './BotMessage';
+import ConfirmNewChatModal from './ConfirmNewChatModal';
 import AIAvatar from '../../assets/rh-logo.svg';
 import UserAvatar from '../../assets/avatarimg.svg';
 
@@ -96,10 +97,22 @@ const ChatBotWindow = ({
   const [isAlertVisible, setIsAlertVisible] = React.useState(
     localStorage.getItem(CHAT_ALERT_LOCAL_STORAGE_KEY) !== 'true',
   );
+  const [isConfirmModalOpen, setIsConfirmModalOpen] = React.useState(false);
   const scrollToBottomRef = React.useRef<HTMLDivElement>(null);
-  const handleNewChat = () => {
+
+  const startNewChat = () => {
     setConversationId(undefined);
     setMessages([]);
+    setIsConfirmModalOpen(false);
+  };
+
+  const handleNewChat = () => {
+    // Only show confirmation if there are existing messages
+    if (messages.length > 0) {
+      setIsConfirmModalOpen(true);
+    } else {
+      startNewChat();
+    }
   };
 
   const scrollToBottom = React.useCallback(() => {
@@ -362,6 +375,12 @@ const ChatBotWindow = ({
           }}
         />
       </ChatbotFooter>
+      {isConfirmModalOpen && (
+        <ConfirmNewChatModal
+          onConfirm={startNewChat}
+          onCancel={() => setIsConfirmModalOpen(false)}
+        />
+      )}
     </Chatbot>
   );
 };

--- a/libs/chatbot/lib/components/ChatBot/ConfirmNewChatModal.tsx
+++ b/libs/chatbot/lib/components/ChatBot/ConfirmNewChatModal.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react';
+import {
+  Button,
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  ModalVariant,
+} from '@patternfly-6/react-core';
+
+const ConfirmNewChatModal = ({
+  onConfirm,
+  onCancel,
+}: {
+  onConfirm: VoidFunction;
+  onCancel: VoidFunction;
+}) => {
+  return (
+    <Modal variant={ModalVariant.small} isOpen onClose={onCancel}>
+      <ModalHeader title="Start a new chat?" />
+      <ModalBody>
+        Starting a new chat will permanently erase your current conversation. If you want to save
+        any information, please copy it before proceeding.
+      </ModalBody>
+      <ModalFooter>
+        <Button variant="link" onClick={onCancel}>
+          Cancel
+        </Button>
+        <Button variant="danger" onClick={onConfirm}>
+          Erase and start a new chat
+        </Button>
+      </ModalFooter>
+    </Modal>
+  );
+};
+
+export default ConfirmNewChatModal;


### PR DESCRIPTION
- Closing the chat does not clear the current conversation
- New chat asks for confirmation to the user.

https://github.com/user-attachments/assets/62cb4fe2-0a6b-4a6f-85e8-ef55cf6a4b84



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a confirmation dialog when starting a new chat session if there are existing messages, helping prevent accidental loss of chat history.
  * Introduced a warning modal that informs users that starting a new chat will erase the current conversation and allows them to cancel or proceed.

* **Behavior Changes**
  * Closing the chatbot window no longer clears the conversation or resets the chat session; messages and session state are preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->