### PR TITLE
AGENT-1261: Update dependency sourcing to remote

### DIFF
--- a/apps/assisted-disconnected-ui/Containerfile.ocp
+++ b/apps/assisted-disconnected-ui/Containerfile.ocp
@@ -1,21 +1,48 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-base-nodejs-openshift-4.19 AS ui-build
-USER root
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-base-nodejs-openshift-4.20 AS ui-build
+USER 0
 
 WORKDIR /app
-COPY --chown=1001:0 / /app
-RUN ls /app
+COPY --chown=1001:0 . /app
 ENV NODE_OPTIONS='--max-old-space-size=8192'
 RUN git config --global --add safe.directory /app
-RUN npm install -g corepack@0.24.1
-RUN yarn install --immutable && yarn build:all
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-4.19 as proxy-build
+# The REMOTE_SOURCES value is set by the build system to indicate the location of the cachito-backed artifacts cache.
+# As cachito might not be available in all environments, we need to make sure the value is set before trying to use it and
+# that the COPY layer below doesn't fail. Setting it to be the Dockerfile itself is fairly safe, as it will always be
+# available.
+ARG REMOTE_SOURCES=apps/assisted-disconnected-ui/Containerfile.ocp
+ARG REMOTE_SOURCES_DIR=/tmp/remote-sources
+
+COPY $REMOTE_SOURCES $REMOTE_SOURCES_DIR
+
+ARG YARN_VERSION=v3.4.1
+
+# bootstrap yarn so we can install and run the other tools.
+RUN CACHED_YARN=./artifacts/yarn-${YARN_VERSION}.tar.gz; \
+    if [ -f ${CACHED_YARN} ]; then \
+      # use dependencies provided by Cachito
+      # TBD as ART needs to update yarn version to be able to use here
+      npm install -g ${CACHED_YARN}; \
+      test -d ${REMOTE_SOURCES_DIR}/cachito-gomod-with-deps || exit 1; \
+      cp -f $REMOTE_SOURCES_DIR/cachito-gomod-with-deps/app/{.yarnrc.yml,yarn.lock,.package.json,apps/assisted-disconnected-ui/package.json} . \
+      && . ${REMOTE_SOURCES_DIR}/cachito-gomod-with-deps/cachito.env \
+      && yarn install --immutable && yarn build:all; \
+    else \
+      # For local builds
+      npm install -g corepack@0.24.1; \
+      corepack enable; \
+      corepack prepare yarn@${YARN_VERSION} --activate; \
+      yarn install --immutable && yarn build:all; \
+    fi
+
+FROM registry.access.redhat.com/ubi9/go-toolset:1.22 as proxy-build
 WORKDIR /app
 COPY apps/assisted-disconnected-ui/proxy /app
 USER 0
-RUN go build
+# Build using vendored deps as build system does not have internet access
+RUN export GOFLAGS="-mod=vendor"; go build
 
-FROM registry.ci.openshift.org/ocp/ubi-micro:9
+FROM registry.ci.openshift.org/ocp/4.20:base-rhel9
 COPY --from=ui-build /app/apps/assisted-disconnected-ui/build /app/proxy/dist
 COPY --from=proxy-build /app/assisted-disconnected-ui /app/proxy
 WORKDIR /app/proxy


### PR DESCRIPTION
Update dockerfile for ART to manage dependencies from REMOTE_SOURCES and CACHED_YARN for the ART builds

