### PR TITLE
ACM-24159: Ability to set up the Hosted Control Plane cluster without worker nodes from ACM UI

### DIFF
--- a/libs/ui-lib/lib/cim/components/Hypershift/modals/ManageHostsModal.tsx
+++ b/libs/ui-lib/lib/cim/components/Hypershift/modals/ManageHostsModal.tsx
@@ -66,7 +66,7 @@ const getPatches = (values: NodePoolFormValues, nodePool: NodePoolK8sResource) =
       );
     }
   } else {
-    if (!!nodePool.spec.replicas) {
+    if (nodePool.spec.replicas !== undefined) {
       patches.push({
         op: 'replace',
         value: values.count,
@@ -127,7 +127,7 @@ const ManageHostsModal = ({
           agentLabels: labelsToFormikValue(
             nodePool.spec.platform?.agent?.agentLabelSelector?.matchLabels || {},
           ),
-          count: nodePool.spec.replicas || 1,
+          count: nodePool.spec.replicas || 0,
           useAutoscaling: !!nodePool.spec.autoScaling,
           autoscaling: {
             minReplicas: nodePool.spec.autoScaling?.min || 1,


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-24159

Additional fix for default values and patch requests in the edit nodepools modal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Manage Hosts modal now correctly handles a replica count of 0.
  * Preserves an explicit 0 in the form instead of defaulting to 1.
  * Ensures updates apply properly when setting replicas to 0, preventing unintended changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->