### PR TITLE
OCPBUGS-115054: Decouple LVMS and LSO from OCP-Virt operator bundle in Assisted Installer

### DIFF
--- a/libs/ui-lib-tests/cypress/integration/use-cases/create-cluster/with-mtv-operator.cy.ts
+++ b/libs/ui-lib-tests/cypress/integration/use-cases/create-cluster/with-mtv-operator.cy.ts
@@ -45,7 +45,7 @@ describe(`Create cluster with MTV operator enabled`, () => {
     });
     it('Selecting MTV checks dependency operators and sends only MTV to the API', () => {
       OperatorsForm.assertOperatorCheckbox('cnv', { checked: false, disabled: false });
-      OperatorsForm.assertOperatorCheckbox('lso', { checked: false, disabled: true });
+      OperatorsForm.assertOperatorCheckbox('lso', { checked: false, disabled: false });
 
       OperatorsForm.mtvOperatorControl.findLabel().click({ force: true });
 

--- a/libs/ui-lib/lib/common/components/operators/operatorSpecs.tsx
+++ b/libs/ui-lib/lib/common/components/operators/operatorSpecs.tsx
@@ -154,7 +154,6 @@ export const getOperatorSpecs = (
             <ExternalLink href={getLsoLink(openshiftVersion)}>Learn more</ExternalLink>
           </>
         ),
-        notStandalone: true,
         supportLevel: getFeatureSupportLevel('LSO'),
       },
       {


### PR DESCRIPTION
https://redhat.atlassian.net/browse/OCPBUGS-115054

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Local Storage Operator classification so it is recognized as a standalone operator.
  * The Local Storage Operator is now enabled by default when configuring a cluster with the MTV operator.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->