### PR TITLE
OCPBUGS-120719: Inaccurate wording in SSH key label

### DIFF
--- a/libs/locales/lib/en/translation.json
+++ b/libs/locales/lib/en/translation.json
@@ -989,6 +989,7 @@
   "ai:Use lowercase alphanumeric characters or hyphen (-)": "Use lowercase alphanumeric characters or hyphen (-)",
   "ai:Use lowercase alphanumeric characters, dot (.) or hyphen (-)": "Use lowercase alphanumeric characters, dot (.) or hyphen (-)",
   "ai:Use the same host discovery SSH key": "Use the same host discovery SSH key",
+  "ai:Use the same host SSH key": "Use the same host SSH key",
   "ai:Use when you have an iPXE server that has already been set up": "Use when you have an iPXE server that has already been set up",
   "ai:useAlerts must be used within AlertsContextProvider": "useAlerts must be used within AlertsContextProvider",
   "ai:Used to describe hosts' physical location. Helps for quicker host selection during cluster creation.": "Used to describe hosts' physical location. Helps for quicker host selection during cluster creation.",

--- a/libs/ui-lib/lib/common/components/clusterConfiguration/SecurityFields.tsx
+++ b/libs/ui-lib/lib/common/components/clusterConfiguration/SecurityFields.tsx
@@ -35,6 +35,7 @@ interface SecurityFieldsFieldsProps {
   imageSshKey?: Cluster['imageInfo']['sshPublicKey'];
   isDisabled?: boolean;
   allowMultipleKeys?: boolean;
+  isSingleClusterMode?: boolean;
 }
 
 const SecurityFields = ({
@@ -42,6 +43,7 @@ const SecurityFields = ({
   imageSshKey,
   isDisabled = false,
   allowMultipleKeys = false,
+  isSingleClusterMode = false,
 }: SecurityFieldsFieldsProps) => {
   //shareSshKey shouldn't response to changes. imageSshKey stays the same, there's a loading state while it's requested
   //clusterSshKey updating causes the textarea to disappear when the user clears it to edit it
@@ -74,7 +76,11 @@ const SecurityFields = ({
           <Checkbox
             name="shareDiscoverySshKey"
             id={fieldId}
-            label={t('ai:Use the same host discovery SSH key')}
+            label={
+              isSingleClusterMode
+                ? t('ai:Use the same host SSH key')
+                : t('ai:Use the same host discovery SSH key')
+            }
             aria-describedby={`${fieldId}-helper`}
             isChecked={shareSshKey}
             isDisabled={isDisabled}

--- a/libs/ui-lib/lib/ocm/components/wizard/steps/networking/NetworkConfigurationForm.tsx
+++ b/libs/ui-lib/lib/ocm/components/wizard/steps/networking/NetworkConfigurationForm.tsx
@@ -22,6 +22,7 @@ import { useClusterWizardContext } from '../../clusterWizardContext';
 import { ClusterWizardFooter, ClusterWizardNavigation } from '../../wizardComponents';
 import { canNextNetwork } from '../../utils';
 import { NetworkConfigurationFields, NetworkConfigurationTable } from './components';
+import { useFeature } from '../../../../hooks';
 
 export const NetworkConfigurationForm: React.FC<{
   cluster: Cluster;
@@ -38,6 +39,7 @@ export const NetworkConfigurationForm: React.FC<{
   const { alerts } = useAlerts();
   const clusterWizardContext = useClusterWizardContext();
   const { isViewerMode } = useSelector(selectCurrentClusterPermissionsState);
+  const isSingleClusterMode = useFeature('ASSISTED_INSTALLER_SINGLE_CLUSTER_FEATURE');
   const { errors, touched, isSubmitting, isValid, setFieldValue, values } =
     useFormikContext<NetworkConfigurationValues>();
   const isAutoSaveRunning = useFormikAutoSave();
@@ -93,6 +95,7 @@ export const NetworkConfigurationForm: React.FC<{
                 clusterSshKey={cluster.sshPublicKey}
                 imageSshKey={infraEnv?.sshAuthorizedKey}
                 isDisabled={isViewerMode}
+                isSingleClusterMode={isSingleClusterMode}
               />
             </Grid>
           </GridItem>


### PR DESCRIPTION
https://redhat.atlassian.net/browse/OCPBUGS-120719

**Current and SaaS:**
<img width="649" height="172" alt="image" src="https://github.com/user-attachments/assets/04a30050-b635-44f4-9f18-41303d48af45" />

New below-the-sea:
<img width="649" height="172" alt="image" src="https://github.com/user-attachments/assets/2fee0490-1590-4834-8dcc-90774cbafeff" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI Improvements**
  - Updated the security configuration label to “Use the same host SSH key” in single-cluster mode.
  - Retained the “Use the same host discovery SSH key” label in other modes.
  - Updated the English translation to match the revised single-cluster wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->