### PR TITLE
MGMT-21259: Do not animate scroll when chat is reopened

### DIFF
--- a/libs/chatbot/lib/components/ChatBot/ChatBotWindow.tsx
+++ b/libs/chatbot/lib/components/ChatBot/ChatBotWindow.tsx
@@ -99,6 +99,7 @@ const ChatBotWindow = ({
   );
   const [isConfirmModalOpen, setIsConfirmModalOpen] = React.useState(false);
   const scrollToBottomRef = React.useRef<HTMLDivElement>(null);
+  const hasInitiallyScrolled = React.useRef(false);
 
   const startNewChat = () => {
     setConversationId(undefined);
@@ -115,9 +116,16 @@ const ChatBotWindow = ({
     }
   };
 
-  const scrollToBottom = React.useCallback(() => {
-    scrollToBottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+  const scrollToBottom = React.useCallback((behavior: ScrollBehavior = 'smooth') => {
+    scrollToBottomRef.current?.scrollIntoView({ behavior });
   }, []);
+
+  React.useEffect(() => {
+    // Determine scroll behavior: auto for initial render with existing messages, smooth for new content
+    const scrollBehavior = !hasInitiallyScrolled.current && messages.length > 0 ? 'auto' : 'smooth';
+    scrollToBottom(scrollBehavior);
+    hasInitiallyScrolled.current = true;
+  }, [messages, scrollToBottom]);
 
   const handleSend = async (message: string | number) => {
     setError(undefined);
@@ -252,10 +260,6 @@ const ChatBotWindow = ({
     },
     [onApiCall, conversationId, messages],
   );
-
-  React.useEffect(() => {
-    scrollToBottomRef.current?.scrollIntoView({ behavior: 'smooth' });
-  }, [messages]);
 
   return (
     <Chatbot displayMode={ChatbotDisplayMode.default}>


### PR DESCRIPTION
When users open an existing chat, do not animate scrolling to the bottom.
We still scroll to the bottom in case they want to continue the conversation.

https://github.com/user-attachments/assets/c54f1ec9-bdab-4de2-83aa-808d692d301f



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved chat window scrolling for a smoother user experience: the window now scrolls instantly to the latest message on initial load and smoothly for new incoming messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->