### PR TITLE
OCPBUGS-114719: Unable to select LSO and LVMS storage operators in the disconnected UI

### DIFF
--- a/libs/ui-lib/lib/common/config/constants.ts
+++ b/libs/ui-lib/lib/common/config/constants.ts
@@ -329,6 +329,7 @@ export const singleClusterOperators = [
   OPERATOR_NAME_NUMA_RESOURCES,
   OPERATOR_NAME_LOKI,
   OPERATOR_NAME_OPENSHIFT_LOGGING,
+  OPERATOR_NAME_LVM,
 ];
 
 export const singleClusterBundles = ['virtualization'];


### PR DESCRIPTION
https://redhat.atlassian.net/browse/OCPBUGS-114719

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Logical Volume Manager operator as a single-cluster operator.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->