### PR TITLE
Define default URL for chatbot API

### DIFF
--- a/apps/assisted-ui/deploy/start.sh
+++ b/apps/assisted-ui/deploy/start.sh
@@ -2,6 +2,7 @@
 set -eo pipefail
 
 export ASSISTED_SERVICE_URL="${ASSISTED_SERVICE_URL:-'http://localhost:8090'}"
+export AIUI_CHAT_API_URL="${AIUI_CHAT_API_URL:-'http://localhost:1234'}"
 
 # shellcheck disable=SC2016
 envsubst '$ASSISTED_SERVICE_URL $AIUI_CHAT_API_URL' < /deploy/nginx.conf > "$NGINX_DEFAULT_CONF_PATH/nginx.conf"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new environment variable for configuring the chat API URL, with a default value provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->