### PR TITLE
MGMT-24202: [Staging] [UI] - Air-gapped -Technology Preview badge placement is inconsistent (should appear at end of line)

### DIFF
--- a/libs/ui-lib/lib/ocm/components/wizard/steps/disconnected/BasicStep.tsx
+++ b/libs/ui-lib/lib/ocm/components/wizard/steps/disconnected/BasicStep.tsx
@@ -28,9 +28,9 @@ export const BasicStep = () => {
           </GridItem>
           <GridItem>
             <Flex alignItems={{ default: 'alignItemsCenter' }} gap={{ default: 'gapSm' }}>
-              <TechnologyPreview />
               <InstallDisconnectedSwitch />
               <span>I'm installing on a disconnected/air-gapped/secured environment</span>
+              <TechnologyPreview />
             </Flex>
           </GridItem>
           <GridItem>


### PR DESCRIPTION
Before:

<img width="1173" height="180" alt="Screenshot From 2026-08-18 15-02-39" src="https://github.com/user-attachments/assets/bdd24101-3616-4934-8a4a-2db332c48628" />

<img width="1173" height="180" alt="Screenshot From 2026-08-18 15-02-30" src="https://github.com/user-attachments/assets/52de6660-1ffd-487c-ad59-395de70a3b2c" />

After:
<img width="1901" height="628" alt="image" src="https://github.com/user-attachments/assets/3a6f89b3-0dc5-42ea-b101-879343aa1887" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the Basic step layout so the disconnected-environment option and label appear before the technology preview.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->