### PR TITLE
AGENT-1260: Switch to rhel-9-base-nodejs-openshift base image

### DIFF
--- a/apps/assisted-disconnected-ui/Containerfile.ocp
+++ b/apps/assisted-disconnected-ui/Containerfile.ocp
@@ -1,6 +1,5 @@
-FROM registry.ci.openshift.org/edge-infrastructure/nodejs-18-minimal:latest as ui-build
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-base-nodejs-openshift-4.19 AS ui-build
 USER root
-RUN microdnf install -y rsync git
 
 WORKDIR /app
 COPY --chown=1001:0 / /app


### PR DESCRIPTION
For nodejs builds switch image from nodejs-18-minimal.