### PR TITLE
MGMT-24988: Prevent stale SSH key upload restore

### DIFF
--- a/libs/ui-lib/lib/common/components/ui/formik/UploadField.test.tsx
+++ b/libs/ui-lib/lib/common/components/ui/formik/UploadField.test.tsx
@@ -1,0 +1,117 @@
+import * as React from 'react';
+import { Formik, useFormikContext } from 'formik';
+import { createRoot } from 'react-dom/client';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import UploadField from './UploadField';
+
+type CapturedFileUploadProps = {
+  filename?: string;
+  onClearClick?: () => void;
+  onDataChange?: (_event: unknown, data: string) => void;
+  onReadStarted?: () => void;
+  onTextChange?: (_event: unknown, text: string) => void;
+  value?: string | File;
+};
+
+type Act = (callback: () => void | Promise<void>) => Promise<void>;
+
+const act = (React as unknown as { unstable_act: Act }).unstable_act;
+
+const fileUploadMock = vi.hoisted(() => ({
+  props: undefined as CapturedFileUploadProps | undefined,
+}));
+
+vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+
+vi.mock('@patternfly/react-core', () => ({
+  FileUpload: (props: CapturedFileUploadProps) => {
+    fileUploadMock.props = props;
+    return null;
+  },
+  FormGroup: ({ children }: { children?: React.ReactNode }) => children,
+  FormHelperText: ({ children }: { children?: React.ReactNode }) => children,
+  HelperText: ({ children }: { children?: React.ReactNode }) => children,
+  HelperTextItem: ({ children }: { children?: React.ReactNode }) => children,
+}));
+
+vi.mock('../../../hooks/use-translation-wrapper', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const SSH_PUBLIC_KEY = 'ssh-ed25519 test@example.com';
+
+const FormikValue = () => {
+  const { values } = useFormikContext<{ sshPublicKey: string }>();
+
+  return <output>{values.sshPublicKey}</output>;
+};
+
+const renderUploadField = () => {
+  const container = document.createElement('div');
+  const root = createRoot(container);
+  document.body.appendChild(container);
+
+  void act(() => {
+    root.render(
+      <Formik initialValues={{ sshPublicKey: '' }} onSubmit={() => undefined}>
+        <>
+          <UploadField label="SSH public key" name="sshPublicKey" />
+          <FormikValue />
+        </>
+      </Formik>,
+    );
+  });
+
+  return {
+    getProps: () => {
+      expect(fileUploadMock.props).toBeDefined();
+      return fileUploadMock.props as CapturedFileUploadProps;
+    },
+    getValue: () => container.querySelector('output')?.textContent,
+    unmount: () => {
+      void act(() => root.unmount());
+      container.remove();
+    },
+  };
+};
+
+afterEach(() => {
+  fileUploadMock.props = undefined;
+});
+
+describe('UploadField', () => {
+  test('does not restore file contents when a pending read finishes after Clear', async () => {
+    const uploadField = renderUploadField();
+    const fileUploadProps = uploadField.getProps();
+
+    await act(async () => {
+      fileUploadProps.onReadStarted?.();
+      fileUploadProps.onClearClick?.();
+      fileUploadProps.onDataChange?.(undefined, SSH_PUBLIC_KEY);
+      await Promise.resolve();
+    });
+
+    expect(uploadField.getValue()).toBe('');
+    expect(fileUploadMock.props?.filename).toBe('');
+    uploadField.unmount();
+  });
+
+  test('stores completed file reads and entered text', async () => {
+    const uploadField = renderUploadField();
+    const fileUploadProps = uploadField.getProps();
+
+    await act(async () => {
+      fileUploadProps.onReadStarted?.();
+      fileUploadProps.onDataChange?.(undefined, SSH_PUBLIC_KEY);
+      await Promise.resolve();
+    });
+    expect(uploadField.getValue()).toBe(SSH_PUBLIC_KEY);
+
+    await act(async () => {
+      fileUploadMock.props?.onTextChange?.(undefined, 'manually entered key');
+      await Promise.resolve();
+    });
+    expect(uploadField.getValue()).toBe('manually entered key');
+    uploadField.unmount();
+  });
+});

--- a/libs/ui-lib/lib/common/components/ui/formik/UploadField.tsx
+++ b/libs/ui-lib/lib/common/components/ui/formik/UploadField.tsx
@@ -32,6 +32,7 @@ const UploadField: React.FC<React.PropsWithChildren<UploadFieldProps>> = ({
 
   const [filename, setFilename] = React.useState<string>();
   const [isFileUploading, setIsFileUploading] = React.useState(false);
+  const isFileReadPendingRef = React.useRef(false);
 
   const [field, { touched, error }, { setValue, setTouched }] = useField<string | File>(name);
   const fieldId = getFieldId(name, 'input', idPostfix);
@@ -62,10 +63,15 @@ const UploadField: React.FC<React.PropsWithChildren<UploadFieldProps>> = ({
         filename={filename}
         data-testid={`upload-field-${fieldId}`}
         onDataChange={(_event, file: string) => {
+          if (!isFileReadPendingRef.current) {
+            return;
+          }
+          isFileReadPendingRef.current = false;
           setValue(file);
           setTouched(true);
         }}
         onTextChange={(_event, file: string) => {
+          isFileReadPendingRef.current = false;
           setValue(file);
           setTouched(true);
         }}
@@ -91,7 +97,10 @@ const UploadField: React.FC<React.PropsWithChildren<UploadFieldProps>> = ({
             onBlur && onBlur(e, file);
           }
         }}
-        onReadStarted={() => setIsFileUploading(true)}
+        onReadStarted={() => {
+          isFileReadPendingRef.current = true;
+          setIsFileUploading(true);
+        }}
         onReadFinished={() => setIsFileUploading(false)}
         isLoading={isFileUploading}
         disabled={isDisabled}
@@ -101,6 +110,7 @@ const UploadField: React.FC<React.PropsWithChildren<UploadFieldProps>> = ({
           maxSize: MAX_FILE_SIZE,
         }}
         onClearClick={() => {
+          isFileReadPendingRef.current = false;
           setFilename('');
           setValue('');
         }}


### PR DESCRIPTION
## Summary

Clearing an SSH key while its asynchronous file read is pending can let stale contents restore the Formik field. Overlapping reads can also commit an older file.

User edits and clears take effect immediately and take precedence over in-flight file reads; only late stale file-read callbacks are ignored. The fix tracks the latest read and adds regression coverage for these races.