### PR TITLE
MGMT-19730: Search in host inventory does not work as expected

### DIFF
--- a/libs/ui-lib/lib/cim/components/Agent/tableUtils.tsx
+++ b/libs/ui-lib/lib/cim/components/Agent/tableUtils.tsx
@@ -556,10 +556,10 @@ export const filterHosts = (
   hostnameFilter: string | undefined,
   statusFilter: string[],
 ) => {
-  const byHostname = filterByHostname(hosts, hostnameFilter);
+  const { hosts: byHostname, sorted } = filterByHostname(hosts, hostnameFilter);
   const byStatus = filterByStatus(byHostname, agents, agentStatuses, bareMetalHosts, statusFilter);
 
-  return byStatus;
+  return { hosts: byStatus, sorted };
 };
 
 type UseAgentsFilterArgs = {
@@ -597,7 +597,7 @@ export const useAgentsFilter = ({
     }
   });
 
-  const filteredHosts = filterHosts(
+  const { hosts: filteredHosts, sorted } = filterHosts(
     hosts,
     agents,
     agentStatuses,
@@ -613,5 +613,6 @@ export const useAgentsFilter = ({
     statusFilter,
     setStatusFilter,
     filteredHosts,
+    sorted,
   };
 };

--- a/libs/ui-lib/lib/cim/components/InfraEnv/InfraEnvAgentTable.tsx
+++ b/libs/ui-lib/lib/cim/components/InfraEnv/InfraEnvAgentTable.tsx
@@ -123,6 +123,7 @@ const InfraEnvAgentTable: React.FC<InfraEnvAgentTableProps> = ({
     setStatusFilter,
     statusFilter,
     filteredHosts: hosts,
+    sorted,
   } = useAgentsFilter({
     agents,
     agentStatuses,
@@ -226,6 +227,7 @@ const InfraEnvAgentTable: React.FC<InfraEnvAgentTableProps> = ({
         <StackItem>
           <HostsTable
             hosts={hosts}
+            relevanceSorted={sorted}
             content={content}
             actionResolver={actionResolver}
             selectedIDs={selectedHostIDs}

--- a/libs/ui-lib/lib/cim/components/InfraEnv/InfraEnvAgentTable.tsx
+++ b/libs/ui-lib/lib/cim/components/InfraEnv/InfraEnvAgentTable.tsx
@@ -227,7 +227,7 @@ const InfraEnvAgentTable: React.FC<InfraEnvAgentTableProps> = ({
         <StackItem>
           <HostsTable
             hosts={hosts}
-            relevanceSorted={sorted}
+            alreadySorted={sorted}
             content={content}
             actionResolver={actionResolver}
             selectedIDs={selectedHostIDs}

--- a/libs/ui-lib/lib/common/components/hosts/AITable.tsx
+++ b/libs/ui-lib/lib/common/components/hosts/AITable.tsx
@@ -80,7 +80,7 @@ export type AITableProps<R> = ReturnType<typeof usePagination> & {
   actionResolver?: ActionsResolver<R>;
   canSelectAll?: boolean;
   variant?: TableProps['variant'];
-  relevanceSorted?: boolean;
+  alreadySorted?: boolean;
 };
 
 // eslint-disable-next-line
@@ -104,7 +104,7 @@ const AITable = <R extends any>({
   perPageOptions,
   canSelectAll,
   variant,
-  relevanceSorted,
+  alreadySorted,
 }: WithTestID & AITableProps<R>) => {
   const itemIDs = React.useMemo(() => data.map(getDataId), [data, getDataId]);
   const [openRows, setOpenRows] = React.useState<OpenRows>({});
@@ -136,7 +136,7 @@ const AITable = <R extends any>({
   }, [data, setSelectedIDs, selectedIDs, getDataId]);
 
   React.useEffect(() => {
-    if (relevanceSorted) {
+    if (alreadySorted) {
       sortByRef.current = sortBy;
       setSortBy({
         index: -1,
@@ -148,15 +148,15 @@ const AITable = <R extends any>({
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [relevanceSorted]);
+  }, [alreadySorted]);
 
   React.useEffect(() => {
-    if (!relevanceSorted) {
+    if (!alreadySorted) {
       sortByRef.current = sortBy;
-    } else if (relevanceSorted && sortBy.index !== -1) {
+    } else if (alreadySorted && sortBy.index !== -1) {
       sortByRef.current = sortBy;
     }
-  }, [sortBy, relevanceSorted]);
+  }, [sortBy, alreadySorted]);
 
   const onSelectAll = React.useCallback(
     (isChecked: boolean) => {
@@ -244,13 +244,13 @@ const AITable = <R extends any>({
   }, []);
 
   const sortedRows = React.useMemo(() => {
-    if (relevanceSorted && sortBy.index === -1) {
+    if (alreadySorted && sortBy.index === -1) {
       return getRows(data);
     }
     return rows.sort(
       rowSorter(sortBy, (row: IRow, index = 0) => row.cells?.[index] as string | HumanizedSortable),
     );
-  }, [relevanceSorted, sortBy, rows, getRows, data]);
+  }, [alreadySorted, sortBy, rows, getRows, data]);
 
   return (
     <>

--- a/libs/ui-lib/lib/common/components/hosts/HostsTable.tsx
+++ b/libs/ui-lib/lib/common/components/hosts/HostsTable.tsx
@@ -60,7 +60,7 @@ type HostsTableProps = ReturnType<typeof usePagination> &
     | 'variant'
   > & {
     hosts: Host[];
-    relevanceSorted?: boolean;
+    alreadySorted?: boolean;
     skipDisabled?: boolean;
     children: React.ReactNode;
   };
@@ -68,7 +68,7 @@ type HostsTableProps = ReturnType<typeof usePagination> &
 const HostsTable = ({
   hosts,
   skipDisabled,
-  relevanceSorted,
+  alreadySorted,
   ...rest
 }: HostsTableProps & WithTestID) => {
   const data = React.useMemo(() => {
@@ -76,15 +76,15 @@ const HostsTable = ({
       (host) => !skipDisabled || host.status !== 'disabled',
     );
 
-    return relevanceSorted
+    return alreadySorted
       ? filteredHosts
       : filteredHosts.sort((a, b) =>
           a.createdAt && b.createdAt && a.createdAt < b.createdAt ? -1 : 1,
         );
-  }, [hosts, skipDisabled, relevanceSorted]);
+  }, [hosts, skipDisabled, alreadySorted]);
 
   return (
-    <AITable<Host> getDataId={getHostId} data={data} relevanceSorted={relevanceSorted} {...rest} />
+    <AITable<Host> getDataId={getHostId} data={data} alreadySorted={alreadySorted} {...rest} />
   );
 };
 

--- a/libs/ui-lib/lib/common/components/hosts/HostsTable.tsx
+++ b/libs/ui-lib/lib/common/components/hosts/HostsTable.tsx
@@ -60,20 +60,32 @@ type HostsTableProps = ReturnType<typeof usePagination> &
     | 'variant'
   > & {
     hosts: Host[];
+    relevanceSorted?: boolean;
     skipDisabled?: boolean;
     children: React.ReactNode;
   };
 
-const HostsTable = ({ hosts, skipDisabled, ...rest }: HostsTableProps & WithTestID) => {
-  const data = React.useMemo(
-    () =>
-      (hosts || [])
-        .filter((host) => !skipDisabled || host.status !== 'disabled')
-        .sort((a, b) => (a.createdAt && b.createdAt && a.createdAt < b.createdAt ? -1 : 1)),
-    [hosts, skipDisabled],
-  );
+const HostsTable = ({
+  hosts,
+  skipDisabled,
+  relevanceSorted,
+  ...rest
+}: HostsTableProps & WithTestID) => {
+  const data = React.useMemo(() => {
+    const filteredHosts = (hosts || []).filter(
+      (host) => !skipDisabled || host.status !== 'disabled',
+    );
 
-  return <AITable<Host> getDataId={getHostId} data={data} {...rest} />;
+    return relevanceSorted
+      ? filteredHosts
+      : filteredHosts.sort((a, b) =>
+          a.createdAt && b.createdAt && a.createdAt < b.createdAt ? -1 : 1,
+        );
+  }, [hosts, skipDisabled, relevanceSorted]);
+
+  return (
+    <AITable<Host> getDataId={getHostId} data={data} relevanceSorted={relevanceSorted} {...rest} />
+  );
 };
 
 export default HostsTable;

--- a/libs/ui-lib/lib/common/components/hosts/utils.ts
+++ b/libs/ui-lib/lib/common/components/hosts/utils.ts
@@ -207,7 +207,7 @@ export const getInventory = (host: Host) => {
 
 export const filterByHostname = (hosts: Host[], hostnameFilter: string | undefined) => {
   if (!hostnameFilter) {
-    return hosts;
+    return { hosts, sorted: false };
   }
   const hostsWithHostname = hosts.map((host) => {
     const { inventory: inventoryString = '' } = host;
@@ -220,12 +220,28 @@ export const filterByHostname = (hosts: Host[], hostnameFilter: string | undefin
   });
 
   const fuse = new Fuse(hostsWithHostname, {
+    includeScore: true,
     ignoreLocation: true,
     threshold: 0.3,
     keys: ['hostname'],
   });
 
-  return fuse.search(hostnameFilter).map(({ item }) => item.host);
+  const filteredHosts = fuse.search(hostnameFilter);
+
+  const sortedHosts = filteredHosts
+    .sort((a, b) => (a.score || 0) - (b.score || 0))
+    .map(({ item }) => item.host);
+
+  const sorted =
+    filteredHosts.length > 1 &&
+    filteredHosts.some(
+      (result, index) => index > 0 && (result.score || 0) !== (filteredHosts[0].score || 0),
+    );
+
+  return {
+    hosts: sortedHosts,
+    sorted,
+  };
 };
 
 export const getFailingHostValidations = (validationsInfo: HostValidationsInfo) =>


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-19730

Bringing the filtering and sorting behaviours of the InfraEnv host table closer to ACM's:

- When a user puts in a hostname filter, the results are sorted by relevancy
- Any previous sorting is saved and restored if the filter is removed
- If any sorting is done after filtering, it is kept when the filter is removed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a "relevance" sorting mode in host tables, enabling fuzzy hostname search results to be sorted by relevance.
  * Host tables now indicate when results are sorted by relevance and disable column-based sorting in that mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->