### PR TITLE
MGMT-20575: Add data-testid to items in the cluster events filter

### DIFF
--- a/libs/ui-lib/lib/common/components/ui/ClusterEventsToolbar.tsx
+++ b/libs/ui-lib/lib/common/components/ui/ClusterEventsToolbar.tsx
@@ -244,6 +244,7 @@ const ClusterEventsToolbar = ({
                   onClick={onHostToggle}
                   isExpanded={isHostExpanded}
                   badge={hostChips.length && <Badge isRead>{hostChips.length}</Badge>}
+                  data-testid="cluster-events-hosts-dropdown-button"
                 >
                   <Placeholder text="Hosts" />
                 </MenuToggle>
@@ -253,6 +254,7 @@ const ClusterEventsToolbar = ({
               <DropdownList>
                 <DropdownItem
                   id={`checkbox-${CLUSTER_LEVEL}`}
+                  data-testid="cluster-level-events-filter-option"
                   hasCheckbox
                   isSelected={getSelections().includes(CLUSTER_LEVEL)}
                   key={CLUSTER_LEVEL}
@@ -262,6 +264,7 @@ const ClusterEventsToolbar = ({
                 </DropdownItem>
                 <DropdownItem
                   id={`checkbox-${DELETED_HOSTS}`}
+                  data-testid="deleted-hosts-filter-option"
                   hasCheckbox
                   isSelected={getSelections().includes(DELETED_HOSTS)}
                   key={DELETED_HOSTS}
@@ -272,6 +275,7 @@ const ClusterEventsToolbar = ({
                 {...sortedHosts.map((host) => (
                   <DropdownItem
                     id={`checkbox-${host.id}`}
+                    data-testid={`host-${host.id}-filter-option`}
                     hasCheckbox
                     isSelected={getSelections().includes(host.id)}
                     key={host.id}
@@ -314,6 +318,7 @@ const ClusterEventsToolbar = ({
                 badge={
                   filters.severities?.length && <Badge isRead>{filters.severities.length}</Badge>
                 }
+                data-testid="cluster-events-severity-dropdown-button"
               >
                 <Placeholder text="Severity" />
               </MenuToggle>


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-20575

Add data-test-id tag to the table list items in cluster events filter:
<img width="1352" height="581" alt="image" src="https://github.com/user-attachments/assets/73059fe3-2554-4fc4-87e9-79d1d55bb432" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added test identifiers to various buttons and dropdown items in the Cluster Events Toolbar to improve UI testing reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->