### PR TITLE
Implement Offline Openshift Versions Dropdown

### DIFF
--- a/libs/ui-lib/lib/common/api/assisted-service/OfflineOpenshiftVersionsAPI.ts
+++ b/libs/ui-lib/lib/common/api/assisted-service/OfflineOpenshiftVersionsAPI.ts
@@ -1,0 +1,16 @@
+import { client } from '../../api/axiosClient';
+import { OpenshiftVersion } from '@openshift-assisted/types/assisted-installer-service';
+
+const OfflineOpenshiftVersionsAPI = {
+  makeBaseURI(version: string) {
+    return `/v2/offline-openshift-versions?version=${version}`;
+  },
+
+  list(version: string) {
+    return client.get<Record<string, OpenshiftVersion>>(
+      `${OfflineOpenshiftVersionsAPI.makeBaseURI(version)}`,
+    );
+  },
+};
+
+export default OfflineOpenshiftVersionsAPI;

--- a/libs/ui-lib/lib/common/api/assisted-service/index.ts
+++ b/libs/ui-lib/lib/common/api/assisted-service/index.ts
@@ -1,5 +1,6 @@
 export { default as ManagedDomainsAPI } from './ManagedDomainsAPI';
 export { default as SupportedOpenshiftVersionsAPI } from './SupportedOpenshiftVersionsAPI';
+export { default as OfflineOpenshiftVersionsAPI } from './OfflineOpenshiftVersionsAPI';
 export { default as ComponentVersionsAPI } from './ComponentVersionsAPI';
 export { default as ClustersAPI } from './ClustersAPI';
 export { default as HostsAPI } from './HostsAPI';

--- a/libs/ui-lib/lib/ocm/components/wizard/clusterWizardContext/ClusterWizardContext.tsx
+++ b/libs/ui-lib/lib/ocm/components/wizard/clusterWizardContext/ClusterWizardContext.tsx
@@ -23,11 +23,13 @@ export type ClusterWizardContextType = {
   setDisconnectedCluster: (cluster: Cluster | undefined) => void;
   disconnectedInfraEnv?: InfraEnv;
   setDisconnectedInfraEnv: (infraEnv: InfraEnv | undefined) => void;
+  disconnectedOpenshiftVersion: string;
+  setDisconnectedOpenshiftVersion: (version: string) => void;
 };
 
 export const ClusterWizardContext = React.createContext<ClusterWizardContextType | null>(null);
 
-export const useClusterWizardContext = () => {
+export const useClusterWizardContext = (): ClusterWizardContextType => {
   const context = React.useContext(ClusterWizardContext);
   if (!context) {
     throw new Error('useClusterWizardContext must be used within ClusterWizardContextProvider');

--- a/libs/ui-lib/lib/ocm/components/wizard/clusterWizardContext/ClusterWizardContextProvider.tsx
+++ b/libs/ui-lib/lib/ocm/components/wizard/clusterWizardContext/ClusterWizardContextProvider.tsx
@@ -42,6 +42,7 @@ export const ClusterWizardContextProvider = ({
   const [installDisconnected, setInstallDisconnected] = React.useState(false);
   const [disconnectedCluster, setDisconnectedCluster] = React.useState<Cluster | undefined>();
   const [disconnectedInfraEnv, setDisconnectedInfraEnv] = React.useState<InfraEnv | undefined>();
+  const [disconnectedOpenshiftVersion, setDisconnectedOpenshiftVersion] = React.useState('');
   const [disconnectedWizardStepIds, setDisconnectedWizardStepIds] =
     React.useState<ClusterWizardStepsType[]>(disconnectedSteps);
   const location = useLocation();
@@ -214,6 +215,8 @@ export const ClusterWizardContextProvider = ({
       setDisconnectedCluster,
       disconnectedInfraEnv,
       setDisconnectedInfraEnv,
+      disconnectedOpenshiftVersion,
+      setDisconnectedOpenshiftVersion,
     };
   }, [
     wizardStepIds,
@@ -229,6 +232,7 @@ export const ClusterWizardContextProvider = ({
     disconnectedCluster,
     disconnectedInfraEnv,
     setDisconnectedInfraEnv,
+    disconnectedOpenshiftVersion,
   ]);
 
   if (!contextValue) {

--- a/libs/ui-lib/lib/ocm/components/wizard/steps/disconnected/BasicStep.tsx
+++ b/libs/ui-lib/lib/ocm/components/wizard/steps/disconnected/BasicStep.tsx
@@ -1,16 +1,7 @@
 import * as React from 'react';
-import {
-  Alert,
-  AlertVariant,
-  FormGroup,
-  FormSelect,
-  FormSelectOption,
-  Grid,
-  GridItem,
-  Content,
-  Flex,
-  Form,
-} from '@patternfly/react-core';
+import * as Yup from 'yup';
+import { Formik, useFormikContext } from 'formik';
+import { Alert, AlertVariant, Grid, GridItem, Content, Flex, Form } from '@patternfly/react-core';
 import { OpenshiftVersion } from '@openshift-assisted/types/assisted-installer-service';
 import OfflineOpenshiftVersionsAPI from '../../../../../common/api/assisted-service/OfflineOpenshiftVersionsAPI';
 import {
@@ -18,6 +9,7 @@ import {
   StaticTextField,
   WithErrorBoundary,
   LoadingState,
+  SelectField,
   getKeys,
   handleApiError,
   getApiErrorMessage,
@@ -29,6 +21,10 @@ import { ClusterWizardNavigation, ClusterWizardFooter } from '../../wizardCompon
 import { InstallDisconnectedSwitch } from './InstallDisconnectedSwitch';
 
 export const DISCONNECTED_BASE_VERSION = '4.22';
+
+type BasicStepValues = {
+  openshiftVersion: string;
+};
 
 const sortVersions = (versions: OpenshiftVersionOptionType[]) =>
   [...versions].sort((version1, version2) =>
@@ -55,63 +51,45 @@ const mapOfflineVersions = (
   return sortVersions(versions);
 };
 
-export const BasicStep = () => {
-  const { moveNext, disconnectedOpenshiftVersion, setDisconnectedOpenshiftVersion } =
-    useClusterWizardContext();
-  const [versions, setVersions] = React.useState<OpenshiftVersionOptionType[]>([]);
-  const [loading, setLoading] = React.useState(true);
-  const [error, setError] = React.useState<string>();
-  const [selectedVersion, setSelectedVersion] = React.useState<string>(
-    disconnectedOpenshiftVersion,
-  );
+type BasicStepFormProps = {
+  versions: OpenshiftVersionOptionType[];
+  loading: boolean;
+  error?: string;
+};
+
+const BasicStepForm: React.FC<BasicStepFormProps> = ({ versions, loading, error }) => {
+  const { setDisconnectedOpenshiftVersion } = useClusterWizardContext();
+  const { values, setFieldValue, isValid, submitForm } = useFormikContext<BasicStepValues>();
 
   React.useEffect(() => {
-    const fetchVersions = async () => {
-      setLoading(true);
-      setError(undefined);
-      try {
-        const { data } = await OfflineOpenshiftVersionsAPI.list(DISCONNECTED_BASE_VERSION);
-        const mappedVersions = mapOfflineVersions(data);
-        setVersions(mappedVersions);
-        if (mappedVersions.length === 0) {
-          setError('No OpenShift versions available.');
-        }
-      } catch (e) {
-        handleApiError(e, (err) => {
-          setError(getApiErrorMessage(err));
-        });
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    void fetchVersions();
-  }, []);
-
-  React.useEffect(() => {
-    if (!selectedVersion && versions.length > 0) {
+    if (!values.openshiftVersion && versions.length > 0) {
       const defaultVersion =
         versions.find((version) => version.default) ?? versions[versions.length - 1];
-      setSelectedVersion(defaultVersion.value);
+      void setFieldValue('openshiftVersion', defaultVersion.value);
     }
-  }, [selectedVersion, versions]);
+  }, [values.openshiftVersion, versions, setFieldValue]);
 
   React.useEffect(() => {
-    if (selectedVersion) {
-      setDisconnectedOpenshiftVersion(selectedVersion);
+    if (values.openshiftVersion) {
+      setDisconnectedOpenshiftVersion(values.openshiftVersion);
     }
-  }, [selectedVersion, setDisconnectedOpenshiftVersion]);
+  }, [values.openshiftVersion, setDisconnectedOpenshiftVersion]);
 
-  const selectedVersionItem = versions.find((version) => version.value === selectedVersion);
+  const selectedVersionItem = versions.find((version) => version.value === values.openshiftVersion);
   const cpuArchitecture = selectedVersionItem?.cpuArchitectures?.[0] ?? 'x86_64';
+
+  const selectOptions = versions.map((version) => ({
+    value: version.value,
+    label: version.version,
+  }));
 
   return (
     <ClusterWizardStep
       navigation={<ClusterWizardNavigation />}
       footer={
         <ClusterWizardFooter
-          onNext={moveNext}
-          isNextDisabled={loading || !!error || !selectedVersion}
+          onNext={() => void submitForm()}
+          isNextDisabled={loading || !!error || !isValid || !values.openshiftVersion}
         />
       }
     >
@@ -138,27 +116,12 @@ export const BasicStep = () => {
             )}
             {!loading && !error && (
               <Form id="wizard-cluster-basic-info__form">
-                <FormGroup
-                  fieldId="disconnected-openshift-version"
+                <SelectField
+                  name="openshiftVersion"
                   label="OpenShift version"
+                  options={selectOptions}
                   isRequired
-                >
-                  <FormSelect
-                    id="disconnected-openshift-version"
-                    value={selectedVersion}
-                    onChange={(_event, value) => setSelectedVersion(value)}
-                    isRequired
-                    aria-label="OpenShift version"
-                  >
-                    {versions.map((version) => (
-                      <FormSelectOption
-                        key={version.value}
-                        value={version.value}
-                        label={version.version}
-                      />
-                    ))}
-                  </FormSelect>
-                </FormGroup>
+                />
                 <StaticTextField name="cpuArchitecture" label="CPU architecture">
                   {cpuArchitecture}
                 </StaticTextField>
@@ -168,5 +131,48 @@ export const BasicStep = () => {
         </Grid>
       </WithErrorBoundary>
     </ClusterWizardStep>
+  );
+};
+
+export const BasicStep = () => {
+  const { moveNext, disconnectedOpenshiftVersion } = useClusterWizardContext();
+  const [versions, setVersions] = React.useState<OpenshiftVersionOptionType[]>([]);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState<string>();
+
+  React.useEffect(() => {
+    const fetchVersions = async () => {
+      setLoading(true);
+      setError(undefined);
+      try {
+        const { data } = await OfflineOpenshiftVersionsAPI.list(DISCONNECTED_BASE_VERSION);
+        const mappedVersions = mapOfflineVersions(data);
+        setVersions(mappedVersions);
+        if (mappedVersions.length === 0) {
+          setError('No OpenShift versions available.');
+        }
+      } catch (e) {
+        handleApiError(e, (err) => {
+          setError(getApiErrorMessage(err));
+        });
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    void fetchVersions();
+  }, []);
+
+  return (
+    <Formik<BasicStepValues>
+      initialValues={{ openshiftVersion: disconnectedOpenshiftVersion }}
+      validationSchema={Yup.object({
+        openshiftVersion: Yup.string().required('OpenShift version is required'),
+      })}
+      validateOnMount
+      onSubmit={() => moveNext()}
+    >
+      <BasicStepForm versions={versions} loading={loading} error={error} />
+    </Formik>
   );
 };

--- a/libs/ui-lib/lib/ocm/components/wizard/steps/disconnected/BasicStep.tsx
+++ b/libs/ui-lib/lib/ocm/components/wizard/steps/disconnected/BasicStep.tsx
@@ -1,19 +1,119 @@
 import * as React from 'react';
-import { Grid, GridItem, Content, Flex, Form } from '@patternfly/react-core';
-import { ClusterWizardStep, StaticTextField, WithErrorBoundary } from '../../../../../common';
+import {
+  Alert,
+  AlertVariant,
+  FormGroup,
+  FormSelect,
+  FormSelectOption,
+  Grid,
+  GridItem,
+  Content,
+  Flex,
+  Form,
+} from '@patternfly/react-core';
+import { OpenshiftVersion } from '@openshift-assisted/types/assisted-installer-service';
+import OfflineOpenshiftVersionsAPI from '../../../../../common/api/assisted-service/OfflineOpenshiftVersionsAPI';
+import {
+  ClusterWizardStep,
+  StaticTextField,
+  WithErrorBoundary,
+  LoadingState,
+  getKeys,
+  handleApiError,
+  getApiErrorMessage,
+  OpenshiftVersionOptionType,
+  CpuArchitecture,
+} from '../../../../../common';
 import { useClusterWizardContext } from '../../clusterWizardContext';
 import { ClusterWizardNavigation, ClusterWizardFooter } from '../../wizardComponents';
 import { InstallDisconnectedSwitch } from './InstallDisconnectedSwitch';
 
-export const DISCONNECTED_OPENSHIFT_VERSION = '4.22.13';
+export const DISCONNECTED_BASE_VERSION = '4.22';
+
+const sortVersions = (versions: OpenshiftVersionOptionType[]) =>
+  [...versions].sort((version1, version2) =>
+    version1.value.localeCompare(version2.value, undefined, { numeric: true }),
+  );
+
+const mapOfflineVersions = (
+  data: Record<string, OpenshiftVersion>,
+): OpenshiftVersionOptionType[] => {
+  const versions = getKeys(data).map((key) => {
+    const versionItem = data[key];
+    const version = versionItem.displayName;
+
+    return {
+      label: `OpenShift ${version}`,
+      value: String(key),
+      version,
+      default: Boolean(versionItem.default),
+      supportLevel: versionItem.supportLevel,
+      cpuArchitectures: versionItem.cpuArchitectures as CpuArchitecture[],
+    } satisfies OpenshiftVersionOptionType;
+  });
+
+  return sortVersions(versions);
+};
 
 export const BasicStep = () => {
-  const { moveNext } = useClusterWizardContext();
+  const { moveNext, disconnectedOpenshiftVersion, setDisconnectedOpenshiftVersion } =
+    useClusterWizardContext();
+  const [versions, setVersions] = React.useState<OpenshiftVersionOptionType[]>([]);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState<string>();
+  const [selectedVersion, setSelectedVersion] = React.useState<string>(
+    disconnectedOpenshiftVersion,
+  );
+
+  React.useEffect(() => {
+    const fetchVersions = async () => {
+      setLoading(true);
+      setError(undefined);
+      try {
+        const { data } = await OfflineOpenshiftVersionsAPI.list(DISCONNECTED_BASE_VERSION);
+        const mappedVersions = mapOfflineVersions(data);
+        setVersions(mappedVersions);
+        if (mappedVersions.length === 0) {
+          setError('No OpenShift versions available.');
+        }
+      } catch (e) {
+        handleApiError(e, (err) => {
+          setError(getApiErrorMessage(err));
+        });
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    void fetchVersions();
+  }, []);
+
+  React.useEffect(() => {
+    if (!selectedVersion && versions.length > 0) {
+      const defaultVersion =
+        versions.find((version) => version.default) ?? versions[versions.length - 1];
+      setSelectedVersion(defaultVersion.value);
+    }
+  }, [selectedVersion, versions]);
+
+  React.useEffect(() => {
+    if (selectedVersion) {
+      setDisconnectedOpenshiftVersion(selectedVersion);
+    }
+  }, [selectedVersion, setDisconnectedOpenshiftVersion]);
+
+  const selectedVersionItem = versions.find((version) => version.value === selectedVersion);
+  const cpuArchitecture = selectedVersionItem?.cpuArchitectures?.[0] ?? 'x86_64';
 
   return (
     <ClusterWizardStep
       navigation={<ClusterWizardNavigation />}
-      footer={<ClusterWizardFooter onNext={moveNext} />}
+      footer={
+        <ClusterWizardFooter
+          onNext={moveNext}
+          isNextDisabled={loading || !!error || !selectedVersion}
+        />
+      }
     >
       <WithErrorBoundary title="Failed to load Basic step">
         <Grid hasGutter>
@@ -25,15 +125,45 @@ export const BasicStep = () => {
               <InstallDisconnectedSwitch />
             </Flex>
           </GridItem>
-          <GridItem>
-            <Form id="wizard-cluster-basic-info__form">
-              <StaticTextField name="openshiftVersion" label="OpenShift version">
-                {DISCONNECTED_OPENSHIFT_VERSION}
-              </StaticTextField>
-              <StaticTextField name="cpuArchitecture" label="CPU architecture">
-                x86_64
-              </StaticTextField>
-            </Form>
+          <GridItem span={12} lg={10} xl={9} xl2={7}>
+            {loading && <LoadingState />}
+            {error && (
+              <Alert
+                isInline
+                variant={AlertVariant.danger}
+                title="Failed to retrieve list of supported OpenShift versions."
+              >
+                {error}
+              </Alert>
+            )}
+            {!loading && !error && (
+              <Form id="wizard-cluster-basic-info__form">
+                <FormGroup
+                  fieldId="disconnected-openshift-version"
+                  label="OpenShift version"
+                  isRequired
+                >
+                  <FormSelect
+                    id="disconnected-openshift-version"
+                    value={selectedVersion}
+                    onChange={(_event, value) => setSelectedVersion(value)}
+                    isRequired
+                    aria-label="OpenShift version"
+                  >
+                    {versions.map((version) => (
+                      <FormSelectOption
+                        key={version.value}
+                        value={version.value}
+                        label={version.version}
+                      />
+                    ))}
+                  </FormSelect>
+                </FormGroup>
+                <StaticTextField name="cpuArchitecture" label="CPU architecture">
+                  {cpuArchitecture}
+                </StaticTextField>
+              </Form>
+            )}
           </GridItem>
         </Grid>
       </WithErrorBoundary>

--- a/libs/ui-lib/lib/ocm/components/wizard/steps/disconnected/DisconnectedReviewStep.tsx
+++ b/libs/ui-lib/lib/ocm/components/wizard/steps/disconnected/DisconnectedReviewStep.tsx
@@ -26,10 +26,11 @@ import {
 } from '../../../../../common';
 import { ClusterWizardFooter, ClusterWizardNavigation } from '../../wizardComponents';
 import { useClusterWizardContext } from '../../clusterWizardContext';
-import { DISCONNECTED_OPENSHIFT_VERSION } from './BasicStep';
 
 export const DisconnectedReviewStep = () => {
-  const { moveBack, disconnectedInfraEnv } = useClusterWizardContext();
+  const { moveBack, disconnectedInfraEnv, disconnectedOpenshiftVersion } =
+    useClusterWizardContext();
+  const openshiftVersion = disconnectedInfraEnv?.openshiftVersion ?? disconnectedOpenshiftVersion;
   const opSpecs = getOperatorSpecs(() => undefined);
   const navigate = useNavigate();
 
@@ -56,9 +57,7 @@ export const DisconnectedReviewStep = () => {
               <ListItem>
                 Boot your cluster's machines from this ISO and{' '}
                 <ExternalLink
-                  href={getDisconnectedDocsLink(
-                    getMajorMinorVersion(DISCONNECTED_OPENSHIFT_VERSION),
-                  )}
+                  href={getDisconnectedDocsLink(getMajorMinorVersion(openshiftVersion))}
                 >
                   follow instructions
                 </ExternalLink>
@@ -83,9 +82,7 @@ export const DisconnectedReviewStep = () => {
           <DescriptionList isHorizontal>
             <DescriptionListGroup>
               <DescriptionListTerm>OpenShift version</DescriptionListTerm>
-              <DescriptionListDescription>
-                {disconnectedInfraEnv?.openshiftVersion ?? DISCONNECTED_OPENSHIFT_VERSION}
-              </DescriptionListDescription>
+              <DescriptionListDescription>{openshiftVersion}</DescriptionListDescription>
             </DescriptionListGroup>
             {disconnectedInfraEnv?.rendezvousIp && (
               <DescriptionListGroup>

--- a/libs/ui-lib/lib/ocm/components/wizard/steps/disconnected/OptionalConfigurationsStep.tsx
+++ b/libs/ui-lib/lib/ocm/components/wizard/steps/disconnected/OptionalConfigurationsStep.tsx
@@ -29,7 +29,6 @@ import {
 import { usePullSecret } from '../../../../hooks';
 import { useClusterWizardContext } from '../../clusterWizardContext';
 import { ClusterWizardNavigation, ClusterWizardFooter } from '../../wizardComponents';
-import { DISCONNECTED_OPENSHIFT_VERSION } from './BasicStep';
 import { HostsNetworkConfigurationControlGroup } from '../clusterDetails/fields/HostsNetworkConfigurationControlGroup';
 import { HostsNetworkConfigurationType } from '../../../../services/types';
 import { getDummyInfraEnvField } from '../staticIp/data/dummyData';
@@ -76,7 +75,7 @@ const OptionalConfigurationsForm: React.FC<OptionalConfigurationsFormProps> = ({
           <GridItem>
             <Content component="h2">Optional configurations</Content>
           </GridItem>
-          <GridItem>
+          <GridItem span={12} lg={10} xl={9} xl2={7}>
             <Form id="wizard-cluster-optional-config__form">
               <InputField
                 label="Rendezvous IP"
@@ -126,6 +125,7 @@ export const OptionalConfigurationsStep = () => {
     setDisconnectedCluster,
     disconnectedInfraEnv,
     setDisconnectedInfraEnv,
+    disconnectedOpenshiftVersion,
   } = useClusterWizardContext();
   const { addAlert, clearAlerts } = useAlerts();
   const [isSubmitting, setIsSubmitting] = React.useState(false);
@@ -159,12 +159,21 @@ export const OptionalConfigurationsStep = () => {
       try {
         const pullSecretToUse = isInOcm ? defaultPullSecret ?? '' : values.pullSecret;
 
+        if (!disconnectedOpenshiftVersion) {
+          addAlert({
+            title: 'Failed to save optional configurations',
+            message: 'OpenShift version is required.',
+            variant: AlertVariant.danger,
+          });
+          return;
+        }
+
         let infraEnvToUse: InfraEnv | undefined = disconnectedInfraEnv;
 
         if (!disconnectedCluster?.id || !infraEnvToUse?.id) {
           const { data: cluster } = await ClustersAPI.registerDisconnected({
             name: DISCONNECTED_CLUSTER_NAME,
-            openshiftVersion: DISCONNECTED_OPENSHIFT_VERSION,
+            openshiftVersion: disconnectedOpenshiftVersion,
           });
           setDisconnectedCluster(cluster);
 
@@ -173,7 +182,7 @@ export const OptionalConfigurationsStep = () => {
             pullSecret: pullSecretToUse,
             clusterId: cluster.id,
             imageType: DISCONNECTED_IMAGE_TYPE,
-            openshiftVersion: DISCONNECTED_OPENSHIFT_VERSION,
+            openshiftVersion: disconnectedOpenshiftVersion,
             sshAuthorizedKey: values.sshPublicKey || undefined,
             rendezvousIp: values.rendezvousIp || undefined,
             staticNetworkConfig:
@@ -213,6 +222,7 @@ export const OptionalConfigurationsStep = () => {
       setDisconnectedInfraEnv,
       addAlert,
       moveNext,
+      disconnectedOpenshiftVersion,
     ],
   );
 

--- a/libs/ui-lib/lib/ocm/components/wizard/steps/disconnected/OptionalConfigurationsStep.tsx
+++ b/libs/ui-lib/lib/ocm/components/wizard/steps/disconnected/OptionalConfigurationsStep.tsx
@@ -111,10 +111,12 @@ const getStaticNetworkConfigUpdate = (
 const buildInfraEnvUpdateParams = (
   values: OptionalConfigurationsValues,
   disconnectedInfraEnv: InfraEnv | undefined,
+  openshiftVersion: string,
 ): InfraEnvUpdateParams => ({
   sshAuthorizedKey: values.sshPublicKey,
   rendezvousIp: values.rendezvousIp,
   staticNetworkConfig: getStaticNetworkConfigUpdate(values, disconnectedInfraEnv),
+  openshiftVersion,
 });
 
 export const OptionalConfigurationsStep = () => {
@@ -194,7 +196,7 @@ export const OptionalConfigurationsStep = () => {
         } else {
           const { data: updatedInfraEnv } = await InfraEnvsAPI.update(
             infraEnvToUse.id,
-            buildInfraEnvUpdateParams(values, infraEnvToUse),
+            buildInfraEnvUpdateParams(values, infraEnvToUse, disconnectedOpenshiftVersion),
           );
           infraEnvToUse = updatedInfraEnv;
         }

--- a/libs/ui-lib/lib/ocm/services/apis/index.ts
+++ b/libs/ui-lib/lib/ocm/services/apis/index.ts
@@ -1,6 +1,7 @@
 export {
   ManagedDomainsAPI,
   SupportedOpenshiftVersionsAPI,
+  OfflineOpenshiftVersionsAPI,
   ComponentVersionsAPI,
   ClustersAPI,
   HostsAPI,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Disconnected cluster setup now retrieves available OpenShift versions dynamically.
  - Added OpenShift version selection with loading and error feedback.
  - The selected version is reflected in review details, documentation links, and cluster registration.
  - CPU architecture information updates based on the selected version.

- **Bug Fixes**
  - Prevented disconnected cluster submission when no OpenShift version is selected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->