### PR TITLE
AGENT-1261: Update dependency sourcing to remote

### DIFF
--- a/apps/assisted-disconnected-ui/Containerfile.ocp
+++ b/apps/assisted-disconnected-ui/Containerfile.ocp
@@ -20,7 +20,7 @@ RUN CACHED_YARN=./artifacts/yarn-${YARN_VERSION}.tar.gz; \
 # As cachito might not be available in all environments, we need to make sure the value is set before trying to use it and
 # that the COPY layer below doesn't fail. Setting it to be the Dockerfile itself is fairly safe, as it will always be
 # available.
-ARG REMOTE_SOURCES=apps/assisted-disconnected-ui/Containerfile
+ARG REMOTE_SOURCES=apps/assisted-disconnected-ui/Containerfile.ocp
 ARG REMOTE_SOURCES_DIR=/remote-sources
 
 COPY $REMOTE_SOURCES $REMOTE_SOURCES_DIR

--- a/apps/assisted-disconnected-ui/Containerfile.ocp
+++ b/apps/assisted-disconnected-ui/Containerfile.ocp
@@ -33,7 +33,7 @@ RUN git config --global --add safe.directory /app
 # use dependencies provided by Cachito
 RUN test -d ${REMOTE_SOURCES_DIR}/cachito-gomod-with-deps || exit 1; \
     cp -f $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/app/{.npmrc,.yarnrc,yarn.lock,registry-ca.pem} . \
- && source ${REMOTE_SOURCES_DIR}/cachito-gomod-with-deps/cachito.env \
+ && . ${REMOTE_SOURCES_DIR}/cachito-gomod-with-deps/cachito.env \
  && yarn install --immutable && yarn build:all
 
 ##################################################
@@ -50,7 +50,7 @@ COPY --from=ui-build ${REMOTE_SOURCES_DIR}/cachito-gomod-with-deps/app/ /app
 USER 0
 # Build deterministically and name the output explicitly
 ENV CGO_ENABLED=0
-RUN source ${REMOTE_SOURCES_DIR}/cachito-gomod-with-deps/cachito.env; \
+RUN . ${REMOTE_SOURCES_DIR}/cachito-gomod-with-deps/cachito.env; \
     if [ -d vendor ]; then export GOFLAGS="-mod=vendor"; fi; \
     go build -o assisted-disconnected-ui .
 

--- a/apps/assisted-disconnected-ui/Containerfile.ocp
+++ b/apps/assisted-disconnected-ui/Containerfile.ocp
@@ -32,7 +32,7 @@ RUN git config --global --add safe.directory /app
 
 # use dependencies provided by Cachito
 RUN test -d ${REMOTE_SOURCES_DIR}/cachito-gomod-with-deps || exit 1; \
-    cp -f $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/app/{.npmrc,.yarnrc,yarn.lock,registry-ca.pem} . \
+    cp -f $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/app/{.yarnrc.yml,yarn.lock,.package.json,apps/assisted-disconnected-ui/package.json} . \
  && . ${REMOTE_SOURCES_DIR}/cachito-gomod-with-deps/cachito.env \
  && yarn install --immutable && yarn build:all
 
@@ -50,14 +50,13 @@ COPY --from=ui-build ${REMOTE_SOURCES_DIR}/cachito-gomod-with-deps/app/ /app
 USER 0
 # Build deterministically and name the output explicitly
 ENV CGO_ENABLED=0
-RUN . ${REMOTE_SOURCES_DIR}/cachito-gomod-with-deps/cachito.env; \
-    if [ -d vendor ]; then export GOFLAGS="-mod=vendor"; fi; \
+RUN if [ -d vendor ]; then export GOFLAGS="-mod=vendor"; fi; \
     go build -o assisted-disconnected-ui .
 
 ##################################################
 #
 # actual base image for final product
-FROM registry.ci.openshift.org/ocp/ubi-micro:9
+FROM registry.ci.openshift.org/ocp/4.20:base-rhel9
 COPY --from=ui-build /app/apps/assisted-disconnected-ui/build /app/proxy/dist
 COPY --from=proxy-build /app/assisted-disconnected-ui /app/proxy
 WORKDIR /app/proxy

--- a/apps/assisted-disconnected-ui/Containerfile.ocp
+++ b/apps/assisted-disconnected-ui/Containerfile.ocp
@@ -1,19 +1,49 @@
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-base-nodejs-openshift-4.19 AS ui-build
+
+# The REMOTE_SOURCES value is set by the build system to indicate the location of the cachito-backed artifacts cache.
+# As cachito might not be available in all environments, we need to make sure the value is set before trying to use it and
+# that the COPY layer below doesn't fail. Setting it to be the Dockerfile itself is fairly safe, as it will always be
+# available.
+ARG REMOTE_SOURCES
+ARG REMOTE_SOURCES_DIR=/remote-sources
+
+COPY $REMOTE_SOURCES $REMOTE_SOURCES_DIR
+
 USER root
 
 WORKDIR /app
-COPY --chown=1001:0 / /app
-RUN ls /app
+COPY --chown=1001:0 . /app
 ENV NODE_OPTIONS='--max-old-space-size=8192'
 RUN git config --global --add safe.directory /app
-RUN npm install -g corepack@0.24.1
-RUN yarn install --immutable && yarn build:all
+
+# bootstrap yarn so we can install and run the other tools.
+USER 0
+ARG YARN_VERSION=v3.4.1
+RUN CACHED_YARN=./artifacts/yarn-${YARN_VERSION}.tar.gz; \
+    if [ -f ${CACHED_YARN} ]; then \
+      npm install -g ${CACHED_YARN}; \
+    else \
+      echo "need yarn at ${CACHED_YARN}"; \
+      exit 1; \
+    fi
+
+# use dependencies provided by Cachito
+RUN test -d ${REMOTE_SOURCES_DIR}/cachito-gomod-with-deps || exit 1; \
+    cp -f $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/app/{.npmrc,.yarnrc,yarn.lock,registry-ca.pem} . \
+ && source ${REMOTE_SOURCES_DIR}/cachito-gomod-with-deps/cachito.env \
+ && yarn install --immutable && yarn build:all
 
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-4.19 as proxy-build
+ARG REMOTE_SOURCES_DIR=/remote-sources
 WORKDIR /app
-COPY apps/assisted-disconnected-ui/proxy /app
+# Use Cachito-provided source + deps for offline build
+COPY --from=ui-build ${REMOTE_SOURCES_DIR}/cachito-gomod-with-deps/app/ /app
 USER 0
-RUN go build
+# Build deterministically and name the output explicitly
+ENV CGO_ENABLED=0
+RUN source ${REMOTE_SOURCES_DIR}/cachito-gomod-with-deps/cachito.env; \
+    if [ -d vendor ]; then export GOFLAGS="-mod=vendor"; fi; \
+    go build -o assisted-disconnected-ui .
 
 FROM registry.ci.openshift.org/ocp/ubi-micro:9
 COPY --from=ui-build /app/apps/assisted-disconnected-ui/build /app/proxy/dist

--- a/apps/assisted-disconnected-ui/Containerfile.ocp
+++ b/apps/assisted-disconnected-ui/Containerfile.ocp
@@ -4,7 +4,7 @@ FROM registry.ci.openshift.org/ocp/builder:rhel-9-base-nodejs-openshift-4.19 AS 
 # As cachito might not be available in all environments, we need to make sure the value is set before trying to use it and
 # that the COPY layer below doesn't fail. Setting it to be the Dockerfile itself is fairly safe, as it will always be
 # available.
-ARG REMOTE_SOURCES
+ARG REMOTE_SOURCES=apps/assisted-disconnected-ui/Containerfile
 ARG REMOTE_SOURCES_DIR=/remote-sources
 
 COPY $REMOTE_SOURCES $REMOTE_SOURCES_DIR
@@ -23,7 +23,7 @@ RUN CACHED_YARN=./artifacts/yarn-${YARN_VERSION}.tar.gz; \
     if [ -f ${CACHED_YARN} ]; then \
       npm install -g ${CACHED_YARN}; \
     else \
-      echo "need yarn at ${CACHED_YARN}"; \
+      npm install https://github.com/yarnpkg/yarn/releases/download/${YARN_VERSION}/yarn-${YARN_VERSION}.tar.gz; \
       exit 1; \
     fi
 

--- a/apps/assisted-disconnected-ui/Containerfile.ocp
+++ b/apps/assisted-disconnected-ui/Containerfile.ocp
@@ -1,4 +1,20 @@
+##################################################
+#
+# nodejs frontend build
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-base-nodejs-openshift-4.19 AS ui-build
+
+USER 0
+
+ARG YARN_VERSION=v3.4.1
+
+# bootstrap yarn so we can install and run the other tools.
+RUN CACHED_YARN=./artifacts/yarn-${YARN_VERSION}.tar.gz; \
+    if [ -f ${CACHED_YARN} ]; then \
+      npm install -g ${CACHED_YARN}; \
+    else \
+      npm install https://github.com/yarnpkg/yarn/releases/download/${YARN_VERSION}/yarn-${YARN_VERSION}.tar.gz; \
+      exit 1; \
+    fi
 
 # The REMOTE_SOURCES value is set by the build system to indicate the location of the cachito-backed artifacts cache.
 # As cachito might not be available in all environments, we need to make sure the value is set before trying to use it and
@@ -9,23 +25,10 @@ ARG REMOTE_SOURCES_DIR=/remote-sources
 
 COPY $REMOTE_SOURCES $REMOTE_SOURCES_DIR
 
-USER root
-
 WORKDIR /app
 COPY --chown=1001:0 . /app
 ENV NODE_OPTIONS='--max-old-space-size=8192'
 RUN git config --global --add safe.directory /app
-
-# bootstrap yarn so we can install and run the other tools.
-USER 0
-ARG YARN_VERSION=v3.4.1
-RUN CACHED_YARN=./artifacts/yarn-${YARN_VERSION}.tar.gz; \
-    if [ -f ${CACHED_YARN} ]; then \
-      npm install -g ${CACHED_YARN}; \
-    else \
-      npm install https://github.com/yarnpkg/yarn/releases/download/${YARN_VERSION}/yarn-${YARN_VERSION}.tar.gz; \
-      exit 1; \
-    fi
 
 # use dependencies provided by Cachito
 RUN test -d ${REMOTE_SOURCES_DIR}/cachito-gomod-with-deps || exit 1; \
@@ -33,9 +36,15 @@ RUN test -d ${REMOTE_SOURCES_DIR}/cachito-gomod-with-deps || exit 1; \
  && source ${REMOTE_SOURCES_DIR}/cachito-gomod-with-deps/cachito.env \
  && yarn install --immutable && yarn build:all
 
+##################################################
+#
+# go backend build
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-4.19 as proxy-build
+
 ARG REMOTE_SOURCES_DIR=/remote-sources
+
 WORKDIR /app
+
 # Use Cachito-provided source + deps for offline build
 COPY --from=ui-build ${REMOTE_SOURCES_DIR}/cachito-gomod-with-deps/app/ /app
 USER 0
@@ -45,6 +54,9 @@ RUN source ${REMOTE_SOURCES_DIR}/cachito-gomod-with-deps/cachito.env; \
     if [ -d vendor ]; then export GOFLAGS="-mod=vendor"; fi; \
     go build -o assisted-disconnected-ui .
 
+##################################################
+#
+# actual base image for final product
 FROM registry.ci.openshift.org/ocp/ubi-micro:9
 COPY --from=ui-build /app/apps/assisted-disconnected-ui/build /app/proxy/dist
 COPY --from=proxy-build /app/assisted-disconnected-ui /app/proxy


### PR DESCRIPTION
Adds a new dockerfile for ART to manage dependencies from REMOTE_SOURCES and CACHED_YARN for the ART builds 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Enabled offline, deterministic container builds using cached/remote-provided dependencies for improved reliability.
  - Consolidated UI assets and backend binary into the final image for consistent runtime behavior.
  - Added build-time validation and safeguards to fail early when required artifacts are missing.
  - Improved build stability via user, environment, and git configuration adjustments.
  - Ensured reproducible binary output and standardized runtime defaults (workdir, port, entry command).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->