### PR TITLE
OCPBUGS-123180: Remove stale OCM_REFRESH_TOKEN code

### DIFF
--- a/apps/assisted-ui/Containerfile
+++ b/apps/assisted-ui/Containerfile
@@ -25,7 +25,6 @@ COPY --chown=1001:0 / "${APP_ROOT}/src/repo"
 RUN npm install -g corepack@0.24.1
 WORKDIR "${APP_ROOT}/src/repo"
 RUN yarn install --immutable && yarn build:all
-COPY /apps/assisted-ui/env.template.js /opt/app-root/src/repo/apps/assisted-ui/build/
 
 FROM registry.access.redhat.com/ubi8/nginx-122 AS assisted-ui
 COPY --from=devcontainer /opt/app-root/src/repo/apps/assisted-ui/build/ "${NGINX_APP_ROOT}/src/"

--- a/apps/assisted-ui/env.template.js
+++ b/apps/assisted-ui/env.template.js
@@ -1,1 +1,0 @@
-window.OCM_REFRESH_TOKEN = '';

--- a/apps/assisted-ui/index.html
+++ b/apps/assisted-ui/index.html
@@ -6,7 +6,6 @@
     <link rel="stylesheet" href="/src/styles.css" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Assisted Installer</title>
-    <script src="/env.js"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/apps/assisted-ui/public/env.js
+++ b/apps/assisted-ui/public/env.js
@@ -1,1 +1,0 @@
-window.OCM_REFRESH_TOKEN = '';

--- a/apps/assisted-ui/src/main.tsx
+++ b/apps/assisted-ui/src/main.tsx
@@ -2,12 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { App } from './components/App';
 
-declare global {
-  interface Window {
-    OCM_REFRESH_TOKEN?: string;
-  }
-}
-
 const rootElement = document.getElementById('root');
 if (rootElement) {
   rootElement.classList.add('pf-v6-u-h-100vh');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed obsolete runtime environment configuration loading from the Assisted UI.
  * Stopped initializing an empty refresh token by default.
  * Simplified application startup by eliminating reliance on the removed refresh-token setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->