### PR TITLE
OCPBUGS-86070: Fix disconnected flow version selection — replace hardcoded 4.20 with dynamic dropdown

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusterWizard/ClusterWizardContext.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/ClusterWizardContext.tsx
@@ -18,6 +18,8 @@ export type ClusterWizardContextType = {
   uiSettings?: UISettingsValues;
   installDisconnected: boolean;
   setInstallDisconnected: (enabled: boolean) => void;
+  disconnectedOpenshiftVersion: string;
+  setDisconnectedOpenshiftVersion: (version: string) => void;
 };
 
 export const ClusterWizardContext = React.createContext<ClusterWizardContextType | null>(null);

--- a/libs/ui-lib/lib/ocm/components/clusterWizard/ClusterWizardContextProvider.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/ClusterWizardContextProvider.tsx
@@ -88,6 +88,7 @@ const ClusterWizardContextProvider = ({
   const [connectedWizardStepIds, setWizardStepIds] = React.useState<ClusterWizardStepsType[]>();
   const [wizardPerPage, setWizardPerPage] = React.useState(10);
   const [installDisconnected, setInstallDisconnected] = React.useState(false);
+  const [disconnectedOpenshiftVersion, setDisconnectedOpenshiftVersion] = React.useState('');
   const location = useLocation();
   const locationState = location.state as ClusterWizardFlowStateType | undefined;
   const {
@@ -227,6 +228,8 @@ const ClusterWizardContextProvider = ({
       setWizardPerPage,
       uiSettings,
       updateUISettings,
+      disconnectedOpenshiftVersion,
+      setDisconnectedOpenshiftVersion,
       installDisconnected,
       setInstallDisconnected: (enabled: boolean) => {
         setInstallDisconnected(enabled);
@@ -247,6 +250,7 @@ const ClusterWizardContextProvider = ({
     uiSettings,
     updateUISettings,
     installDisconnected,
+    disconnectedOpenshiftVersion,
     connectedWizardStepIds,
   ]);
 

--- a/libs/ui-lib/lib/ocm/components/clusterWizard/disconnected/BasicStep.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/disconnected/BasicStep.tsx
@@ -2,27 +2,47 @@ import * as React from 'react';
 import {
   ClusterWizardStep,
   TechnologyPreview,
-  ExternalLink,
-  OCP_RELEASES_PAGE,
   StaticTextField,
   useTranslation,
 } from '../../../../common';
+import { getDefaultOpenShiftVersion } from '../../../../common/components/ui/formik/utils';
 import { Flex, Grid, GridItem, Form, Content } from '@patternfly/react-core';
-import OcmOpenShiftVersion from '../../clusterConfiguration/OcmOpenShiftVersion';
+import OcmOpenShiftVersionSelect from '../../clusterConfiguration/OcmOpenShiftVersionSelect';
 import { useClusterWizardContext } from '../ClusterWizardContext';
 import ClusterWizardFooter from '../ClusterWizardFooter';
 import ClusterWizardNavigation from '../ClusterWizardNavigation';
 import { WithErrorBoundary } from '../../../../common/components/ErrorHandling/WithErrorBoundary';
 import InstallDisconnectedSwitch from './InstallDisconnectedSwitch';
-import { Formik } from 'formik';
+import { Formik, useFormikContext } from 'formik';
+import { useOpenShiftVersionsContext } from '../OpenShiftVersionsContext';
+
+type BasicStepFormikValues = {
+  openshiftVersion: string;
+  customOpenshiftSelect: string | null;
+};
+
+const VersionSyncEffect = () => {
+  const { values } = useFormikContext<BasicStepFormikValues>();
+  const { setDisconnectedOpenshiftVersion } = useClusterWizardContext();
+  React.useEffect(() => {
+    if (values.openshiftVersion) {
+      setDisconnectedOpenshiftVersion(values.openshiftVersion);
+    }
+  }, [values.openshiftVersion, setDisconnectedOpenshiftVersion]);
+  return null;
+};
 
 const BasicStep = () => {
   const { t } = useTranslation();
-  const { moveNext } = useClusterWizardContext();
+  const { moveNext, disconnectedOpenshiftVersion } = useClusterWizardContext();
+  const { latestVersions } = useOpenShiftVersionsContext();
+  const initialVersion =
+    disconnectedOpenshiftVersion || getDefaultOpenShiftVersion(latestVersions);
 
   return (
-    <Formik
-      initialValues={{}}
+    <Formik<BasicStepFormikValues>
+      initialValues={{ openshiftVersion: initialVersion, customOpenshiftSelect: null }}
+      enableReinitialize
       onSubmit={() => {
         // nothing to do
       }}
@@ -31,6 +51,7 @@ const BasicStep = () => {
         navigation={<ClusterWizardNavigation />}
         footer={<ClusterWizardFooter onNext={moveNext} />}
       >
+        <VersionSyncEffect />
         <WithErrorBoundary title="Failed to load Basic step">
           <Grid hasGutter>
             <GridItem>
@@ -47,13 +68,7 @@ const BasicStep = () => {
             </GridItem>
             <GridItem>
               <Form id="wizard-cluster-basic-info__form">
-                <OcmOpenShiftVersion openshiftVersion="4.20" withPreviewText withMultiText>
-                  <ExternalLink href={`${window.location.origin}/${OCP_RELEASES_PAGE}`}>
-                    <span data-ouia-id="openshift-releases-link">
-                      {t('ai:Learn more about OpenShift releases')}
-                    </span>
-                  </ExternalLink>
-                </OcmOpenShiftVersion>
+                <OcmOpenShiftVersionSelect />
                 <StaticTextField name="cpuArchitecture" label="CPU architecture" isRequired>
                   x86_64
                 </StaticTextField>

--- a/libs/ui-lib/lib/ocm/components/clusterWizard/disconnected/ReviewStep.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/disconnected/ReviewStep.tsx
@@ -34,7 +34,7 @@ const downloadUrl =
   'https://mirror.openshift.com/pub/cgw/assisted-installer-disconnected/latest/agent-ove.x86_64.iso';
 
 const ReviewStep = () => {
-  const { moveBack } = useClusterWizardContext();
+  const { moveBack, disconnectedOpenshiftVersion } = useClusterWizardContext();
   const opSpecs = getOperatorSpecs(() => undefined);
   const navigate = useNavigate();
 
@@ -98,7 +98,9 @@ const ReviewStep = () => {
             <DescriptionList isHorizontal>
               <DescriptionListGroup>
                 <DescriptionListTerm>OpenShift version</DescriptionListTerm>
-                <DescriptionListDescription>4.20</DescriptionListDescription>
+                <DescriptionListDescription>
+                  {disconnectedOpenshiftVersion || '—'}
+                </DescriptionListDescription>
               </DescriptionListGroup>
               <DescriptionListGroup>
                 <DescriptionListTerm>CPU architecture</DescriptionListTerm>


### PR DESCRIPTION
## Summary

https://redhat.atlassian.net/browse/OCPBUGS-86070

The disconnected/air-gapped BasicStep had the OpenShift version hardcoded to `"4.20"` via a static `OcmOpenShiftVersion` component. This prevented users from selecting 4.21, 4.22 (including RC builds), or any future versions when the disconnected toggle is enabled.

**Root cause:** `OcmOpenShiftVersion openshiftVersion="4.20"` in `BasicStep.tsx` — a static display, not a selector.

**Fix:** Replace with `OcmOpenShiftVersionSelect` — the same dynamic dropdown component used in the connected flow. It consumes `OpenShiftVersionsContext` (already available in the wizard component tree) to fetch and display all available versions from the `/v2/openshift-versions` API.

### Changes
- Replace static `OcmOpenShiftVersion` with dynamic `OcmOpenShiftVersionSelect` in disconnected `BasicStep.tsx`
- Add typed Formik initial values (`openshiftVersion`, `customOpenshiftSelect`) required by the dropdown
- Remove unused imports (`ExternalLink`, `OCP_RELEASES_PAGE`, `OcmOpenShiftVersion`)

### Context
- This is the **standalone OCM path** (`libs/ui-lib/lib/ocm/`). The similar issue in the **CIM/ACM path** (`libs/ui-lib/lib/cim/`) is being fixed separately in #3723.
- Commit [0b7af138](https://github.com/openshift-assisted/assisted-installer-ui/commit/0b7af138) ([MGMT-22941](https://redhat.atlassian.net/browse/MGMT-22941)) previously fixed this as part of the "ABI above the sea" flow, but was reverted in #3517. This PR re-applies only the minimal version selection fix without the larger reverted flow.

### Known follow-ups (out of scope)
- CPU architecture is still hardcoded to `x86_64` in the same component
- `ReviewStep.tsx` also has a hardcoded `"4.20"` reference

## Test plan
- [ ] Navigate to Assisted Installer → Create Cluster → toggle "disconnected/air-gapped"
- [ ] Verify the OpenShift version dropdown shows all available versions (4.20, 4.21, 4.22, etc.)
- [ ] Verify "Show all available versions" modal works
- [ ] Verify connected flow (non-disconnected) is unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated the OpenShift version selection interface in the disconnected cluster wizard
  * Removed the external releases page link from the version selector

* **New Features**
  * Disconnected OpenShift version now persists through the wizard and is shown in the review/summary pages

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openshift-assisted/assisted-installer-ui/pull/3731?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->