### PR TITLE
OCPBUGS-115122: OVE Below the sea level UI: Technology preview is shown right next to Machine Network dropdown when using IPV6

### DIFF
--- a/libs/ui-lib/lib/common/components/clusterWizard/networkingSteps/AvailableSubnetsControl.tsx
+++ b/libs/ui-lib/lib/common/components/clusterWizard/networkingSteps/AvailableSubnetsControl.tsx
@@ -32,6 +32,7 @@ export interface AvailableSubnetsControlProps {
   hosts?: Host[];
   isMultiNodeCluster?: boolean;
   allowSingleStackIPv6?: boolean;
+  showIpv6TechPreviewBadge?: boolean;
 }
 
 export const AvailableSubnetsControl = ({
@@ -44,6 +45,7 @@ export const AvailableSubnetsControl = ({
   hosts,
   isMultiNodeCluster = true,
   allowSingleStackIPv6 = false,
+  showIpv6TechPreviewBadge = true,
 }: AvailableSubnetsControlProps) => {
   const { t } = useTranslation();
   const { values, errors, setFieldValue } = useFormikContext<NetworkConfigurationValues>();
@@ -229,6 +231,7 @@ export const AvailableSubnetsControl = ({
                   onAfterSelect={(newSelection) => {
                     reorderNetworksForPrimary(newSelection, values, setFieldValue);
                   }}
+                  showIpv6TechPreviewBadge={showIpv6TechPreviewBadge}
                   data-testid="subnets-dropdown-toggle-primary"
                 />
               </StackItem>
@@ -249,6 +252,7 @@ export const AvailableSubnetsControl = ({
             name="machineNetworks.1.cidr"
             machineSubnets={secondaryMachineSubnets}
             isDisabled={isDisabled}
+            showIpv6TechPreviewBadge={showIpv6TechPreviewBadge}
             data-testid="subnets-dropdown-toggle-secondary"
           />
         </FormGroup>

--- a/libs/ui-lib/lib/common/components/clusterWizard/networkingSteps/SubnetsDropdown.tsx
+++ b/libs/ui-lib/lib/common/components/clusterWizard/networkingSteps/SubnetsDropdown.tsx
@@ -10,16 +10,16 @@ import {
 } from '@patternfly/react-core';
 import { useField } from 'formik';
 import { Address4, Address6 } from 'ip-address';
-import { getFieldId } from '../../ui';
+import { getFieldId, TechnologyPreview, PreviewBadgePosition } from '../../ui';
 import { HostSubnet } from '../../../types';
 import { NO_SUBNET_SET } from '../../../config';
-import { TechnologyPreview, PreviewBadgePosition } from '../../ui';
 
 type SubnetsDropdownProps = {
   name: string;
   machineSubnets: HostSubnet[];
   isDisabled: boolean;
   onAfterSelect?: (selectedValue: string) => void;
+  showIpv6TechPreviewBadge?: boolean;
 };
 
 const toFormSelectOptions = (subnets: HostSubnet[]) => {
@@ -50,6 +50,7 @@ export const SubnetsDropdown = ({
   machineSubnets,
   isDisabled,
   onAfterSelect,
+  showIpv6TechPreviewBadge = true,
   ...props
 }: SubnetsDropdownProps & MenuToggleProps) => {
   const [field, , { setValue }] = useField(name);
@@ -126,7 +127,10 @@ export const SubnetsDropdown = ({
         <DropdownGroup label="IPv4" key="ipv4-group">
           {ipv4Items}
         </DropdownGroup>,
-        <DropdownGroup label="IPv6 (Technology Preview)" key="ipv6-group">
+        <DropdownGroup
+          label={showIpv6TechPreviewBadge ? 'IPv6 (Technology Preview)' : 'IPv6'}
+          key="ipv6-group"
+        >
           {ipv6Items}
         </DropdownGroup>,
       ];
@@ -138,7 +142,7 @@ export const SubnetsDropdown = ({
         {label}
       </DropdownItem>
     ));
-  }, [machineSubnets, ipv4Subnets, ipv6Subnets, itemsSubnets]);
+  }, [machineSubnets, ipv4Subnets, ipv6Subnets, itemsSubnets, showIpv6TechPreviewBadge]);
 
   const onSelect = (event?: React.MouseEvent<Element, MouseEvent>): void => {
     const nextValue = event?.currentTarget.id;
@@ -152,7 +156,10 @@ export const SubnetsDropdown = ({
   const currentItem = itemsSubnets.find((i) => i.label === currentDisplayValue);
   const isPrimaryMachineNetwork = name === 'machineNetworks.0.cidr';
   const showBadge = Boolean(
-    isPrimaryMachineNetwork && currentItem && Address6.isValid(currentItem.value),
+    showIpv6TechPreviewBadge &&
+      isPrimaryMachineNetwork &&
+      currentItem &&
+      Address6.isValid(currentItem.value),
   );
 
   const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (

--- a/libs/ui-lib/lib/ocm/components/wizard/steps/networking/components/NetworkConfigurationFields.tsx
+++ b/libs/ui-lib/lib/ocm/components/wizard/steps/networking/components/NetworkConfigurationFields.tsx
@@ -230,6 +230,7 @@ export const NetworkConfigurationFields = ({
             openshiftVersion={cluster.openshiftVersion}
             isViewerMode={isViewerMode}
             allowSingleStackIPv6={isSingleClusterFeature}
+            showIpv6TechPreviewBadge={!isSingleClusterFeature}
           />
         </StackItem>
       )}


### PR DESCRIPTION
Before: 

<img width="1920" height="999" alt="image" src="https://github.com/user-attachments/assets/8f858708-98b0-4b56-aace-59b418b87a15" />


After:

<img width="1920" height="999" alt="image" src="https://github.com/user-attachments/assets/3167dedf-4dde-418d-b278-49f7d2660eca" />
