### PR TITLE
[release-4.22] OCPBUGS-119960: Bump qs to >=6.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "resolutions": {
     "lodash": "^4.17.23",
     "lodash-es": "^4.17.23",
-    "qs": "^6.14.1",
+    "qs": ">=6.16.0",
     "axios": "^1.18.1",
     "follow-redirects": "^1.16.0",
     "shell-quote": "^1.8.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15002,12 +15002,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qs@npm:^6.14.1":
-  version: 6.15.1
-  resolution: "qs@npm:6.15.1"
+"qs@npm:>=6.16.0":
+  version: 6.16.0
+  resolution: "qs@npm:6.16.0"
   dependencies:
-    side-channel: ^1.1.0
-  checksum: 777eb585b886ebf5c8e499a736c64505748169e6fa0ef1409f351986837f64aebb7b9b06bcf469e2b9b508d760515ed0d2089a7ae8334feea0ec0caebc08f9f6
+    es-define-property: ^1.0.1
+    side-channel: ^1.1.1
+  checksum: fb97665d1b481fadbcb17cc056f1af95ae93328195bf9536a56142137f4d9cc16fe2a1dab9cd17186c9fa69a7e6fa64a3766f71ffaa7c248ec5555f34d21047b
   languageName: node
   linkType: hard
 
@@ -16484,6 +16485,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"side-channel-list@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "side-channel-list@npm:1.0.1"
+  dependencies:
+    es-errors: ^1.3.0
+    object-inspect: ^1.13.4
+  checksum: 3499671cd52adaee739eac1e14d07530b8e3530192741aeb05e7fe4ad1b51d1368ceea2cd3c21b0f62b05410a5c70a7c4d997ba4b143303ef73d0c65dfd1c252
+  languageName: node
+  linkType: hard
+
 "side-channel-map@npm:^1.0.1":
   version: 1.0.1
   resolution: "side-channel-map@npm:1.0.1"
@@ -16531,6 +16542,19 @@ __metadata:
     side-channel-map: ^1.0.1
     side-channel-weakmap: ^1.0.2
   checksum: bf73d6d6682034603eb8e99c63b50155017ed78a522d27c2acec0388a792c3ede3238b878b953a08157093b85d05797217d270b7666ba1f111345fbe933380ff
+  languageName: node
+  linkType: hard
+
+"side-channel@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "side-channel@npm:1.1.1"
+  dependencies:
+    es-errors: ^1.3.0
+    object-inspect: ^1.13.4
+    side-channel-list: ^1.0.1
+    side-channel-map: ^1.0.1
+    side-channel-weakmap: ^1.0.2
+  checksum: e0f217140c463636ee556260bbc8f47ba2931f1248826f58e1502704135814c763b325dd9ab122a04176aa45b4a4f8cc556415bcab7a0179d85250fb7812f063
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Bumps `qs` to `>=6.16.0` to fix **CVE-2026-82417** (CVSS 7.5, Important).

## CVE Details

- **CVE:** [CVE-2026-82417](https://www.cve.org/CVERecord?id=CVE-2026-82417)
- **GHSA:** [GHSA-4mjr-xmp4-gh2g](https://github.com/ljharb/qs/security/advisories/GHSA-4mjr-xmp4-gh2g)
- **Package:** `qs` < 6.16.0
- **Vulnerability:** `qs.stringify` throws TypeError on objects with crafted `constructor.isBuffer` — Denial of Service
- **Fix:** Upstream version 6.16.0+ ([commit e83d321](https://github.com/ljharb/qs/commit/e83d321ffafb38cf210683ac31714fce6ce1c6c6))

## Impact Assessment

- **Risk:** MEDIUM — DoS only, no data exfiltration; requires attacker-controlled input to reach `qs.stringify`
- **Dependency type:** Transitive (via express, body-parser, @cypress/request, union, url)
- **Runtime impact:** Unhandled TypeError crashes the process if `qs.stringify` is called on malicious input

## Changes

- Updated `qs` yarn resolution from `^6.14.1` to `>=6.16.0` in `package.json`
- Regenerated `yarn.lock`

Related: OCPBUGS-119960
