### PR TITLE
Do not push to quay the chatbot releases

### DIFF
--- a/.github/workflows/push-to-master.yaml
+++ b/.github/workflows/push-to-master.yaml
@@ -8,6 +8,7 @@ on:
       - 'v*'
       - '!v*-cim'
       - '!v*-virt'
+      - '!v*-chatbot'
 
 env:
   QUAY_ORG: quay.io/edge-infrastructure


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow triggers to exclude tags matching v*-chatbot from running the “push to master or release tag” pipeline, reducing unnecessary CI runs while preserving existing release and exclusion patterns.
  * No changes to application behavior or public interfaces.
  * No user-facing impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->