### PR TITLE
OCPBUGS-112666: console.redhat.com disconnected/OVE ISO serves a 4.21.28 ignition on top of a 4.21.27 ISO

### DIFF
--- a/libs/ui-lib/lib/ocm/components/wizard/steps/disconnected/BasicStep.tsx
+++ b/libs/ui-lib/lib/ocm/components/wizard/steps/disconnected/BasicStep.tsx
@@ -10,7 +10,7 @@ import { useClusterWizardContext } from '../../clusterWizardContext';
 import { ClusterWizardNavigation, ClusterWizardFooter } from '../../wizardComponents';
 import { InstallDisconnectedSwitch } from './InstallDisconnectedSwitch';
 
-export const DISCONNECTED_OPENSHIFT_VERSION = '4.21';
+export const DISCONNECTED_OPENSHIFT_VERSION = '4.21.27';
 
 export const BasicStep = () => {
   const { moveNext } = useClusterWizardContext();


### PR DESCRIPTION
Issue:
https://redhat.atlassian.net/browse/OCPBUGS-112666

Fix:
Replace '4.21' with '4.21.27'
