### PR TITLE
NO-ISSUE: Add OCM refresh-token auth so stand-alone UI can use stage …

### DIFF
--- a/apps/assisted-ui/README.md
+++ b/apps/assisted-ui/README.md
@@ -61,6 +61,48 @@ This project is a user interface backed by Assisted Installer API.
 
 - Open the UI at `http://localhost:3000`
 
+### Use stage as the Assisted Installer service
+
+Use https://api.stage.openshift.com (same backend as https://console.dev.redhat.com/) instead of a
+local assisted-service.
+
+1. Create `apps/assisted-ui/.env.local`:
+
+   ```ini
+   AIUI_APP_API_URL=https://api.stage.openshift.com
+   AIUI_SSO_API_URL=https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
+   ```
+
+   - `AIUI_APP_API_URL` — Vite proxies `/api` to the stage Assisted Installer API
+   - `AIUI_SSO_API_URL` — Vite proxies `/token` to Red Hat SSO (refresh → access token)
+
+2. Get an OCM refresh token with the [ocm CLI](https://github.com/openshift-online/ocm-cli):
+
+   ```bash
+   # Fedora
+   sudo dnf copr enable ocm/tools && sudo dnf install ocm-cli
+
+   ocm login --use-auth-code --url=https://api.stage.openshift.com
+   jq -r .refresh_token ~/.config/ocm/ocm.json
+   ```
+
+3. Set the refresh token locally in `apps/assisted-ui/public/env.js`. Keep the committed value empty
+   (`''`) — never commit a real token:
+
+   ```js
+   window.OCM_REFRESH_TOKEN = '<paste-refresh-token>';
+   ```
+
+4. From the monorepo root, start the UI and open http://localhost:5173:
+
+   ```bash
+   yarn start:assisted_ui
+   ```
+
+On startup, `src/main.tsx` exchanges the refresh token for a short-lived access token and attaches
+`Authorization: Bearer …` to Assisted API requests. Leave `OCM_REFRESH_TOKEN` empty when using a
+local assisted-service that does not require OCM auth.
+
 ## Running integration tests
 
 TBD

--- a/apps/assisted-ui/src/main.tsx
+++ b/apps/assisted-ui/src/main.tsx
@@ -1,11 +1,51 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import type { AxiosInstance } from 'axios';
+import * as OCM from '@openshift-assisted/ui-lib/ocm';
 import { App } from './components/App';
 
 declare global {
   interface Window {
     OCM_REFRESH_TOKEN?: string;
   }
+}
+
+// Put your OCM_REFRESH_TOKEN in public/env.js (keep empty in git)
+const refreshToken = window.OCM_REFRESH_TOKEN;
+let accessToken = '';
+let expiresAt = 0;
+
+const getAccessToken = async () => {
+  if (accessToken && Date.now() < expiresAt - 5000) {
+    return accessToken;
+  }
+  const body = new URLSearchParams({
+    grant_type: 'refresh_token',
+    refresh_token: refreshToken || '',
+    client_id: 'ocm-cli',
+  });
+  const res = await fetch('/token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body,
+  });
+  if (!res.ok) {
+    throw new Error(`Token refresh failed: ${res.status}`);
+  }
+  const data = (await res.json()) as { access_token: string; expires_in: number };
+  accessToken = data.access_token;
+  expiresAt = Date.now() + data.expires_in * 1000;
+  return accessToken;
+};
+
+if (refreshToken) {
+  OCM.Api.setAuthInterceptor((client: AxiosInstance) => {
+    client.interceptors.request.use(async (config) => {
+      config.headers.set('Authorization', `Bearer ${await getAccessToken()}`);
+      return config;
+    });
+    return client;
+  });
 }
 
 const rootElement = document.getElementById('root');


### PR DESCRIPTION
…as the Assisted Installer service

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic authentication for the Assisted Installer interface using a configured refresh token.
  - Access credentials are refreshed automatically before expiration, helping maintain sessions during use.
  - Authentication failures now provide clear errors instead of allowing requests to continue unauthenticated.

- **Documentation**
  - Added setup instructions covering environment configuration, token retrieval, local token setup, application startup, and authentication behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->