### PR TITLE
OCPBUGS-100526,OCPBUGS-103014: Bump ip-address to 10.5.0 to fix CVE-2026-54272 and CVE-2026-69192

### DIFF
--- a/libs/ui-lib/package.json
+++ b/libs/ui-lib/package.json
@@ -21,7 +21,7 @@
     "fuse.js": "^6.4.6",
     "human-date": "^1.4.0",
     "humanize-plus": "^1.8.2",
-    "ip-address": "^7.1.0",
+    "ip-address": "^10.3.1",
     "is-cidr": "^4.0.2",
     "is-in-subnet": "^4",
     "js-yaml": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "axios": "^1.18.1",
     "follow-redirects": "^1.16.0",
     "shell-quote": "^1.8.4",
-    "ip-address": "^10.1.1",
+    "ip-address": "^10.3.1",
     "tar": "^7.5.21",
     "basic-ftp": "^5.3.1",
     "ws": "^8.21.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1721,7 +1721,7 @@ __metadata:
     fuse.js: ^6.4.6
     human-date: ^1.4.0
     humanize-plus: ^1.8.2
-    ip-address: ^7.1.0
+    ip-address: ^10.3.1
     is-cidr: ^4.0.2
     is-in-subnet: ^4
     js-yaml: ^4.3.0
@@ -11138,10 +11138,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ip-address@npm:^10.1.1":
-  version: 10.2.0
-  resolution: "ip-address@npm:10.2.0"
-  checksum: 3ffba04dc4cdaf81ed2ed6edc47eee1494bb97550ef73f1918ca28405d175c03efa416b8337e868123b08c2cc677e3a07c5ce03eda3b1aeb2741c149bd37ddf9
+"ip-address@npm:^10.3.1":
+  version: 10.5.0
+  resolution: "ip-address@npm:10.5.0"
+  checksum: ffb64aea3ab0bf975b237954f89bf3c37cb5fc9d078cf5868408e54d29636d14618ed67dafcde664b3cdfc778ee78c811286cf67e59d1243a0c198d05aa47683
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## CVE Remediation: ip-address SSRF vulnerabilities

Bumps `ip-address` from 10.2.0 to 10.5.0 to fix two SSRF vulnerabilities:

- **CVE-2026-54272** (Moderate, CVSS 7.2): SSRF via IPv4-mapped/NAT64 IPv6 address misclassification. Fixed in >=10.2.1.
  - Jira: https://redhat.atlassian.net/browse/OCPBUGS-100526
  - Advisory: https://github.com/beaugunderson/ip-address/security/advisories/GHSA-22jq-vg5j-6vgg

- **CVE-2026-69192** (Important, CVSS 8.6): Inconsistent IP address parsing leads to SSRF and trust-boundary bypass. Fixed in >=10.3.1.
  - Jira: https://redhat.atlassian.net/browse/OCPBUGS-103014
  - Advisory: https://github.com/beaugunderson/ip-address/security/advisories/GHSA-mwp4-54f8-5fhr

### Changes

- `package.json`: Updated `resolutions.ip-address` from `^10.1.1` to `^10.3.1`
- `libs/ui-lib/package.json`: Updated `dependencies.ip-address` from `^7.1.0` to `^10.3.1`
- `yarn.lock`: Regenerated (resolved version: 10.5.0)

### Validation

- `yarn install --immutable`: ✅ pass
- TypeScript type-check (`tsc --noEmit`): ✅ pass
- Unit tests (`vitest run`): ✅ 88/88 passed