### PR TITLE
MGMT-21260 focus input on new chat

### DIFF
--- a/libs/chatbot/lib/components/ChatBot/ChatBotWindow.tsx
+++ b/libs/chatbot/lib/components/ChatBot/ChatBotWindow.tsx
@@ -49,6 +49,7 @@ const getErrorMessage = (error: unknown) => {
 };
 
 const CHAT_ALERT_LOCAL_STORAGE_KEY = 'assisted.hide.chat.alert';
+const MESSAGE_BAR_ID = 'assisted-chatbot__message-bar';
 
 type MsgProps = React.ComponentProps<typeof Message>;
 
@@ -104,6 +105,13 @@ const ChatBotWindow = ({
     setConversationId(undefined);
     setMessages([]);
     setIsConfirmModalOpen(false);
+    // Focus the input field after starting a new chat
+    requestAnimationFrame(() => {
+      const inputElement = document.querySelector(`#${MESSAGE_BAR_ID}`) as HTMLElement;
+      if (inputElement) {
+        inputElement.focus();
+      }
+    });
   };
 
   const handleNewChat = () => {
@@ -363,6 +371,7 @@ const ChatBotWindow = ({
       </ChatbotContent>
       <ChatbotFooter>
         <MessageBar
+          id={MESSAGE_BAR_ID}
           onSendMessage={(msg) => void handleSend(msg)}
           isSendButtonDisabled={isLoading || isStreaming}
           hasAttachButton={false}

--- a/libs/chatbot/lib/components/ChatBot/ChatBotWindow.tsx
+++ b/libs/chatbot/lib/components/ChatBot/ChatBotWindow.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import isString from 'lodash-es/isString.js';
 import {
   Chatbot,
   ChatbotAlert,
@@ -23,10 +22,20 @@ import {
   Tooltip,
 } from '@patternfly-6/react-core';
 import { ExternalLinkAltIcon } from '@patternfly-6/react-icons/dist/js/icons/external-link-alt-icon';
-import { PlusIcon, TimesIcon } from '@patternfly-6/react-icons';
+import { PlusIcon } from '@patternfly-6/react-icons/dist/js/icons/plus-icon';
+import { TimesIcon } from '@patternfly-6/react-icons/dist/js/icons/times-icon';
 
 import BotMessage, { FeedbackRequest } from './BotMessage';
 import ConfirmNewChatModal from './ConfirmNewChatModal';
+import {
+  focusSendMessageInput as focusNewMessageBox,
+  getErrorMessage,
+  getUserQuestionForBotAnswer,
+  MESSAGE_BAR_ID,
+  botRole,
+  userRole,
+  MsgProps,
+} from './helpers';
 import AIAvatar from '../../assets/rh-logo.svg';
 import UserAvatar from '../../assets/avatarimg.svg';
 
@@ -35,23 +44,7 @@ type StreamEvent =
   | { event: 'token'; data: { token: string; role: string } }
   | { event: 'end' };
 
-const botRole = 'bot';
-const userRole = 'user';
-
-const getErrorMessage = (error: unknown) => {
-  if (error instanceof Error) {
-    return error.message;
-  }
-  if (isString(error)) {
-    return error;
-  }
-  return 'Unexpected error';
-};
-
 const CHAT_ALERT_LOCAL_STORAGE_KEY = 'assisted.hide.chat.alert';
-const MESSAGE_BAR_ID = 'assisted-chatbot__message-bar';
-
-type MsgProps = React.ComponentProps<typeof Message>;
 
 export type ChatBotWindowProps = {
   conversationId: string | undefined;
@@ -61,25 +54,6 @@ export type ChatBotWindowProps = {
   onApiCall: typeof fetch;
   username: string;
   onClose: () => void;
-};
-
-// Helper function to get the user question for a bot message
-const getUserQuestionForBotAnswer = (
-  messages: MsgProps[],
-  messageIndex: number,
-): string | undefined => {
-  if (messageIndex === 0) {
-    return undefined;
-  }
-  // Look backwards from the previous message to find the most recent user message
-  for (let i = messageIndex - 1; i >= 0; i--) {
-    const msg = messages[i];
-    if (msg?.role === userRole && msg.content) {
-      return String(msg.content);
-    }
-  }
-
-  return undefined;
 };
 
 const ChatBotWindow = ({
@@ -105,13 +79,7 @@ const ChatBotWindow = ({
     setConversationId(undefined);
     setMessages([]);
     setIsConfirmModalOpen(false);
-    // Focus the input field after starting a new chat
-    requestAnimationFrame(() => {
-      const inputElement = document.querySelector(`#${MESSAGE_BAR_ID}`) as HTMLElement;
-      if (inputElement) {
-        inputElement.focus();
-      }
-    });
+    focusNewMessageBox();
   };
 
   const handleNewChat = () => {

--- a/libs/chatbot/lib/components/ChatBot/helpers.ts
+++ b/libs/chatbot/lib/components/ChatBot/helpers.ts
@@ -1,0 +1,46 @@
+import isString from 'lodash-es/isString.js';
+import { Message } from '@patternfly-6/chatbot';
+
+export type MsgProps = React.ComponentProps<typeof Message>;
+
+export const MESSAGE_BAR_ID = 'assisted-chatbot__message-bar';
+export const botRole = 'bot';
+export const userRole = 'user';
+
+export const getErrorMessage = (error: unknown) => {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (isString(error)) {
+    return error;
+  }
+  return 'Unexpected error';
+};
+
+export const focusSendMessageInput = () => {
+  requestAnimationFrame(() => {
+    const inputElement = document.querySelector(`#${MESSAGE_BAR_ID}`) as HTMLElement;
+    if (inputElement) {
+      inputElement.focus();
+    }
+  });
+};
+
+// Helper function to get the user question for a bot message
+export const getUserQuestionForBotAnswer = (
+  messages: MsgProps[],
+  messageIndex: number,
+): string | undefined => {
+  if (messageIndex === 0) {
+    return undefined;
+  }
+  // Look backwards from the previous message to find the most recent user message
+  for (let i = messageIndex - 1; i >= 0; i--) {
+    const msg = messages[i];
+    if (msg?.role === userRole && msg.content) {
+      return String(msg.content);
+    }
+  }
+
+  return undefined;
+};


### PR DESCRIPTION
When users create a new chat, focus the "Send message" box so they can start typing.
https://github.com/user-attachments/assets/f89b99e8-53fb-4722-8d21-704cf7fc4e5c
<!-- This  is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code organization for chatbot components by moving utility functions and constants into a dedicated helpers module.

* **New Features**
  * Enhanced accessibility and user experience by ensuring the message input is automatically focused when starting a new chat.
  * Added a unique identifier to the message input bar for improved element identification and interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->