### PR TITLE
NO-ISSUE: Update verbiage

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusterWizard/disconnected/ReviewStep.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/disconnected/ReviewStep.tsx
@@ -110,7 +110,7 @@ const ReviewStep = () => {
               </DescriptionListGroup>
               <DescriptionListGroup>
                 <DescriptionListTerm>ISO size</DescriptionListTerm>
-                <DescriptionListDescription>approx. 35GB</DescriptionListDescription>
+                <DescriptionListDescription>approx. 40GB</DescriptionListDescription>
               </DescriptionListGroup>
             </DescriptionList>
           </Grid>


### PR DESCRIPTION
With OCP 4.19.9, the OVE ISO size is approximately 40GB.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected ISO size estimate in the review step UI from “approx. 35GB” to “approx. 40GB” to reflect current requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->