### PR TITLE
[release-4.22] OCPBUGS-113718: Remove CustomNoUpgrade featureSet from disconnected UI

### DIFF
--- a/libs/ui-lib/lib/common/api/assisted-service/ClustersAPI.ts
+++ b/libs/ui-lib/lib/common/api/assisted-service/ClustersAPI.ts
@@ -239,12 +239,6 @@ const ClustersAPI = {
       params,
     );
   },
-
-  updateInstallConfig(clusterId: Cluster['id'], config: string) {
-    return client.patch(`${ClustersAPI.makeBaseURI(clusterId)}/install-config`, config, {
-      headers: { 'Content-Type': 'application/json' },
-    });
-  },
 };
 
 export default ClustersAPI;

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfigurationForm.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfigurationForm.tsx
@@ -16,7 +16,6 @@ import {
   SecurityFields,
   useAlerts,
   useFormikAutoSave,
-  ClustersAPI,
   useTranslation,
 } from '../../../../common';
 import { useDefaultConfiguration } from '../ClusterDefaultConfigurationContext';
@@ -47,7 +46,6 @@ import {
   V2ClusterUpdateParams,
 } from '@openshift-assisted/types/assisted-installer-service';
 import { useNewFeatureSupportLevel } from '../../../../common/components/newFeatureSupportLevels';
-import { useFeature } from '../../../hooks/use-feature';
 
 const NetworkConfigurationForm: React.FC<{
   cluster: Cluster;
@@ -68,10 +66,6 @@ const NetworkConfigurationForm: React.FC<{
     useFormikContext<NetworkConfigurationValues>();
   const isAutoSaveRunning = useFormikAutoSave();
   const errorFields = getFormikErrorFields(errors, touched);
-  const isSingleClusterFeatureEnabled = useFeature('ASSISTED_INSTALLER_SINGLE_CLUSTER_FEATURE');
-  const { addAlert } = useAlerts();
-  const dispatch = useDispatch();
-
   // DHCP allocation is currently not supported for Nutanix hosts
   // https://issues.redhat.com/browse/MGMT-12382
   const isHostsPlatformTypeNutanix = React.useMemo(
@@ -84,34 +78,6 @@ const NetworkConfigurationForm: React.FC<{
       setFieldValue('vipDhcpAllocation', false);
     }
   }, [isHostsPlatformTypeNutanix, setFieldValue, values.vipDhcpAllocation]);
-
-  const onNext = React.useCallback(async () => {
-    if (isSingleClusterFeatureEnabled) {
-      try {
-        await ClustersAPI.updateInstallConfig(
-          cluster.id,
-          JSON.stringify(
-            JSON.stringify({
-              featureSet: 'CustomNoUpgrade',
-              featureGates: ['NoRegistryClusterInstall=true'],
-            }),
-          ),
-        );
-      } catch (e) {
-        handleApiError(e, () =>
-          addAlert({
-            title: 'Failed to update install-config',
-            message: getApiErrorMessage(e),
-          }),
-        );
-        if (isUnknownServerError(e as Error)) {
-          dispatch(setServerUpdateError());
-        }
-        return;
-      }
-    }
-    clusterWizardContext.moveNext();
-  }, [addAlert, cluster.id, clusterWizardContext, dispatch, isSingleClusterFeatureEnabled]);
 
   const isNextDisabled =
     isSubmitting ||
@@ -127,7 +93,7 @@ const NetworkConfigurationForm: React.FC<{
       isSubmitting={isSubmitting}
       isNextDisabled={isNextDisabled}
       isWaitingForHosts={!canNextNetwork({ cluster })}
-      onNext={() => void onNext()}
+      onNext={() => clusterWizardContext.moveNext()}
       onBack={() => clusterWizardContext.moveBack()}
       isBackDisabled={isSubmitting || isAutoSaveRunning}
     />


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/openshift-assisted/assisted-installer-ui/pull/3954, since the original backport to release-4.22 failed due some conflicts.

This patch is required to properly release the OVE ISO 4.22, otherwise it won't be possible to further upgrade the cluster once installed