### PR TITLE
OCPBUGS-104550: Bump tmp to 0.2.6+ to fix CVE-2026-44705 path traversal

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "tar": "^7.5.21",
     "ws": "^8.21.0",
     "minimatch": "^10.2.6",
-    "brace-expansion": "^5.0.9"
+    "brace-expansion": "^5.0.9",
+    "tmp": "^0.2.6"
   },
   "scripts": {
     "_build:lib": "yarn workspace @openshift-assisted/ui-lib build && yarn workspace @openshift-assisted/chatbot build",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8760,13 +8760,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"os-tmpdir@npm:~1.0.2":
-  version: 1.0.2
-  resolution: "os-tmpdir@npm:1.0.2"
-  checksum: 5666560f7b9f10182548bf7013883265be33620b1c1b4a4d405c25be2636f970c5488ff3e6c48de75b55d02bde037249fe5dbfbb4c0fb7714953d56aed062e6d
-  languageName: node
-  linkType: hard
-
 "ospath@npm:^1.2.2":
   version: 1.2.2
   resolution: "ospath@npm:1.2.2"
@@ -11043,19 +11036,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tmp@npm:^0.0.33":
-  version: 0.0.33
-  resolution: "tmp@npm:0.0.33"
-  dependencies:
-    os-tmpdir: ~1.0.2
-  checksum: 902d7aceb74453ea02abbf58c203f4a8fc1cead89b60b31e354f74ed5b3fb09ea817f94fb310f884a5d16987dd9fa5a735412a7c2dd088dd3d415aa819ae3a28
-  languageName: node
-  linkType: hard
-
-"tmp@npm:~0.2.1":
-  version: 0.2.3
-  resolution: "tmp@npm:0.2.3"
-  checksum: 73b5c96b6e52da7e104d9d44afb5d106bb1e16d9fa7d00dbeb9e6522e61b571fbdb165c756c62164be9a3bbe192b9b268c236d370a2a0955c7689cd2ae377b95
+"tmp@npm:^0.2.6":
+  version: 0.2.7
+  resolution: "tmp@npm:0.2.7"
+  checksum: 45dec2fc288ad368eeff7268cb6d5d33452c6d35f4f7d9b1b5e023409a141dab57a3c08b5f505daf3af6d69667a5f544fc1a5b6a27c6f9396a5a1b4002912f1c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Bumps the `tmp` npm package to >=0.2.6 via a Yarn resolution to fix CVE-2026-44705 (path traversal, CVSS 8.2 Important).

## Details

- **GHSA**: [GHSA-ph9p-34f9-6g65](https://github.com/raszi/node-tmp/security/advisories/GHSA-ph9p-34f9-6g65)
- **Jira**: [OCPBUGS-104550](https://redhat.atlassian.net/browse/OCPBUGS-104550)
- **Fix**: Added `"tmp": "^0.2.6"` to root `package.json` resolutions (Yarn override), resolving to 0.2.7
- **Dependency chain**: `cypress` → `tmp ~0.2.x` (was vulnerable, now 0.2.7)
- **Scope**: `package.json` (+1 resolution line) and `yarn.lock` (tmp block update)

Backport of https://github.com/openshift-assisted/assisted-installer-ui/pull/4014 (release-4.22).

Follows the same Yarn resolution pattern used for prior CVE fixes in this repo (ws, minimatch, tar, dompurify).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)