### PR TITLE
Bug OCPBUGS-100525,OCPBUGS-103013: Bump ip-address to 10.5.0 to fix CVE-2026-54272 and CVE-2026-69192

### DIFF
--- a/libs/ui-lib/package.json
+++ b/libs/ui-lib/package.json
@@ -20,7 +20,7 @@
     "fuse.js": "^6.4.6",
     "human-date": "^1.4.0",
     "humanize-plus": "^1.8.2",
-    "ip-address": "^7.1.0",
+    "ip-address": "^10.3.1",
     "is-cidr": "^4.0.2",
     "is-in-subnet": "^4",
     "js-yaml": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "lodash-es": "^4.17.23",
     "axios": "^1.18.1",
     "shell-quote": "^1.8.4",
-    "ip-address": "^10.1.1",
+    "ip-address": "^10.3.1",
     "@cypress/request/form-data": "2.5.6",
     "tar": "^7.5.21",
     "ws": "^8.21.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -897,7 +897,7 @@ __metadata:
     fuse.js: ^6.4.6
     human-date: ^1.4.0
     humanize-plus: ^1.8.2
-    ip-address: ^7.1.0
+    ip-address: ^10.3.1
     is-cidr: ^4.0.2
     is-in-subnet: ^4
     js-yaml: ^4.3.0
@@ -6279,10 +6279,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ip-address@npm:^10.1.1":
-  version: 10.2.0
-  resolution: "ip-address@npm:10.2.0"
-  checksum: 3ffba04dc4cdaf81ed2ed6edc47eee1494bb97550ef73f1918ca28405d175c03efa416b8337e868123b08c2cc677e3a07c5ce03eda3b1aeb2741c149bd37ddf9
+"ip-address@npm:^10.3.1":
+  version: 10.5.0
+  resolution: "ip-address@npm:10.5.0"
+  checksum: ffb64aea3ab0bf975b237954f89bf3c37cb5fc9d078cf5868408e54d29636d14618ed67dafcde664b3cdfc778ee78c811286cf67e59d1243a0c198d05aa47683
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## CVE Remediation

Bumps `ip-address` from 10.2.0 to 10.5.0 to fix two vulnerabilities:

- **CVE-2026-54272** (Moderate, CVSS 7.2): SSRF through misclassification of IPv4-mapped/NAT64 IPv6 addresses in ip-address 10.1.1–10.2.0. Fixed in 10.2.1+.
- **CVE-2026-69192** (Important, CVSS 8.6): Octal parsing disagreement — leading zeros decoded as decimal vs octal — in ip-address <10.3.1. Fixed in 10.3.1.

### Changes
- Root `package.json`: resolution override `ip-address` `^10.1.1` → `^10.3.1`
- `libs/ui-lib/package.json`: direct dependency `ip-address` `^7.1.0` → `^10.3.1`
- `yarn.lock`: regenerated (ip-address resolves to 10.5.0)

### Verification
- Unit tests: 79/79 passed
- Lint: all workspaces clean
- Type-check: ui-lib (changed package) clean

### Jira
- [OCPBUGS-100525](https://redhat.atlassian.net/browse/OCPBUGS-100525)
- [OCPBUGS-103013](https://redhat.atlassian.net/browse/OCPBUGS-103013)