### PR TITLE
MGMT-24988: Prevent stale SSH key upload restore

### DIFF
--- a/libs/ui-lib/lib/common/components/ui/formik/UploadField.test.tsx
+++ b/libs/ui-lib/lib/common/components/ui/formik/UploadField.test.tsx
@@ -1,0 +1,169 @@
+import * as React from 'react';
+import { Formik, useFormikContext } from 'formik';
+import { createRoot } from 'react-dom/client';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import UploadField from './UploadField';
+
+type CapturedFileUploadProps = {
+  filename?: string;
+  onClearClick?: () => void;
+  onDataChange?: (_event: unknown, data: string) => void;
+  onReadFinished?: (_event: unknown, file: File) => void;
+  onReadStarted?: (_event: unknown, file: File) => void;
+  onTextChange?: (_event: unknown, text: string) => void;
+  value?: string | File;
+};
+
+type Act = (callback: () => void | Promise<void>) => Promise<void>;
+
+const act = (React as unknown as { unstable_act: Act }).unstable_act;
+
+const fileUploadMock = vi.hoisted(() => ({
+  props: undefined as CapturedFileUploadProps | undefined,
+}));
+
+vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+
+vi.mock('@patternfly/react-core', () => ({
+  FileUpload: (props: CapturedFileUploadProps) => {
+    fileUploadMock.props = props;
+    return null;
+  },
+  FormGroup: ({ children }: { children?: React.ReactNode }) => children,
+  FormHelperText: ({ children }: { children?: React.ReactNode }) => children,
+  HelperText: ({ children }: { children?: React.ReactNode }) => children,
+  HelperTextItem: ({ children }: { children?: React.ReactNode }) => children,
+}));
+
+vi.mock('../../../hooks/use-translation-wrapper', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const SSH_PUBLIC_KEY = 'ssh-ed25519 test@example.com';
+
+const createFile = (name: string) => new File([SSH_PUBLIC_KEY], name);
+
+const FormikValue = () => {
+  const { values } = useFormikContext<{ sshPublicKey: string }>();
+
+  return <output>{values.sshPublicKey}</output>;
+};
+
+const renderUploadField = () => {
+  const container = document.createElement('div');
+  const root = createRoot(container);
+  document.body.appendChild(container);
+
+  void act(() => {
+    root.render(
+      <Formik initialValues={{ sshPublicKey: '' }} onSubmit={() => undefined}>
+        <>
+          <UploadField label="SSH public key" name="sshPublicKey" />
+          <FormikValue />
+        </>
+      </Formik>,
+    );
+  });
+
+  return {
+    getProps: () => {
+      expect(fileUploadMock.props).toBeDefined();
+      return fileUploadMock.props as CapturedFileUploadProps;
+    },
+    getValue: () => container.querySelector('output')?.textContent,
+    unmount: () => {
+      void act(() => root.unmount());
+      container.remove();
+    },
+  };
+};
+
+afterEach(() => {
+  fileUploadMock.props = undefined;
+});
+
+describe('UploadField', () => {
+  test('does not restore file contents when a pending read finishes after Clear', async () => {
+    const uploadField = renderUploadField();
+    const fileUploadProps = uploadField.getProps();
+    const file = createFile('stale.pub');
+
+    await act(async () => {
+      fileUploadProps.onReadStarted?.(undefined, file);
+      fileUploadProps.onClearClick?.();
+      fileUploadProps.onReadFinished?.(undefined, file);
+      fileUploadProps.onDataChange?.(undefined, SSH_PUBLIC_KEY);
+      await Promise.resolve();
+    });
+
+    expect(uploadField.getValue()).toBe('');
+    expect(fileUploadMock.props?.filename).toBe('');
+    uploadField.unmount();
+  });
+
+  test('stores completed file reads and entered text', async () => {
+    const uploadField = renderUploadField();
+    const fileUploadProps = uploadField.getProps();
+    const file = createFile('key.pub');
+
+    await act(async () => {
+      fileUploadProps.onReadStarted?.(undefined, file);
+      fileUploadProps.onReadFinished?.(undefined, file);
+      fileUploadProps.onDataChange?.(undefined, SSH_PUBLIC_KEY);
+      await Promise.resolve();
+    });
+    expect(uploadField.getValue()).toBe(SSH_PUBLIC_KEY);
+
+    await act(async () => {
+      fileUploadMock.props?.onTextChange?.(undefined, 'manually entered key');
+      await Promise.resolve();
+    });
+    expect(uploadField.getValue()).toBe('manually entered key');
+    uploadField.unmount();
+  });
+
+  test('only stores the contents of the most recently started file read', async () => {
+    const uploadField = renderUploadField();
+    const fileUploadProps = uploadField.getProps();
+    const firstFile = createFile('first.pub');
+    const secondFile = createFile('second.pub');
+
+    await act(async () => {
+      fileUploadProps.onReadStarted?.(undefined, firstFile);
+      fileUploadProps.onReadStarted?.(undefined, secondFile);
+
+      fileUploadProps.onReadFinished?.(undefined, firstFile);
+      fileUploadProps.onDataChange?.(undefined, 'first key');
+
+      fileUploadProps.onReadFinished?.(undefined, secondFile);
+      fileUploadProps.onDataChange?.(undefined, 'second key');
+      await Promise.resolve();
+    });
+
+    expect(uploadField.getValue()).toBe('second key');
+    uploadField.unmount();
+  });
+
+  test('does not restore a cleared read when a new file read starts', async () => {
+    const uploadField = renderUploadField();
+    const fileUploadProps = uploadField.getProps();
+    const staleFile = createFile('stale.pub');
+    const currentFile = createFile('current.pub');
+
+    await act(async () => {
+      fileUploadProps.onReadStarted?.(undefined, staleFile);
+      fileUploadProps.onClearClick?.();
+      fileUploadProps.onReadStarted?.(undefined, currentFile);
+
+      fileUploadProps.onReadFinished?.(undefined, staleFile);
+      fileUploadProps.onDataChange?.(undefined, 'stale key');
+
+      fileUploadProps.onReadFinished?.(undefined, currentFile);
+      fileUploadProps.onDataChange?.(undefined, 'current key');
+      await Promise.resolve();
+    });
+
+    expect(uploadField.getValue()).toBe('current key');
+    uploadField.unmount();
+  });
+});

--- a/libs/ui-lib/lib/common/components/ui/formik/UploadField.tsx
+++ b/libs/ui-lib/lib/common/components/ui/formik/UploadField.tsx
@@ -32,6 +32,8 @@ const UploadField: React.FC<React.PropsWithChildren<UploadFieldProps>> = ({
 
   const [filename, setFilename] = React.useState<string>();
   const [isFileUploading, setIsFileUploading] = React.useState(false);
+  const currentFileReadRef = React.useRef<{ file: File; isFinished: boolean }>();
+  const pendingFileReadsRef = React.useRef(0);
 
   const [field, { touched, error }, { setValue, setTouched }] = useField<string | File>(name);
   const fieldId = getFieldId(name, 'input', idPostfix);
@@ -62,10 +64,15 @@ const UploadField: React.FC<React.PropsWithChildren<UploadFieldProps>> = ({
         filename={filename}
         data-testid={`upload-field-${fieldId}`}
         onDataChange={(_event, file: string) => {
+          if (!currentFileReadRef.current?.isFinished) {
+            return;
+          }
+          currentFileReadRef.current = undefined;
           setValue(file);
           setTouched(true);
         }}
         onTextChange={(_event, file: string) => {
+          currentFileReadRef.current = undefined;
           setValue(file);
           setTouched(true);
         }}
@@ -91,8 +98,18 @@ const UploadField: React.FC<React.PropsWithChildren<UploadFieldProps>> = ({
             onBlur && onBlur(e, file);
           }
         }}
-        onReadStarted={() => setIsFileUploading(true)}
-        onReadFinished={() => setIsFileUploading(false)}
+        onReadStarted={(_event, file) => {
+          currentFileReadRef.current = { file, isFinished: false };
+          pendingFileReadsRef.current += 1;
+          setIsFileUploading(true);
+        }}
+        onReadFinished={(_event, file) => {
+          if (currentFileReadRef.current?.file === file) {
+            currentFileReadRef.current.isFinished = true;
+          }
+          pendingFileReadsRef.current = Math.max(pendingFileReadsRef.current - 1, 0);
+          setIsFileUploading(pendingFileReadsRef.current > 0);
+        }}
         isLoading={isFileUploading}
         disabled={isDisabled}
         allowEditingUploadedText={allowEdittingUploadedText}
@@ -101,6 +118,7 @@ const UploadField: React.FC<React.PropsWithChildren<UploadFieldProps>> = ({
           maxSize: MAX_FILE_SIZE,
         }}
         onClearClick={() => {
+          currentFileReadRef.current = undefined;
           setFilename('');
           setValue('');
         }}


### PR DESCRIPTION
## Summary

Clearing an SSH key while its asynchronous file read is pending can let stale contents restore the Formik field. Overlapping reads can also commit an older file.

User edits and clears take effect immediately and take precedence over in-flight file reads; only late stale file-read callbacks are ignored. The fix tracks the latest read and adds regression coverage for these races.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved file upload handling when multiple files are read at the same time.
  - Prevented outdated or incomplete file data from overwriting the current form value.
  - Improved behavior when clearing uploads or entering file content manually.
  - Upload progress now remains accurate until all file reads are complete.

- **Tests**
  - Added comprehensive coverage for completed, overlapping, cleared, manually entered, and stale upload scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->