### PR TITLE
OCPBUGS-83603: Standardize ISO terminology and correct misleading boot instructions

### DIFF
--- a/libs/ui-lib/lib/common/config/docs_links.ts
+++ b/libs/ui-lib/lib/common/config/docs_links.ts
@@ -240,3 +240,6 @@ export const getNumaResourcesLink = (ocpVersion?: string) =>
   `https://docs.redhat.com/en/documentation/openshift_container_platform/${getDocsOpenshiftVersion(
     ocpVersion,
   )}/html/scalability_and_performance/cnf-numa-aware-scheduling`;
+
+export const getDisconnectedDocsLink = (ocpVersion: string) =>
+  `https://docs.redhat.com/en/documentation/openshift_container_platform/${ocpVersion}/html/installing_an_on-premise_cluster_with_the_agent-based_installer/installing-ove`;

--- a/libs/ui-lib/lib/ocm/components/wizard/steps/disconnected/DisconnectedReviewStep.tsx
+++ b/libs/ui-lib/lib/ocm/components/wizard/steps/disconnected/DisconnectedReviewStep.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { Formik } from 'formik';
 import { saveAs } from 'file-saver';
 import { useNavigate } from 'react-router';
 import {
@@ -24,6 +23,9 @@ import {
   singleClusterOperators,
   WithErrorBoundary,
   getOperatorSpecs,
+  ExternalLink,
+  getDisconnectedDocsLink,
+  getMajorMinorVersion,
 } from '../../../../../common';
 import { ClusterWizardFooter, ClusterWizardNavigation } from '../../wizardComponents';
 import { useClusterWizardContext } from '../../clusterWizardContext';
@@ -35,83 +37,79 @@ export const DisconnectedReviewStep = () => {
   const navigate = useNavigate();
 
   return (
-    <Formik
-      initialValues={{}}
-      onSubmit={() => {
-        // nothing to do
-      }}
+    <ClusterWizardStep
+      navigation={<ClusterWizardNavigation />}
+      footer={
+        <ClusterWizardFooter
+          onNext={() => {
+            saveAs(disconnectedInfraEnv?.downloadUrl ?? '');
+            void navigate('/cluster-list');
+          }}
+          onBack={moveBack}
+          nextButtonText="Download ISO"
+        />
+      }
     >
-      <ClusterWizardStep
-        navigation={<ClusterWizardNavigation />}
-        footer={
-          <ClusterWizardFooter
-            onNext={() => {
-              saveAs(disconnectedInfraEnv?.downloadUrl ?? '');
-              void navigate('/cluster-list');
-            }}
-            onBack={moveBack}
-            nextButtonText="Download ISO"
-          />
-        }
-      >
-        <WithErrorBoundary title="Failed to load Review step">
-          <Grid hasGutter>
-            <Split>
-              <SplitItem>
-                <Content component="h2">Review and download ISO</Content>
-              </SplitItem>
-              <SplitItem>
-                <TechnologyPreview />
-              </SplitItem>
-            </Split>
-            <Alert isInline variant="info" title="Discovery ISO boot instructions">
-              <List component={ListComponent.ol} type={OrderType.number}>
-                <ListItem>Download ISO</ListItem>
-                <ListItem>
-                  Download or copy your pull secret from{' '}
-                  <a href={PULL_SECRET_INFO_LINK} target="_blank" rel="noopener noreferrer">
-                    here
-                  </a>
-                </ListItem>
-                <ListItem>
-                  Boot your cluster's machines from this ISO and follow instructions
-                </ListItem>
-                <ListItem>
-                  Provide your pull secret inside the installation wizard when requested
-                </ListItem>
-              </List>
-            </Alert>
-            <Alert isInline isExpandable variant="info" title="List of available operators">
-              <List>
-                {singleClusterOperators.map((o) => {
-                  const operator = Object.values(opSpecs)
-                    .flatMap((op) => op)
-                    .find((op) => op.operatorKey === o);
-                  return <ListItem key={o}>{operator ? operator.title : o}</ListItem>;
-                })}
-              </List>
-            </Alert>
-            <DescriptionList isHorizontal>
-              <DescriptionListGroup>
-                <DescriptionListTerm>OpenShift version</DescriptionListTerm>
-                <DescriptionListDescription>
-                  {disconnectedInfraEnv?.openshiftVersion ?? DISCONNECTED_OPENSHIFT_VERSION}
-                </DescriptionListDescription>
-              </DescriptionListGroup>
-              <DescriptionListGroup>
-                <DescriptionListTerm>CPU architecture</DescriptionListTerm>
-                <DescriptionListDescription>
-                  {disconnectedInfraEnv?.cpuArchitecture ?? 'x86_64'}
-                </DescriptionListDescription>
-              </DescriptionListGroup>
-              <DescriptionListGroup>
-                <DescriptionListTerm>ISO size</DescriptionListTerm>
-                <DescriptionListDescription>approx. 43.5GB</DescriptionListDescription>
-              </DescriptionListGroup>
-            </DescriptionList>
-          </Grid>
-        </WithErrorBoundary>
-      </ClusterWizardStep>
-    </Formik>
+      <WithErrorBoundary title="Failed to load Review step">
+        <Grid hasGutter>
+          <Split>
+            <SplitItem>
+              <Content component="h2">Review and download ISO</Content>
+            </SplitItem>
+            <SplitItem>
+              <TechnologyPreview />
+            </SplitItem>
+          </Split>
+          <Alert isInline variant="info" title="ISO boot instructions">
+            <List component={ListComponent.ol} type={OrderType.number}>
+              <ListItem>Download the ISO.</ListItem>
+              <ListItem>
+                Boot your cluster's machines from this ISO and{' '}
+                <ExternalLink
+                  href={getDisconnectedDocsLink(
+                    getMajorMinorVersion(DISCONNECTED_OPENSHIFT_VERSION),
+                  )}
+                >
+                  follow instructions
+                </ExternalLink>
+                .
+              </ListItem>
+              <ListItem>
+                Your <ExternalLink href={PULL_SECRET_INFO_LINK}>pull secret</ExternalLink> was
+                included automatically. You can change it inside the installation wizard.
+              </ListItem>
+            </List>
+          </Alert>
+          <Alert isInline isExpandable variant="info" title="List of available operators">
+            <List>
+              {singleClusterOperators.map((o) => {
+                const operator = Object.values(opSpecs)
+                  .flatMap((op) => op)
+                  .find((op) => op.operatorKey === o);
+                return <ListItem key={o}>{operator ? operator.title : o}</ListItem>;
+              })}
+            </List>
+          </Alert>
+          <DescriptionList isHorizontal>
+            <DescriptionListGroup>
+              <DescriptionListTerm>OpenShift version</DescriptionListTerm>
+              <DescriptionListDescription>
+                {disconnectedInfraEnv?.openshiftVersion ?? DISCONNECTED_OPENSHIFT_VERSION}
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+            <DescriptionListGroup>
+              <DescriptionListTerm>CPU architecture</DescriptionListTerm>
+              <DescriptionListDescription>
+                {disconnectedInfraEnv?.cpuArchitecture ?? 'x86_64'}
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+            <DescriptionListGroup>
+              <DescriptionListTerm>ISO size</DescriptionListTerm>
+              <DescriptionListDescription>approx. 50+GB</DescriptionListDescription>
+            </DescriptionListGroup>
+          </DescriptionList>
+        </Grid>
+      </WithErrorBoundary>
+    </ClusterWizardStep>
   );
 };


### PR DESCRIPTION
https://redhat.atlassian.net/browse/OCPBUGS-83603
https://redhat.atlassian.net/browse/AGENT-1294

- Removed Formik component (unnecessary).
- Converted list instructions into sentences per [PatternFly guidelines](https://www.patternfly.org/content-design/writing-guides/patternfly-design-guidelines#lists).
- Added Doc link: https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html/installing_an_on-premise_cluster_with_the_agent-based_installer/installing-ove 
- Tweaked wording related to pull secrets.
- Changed approximate ISO size

<img width="900" height="717" alt="image" src="https://github.com/user-attachments/assets/52c4c286-7379-4978-9a4b-7297dc207532" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added version-specific links to OpenShift disconnected-installation documentation.
- Added direct access to pull-secret information.

## Improvements
- Clarified boot instructions and noted that the pull secret is included automatically.
- Updated the estimated ISO size to approximately 50+ GB.
- Preserved existing download, navigation, operator, and environment details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->