### PR TITLE
OCPBUGS-62680: Include assisted disconnected UI image in release payload

### DIFF
--- a/apps/assisted-disconnected-ui/Containerfile.ocp
+++ b/apps/assisted-disconnected-ui/Containerfile.ocp
@@ -35,6 +35,9 @@ USER 0
 RUN export GOFLAGS="-mod=vendor"; go build
 
 FROM registry.ci.openshift.org/ocp/4.21:base-rhel9
+
+LABEL io.openshift.release.operator=true
+
 COPY --from=ui-build /app/apps/assisted-disconnected-ui/build /app/proxy/dist
 COPY --from=proxy-build /app/assisted-disconnected-ui /app/proxy
 WORKDIR /app/proxy


### PR DESCRIPTION
To onboard assisted disconnected UI onto OCP, add the `LABEL io.openshift.release.operator=true` so that the image is included in the release payload.

